### PR TITLE
feat(open-editor): suporte ao editor embutido do Warp

### DIFF
--- a/packages/open-editor/package.json
+++ b/packages/open-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-open-editor",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "PI extension to open files in the user's $EDITOR (tmux pane, GUI, or new terminal window)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/open-editor/src/index.ts
+++ b/packages/open-editor/src/index.ts
@@ -11,6 +11,47 @@ function isTerminalEditor(editor: string): boolean {
   return TERMINAL_EDITORS.some((t) => base === t || base.startsWith(t + "."));
 }
 
+function isInsideWarp(): boolean {
+  if (process.env.TERM_PROGRAM === "WarpTerminal") return true;
+  if (process.env.WARP_IS_LOCAL_SHELL_SESSION) return true;
+
+  let pid: number | null = process.ppid;
+  while (pid && pid > 1) {
+    try {
+      const comm = readFileSync(`/proc/${pid}/comm`, "utf-8").trim();
+      if (comm.includes("warp")) return true;
+      const stat: string = readFileSync(`/proc/${pid}/stat`, "utf-8");
+      const ppidMatch: RegExpMatchArray | null = stat.match(/\) \S+ (\d+)/);
+      pid = ppidMatch ? parseInt(ppidMatch[1], 10) : null;
+    } catch {
+      break;
+    }
+  }
+  return false;
+}
+
+function findOpenCommand(): string | null {
+  for (const candidate of ["xdg-open", "open"]) {
+    const which = spawnSync("which", [candidate], { encoding: "utf-8" });
+    if (which.status === 0) return which.stdout.trim();
+  }
+  return null;
+}
+
+function buildWarpUri(filePath: string, line?: number): string {
+  const params = new URLSearchParams({ path: filePath });
+  if (line && line > 0) params.set("line", String(line));
+  return `warp://action/open_file_editor?${params.toString()}`;
+}
+
+function openInWarp(filePath: string, line: number | undefined, cwd: string): boolean {
+  const opener = findOpenCommand();
+  if (!opener) return false;
+  const uri = buildWarpUri(filePath, line);
+  spawn(opener, [uri], { detached: true, stdio: "ignore", cwd }).unref();
+  return true;
+}
+
 function buildEditorCommand(editor: string, filePath: string, line?: number): string {
   if (line) {
     if (editor.includes("vim") || editor.includes("nvim")) return `${editor} +${line} '${filePath}'`;
@@ -64,6 +105,14 @@ export default function (pi: ExtensionAPI) {
       const editor = process.env.EDITOR || "nvim";
       const filePath = resolve(ctx.cwd, params.path);
       const inTmux = !!process.env.TMUX;
+
+      if (isInsideWarp() && openInWarp(filePath, params.line, ctx.cwd)) {
+        const location = params.line ? `${params.path}:${params.line}` : params.path;
+        return {
+          content: [{ type: "text", text: `Opened ${location} in Warp editor` }],
+          details: {},
+        };
+      }
 
       if (isTerminalEditor(editor)) {
         if (inTmux) {


### PR DESCRIPTION
## O que muda

A extensão `open-editor` agora abre arquivos no **editor de código embutido do Warp** quando o pi está rodando dentro do Warp Terminal. Fora do Warp, o comportamento original é mantido ($EDITOR em tmux pane / novo terminal / app GUI).

## Por quê

O Warp tem um editor de código/markdown embutido. Quando o usuário já está no Warp, abrir um arquivo via tool deve usar esse editor em vez de spawnar um vim/nova janela de terminal, mantendo tudo dentro do Warp.

## Como funciona

- Detecção de Warp via `TERM_PROGRAM=WarpTerminal`, `WARP_IS_LOCAL_SHELL_SESSION`, com fallback subindo a árvore de processos em `/proc` (necessário porque dentro do tmux o `TERM_PROGRAM` é sobrescrito para `tmux`).
- Abertura via URI scheme oficial do Warp: `warp://action/open_file_editor?path=<absoluto>&line=<n>`, disparado com `xdg-open`/`open`.
- O `path` é resolvido para absoluto (requisito do Warp). A URI é montada com `URLSearchParams`, compatível com o `url::query_pairs` do parser do Warp (inclusive paths com espaço).
- Se a abertura no Warp falhar (sem opener disponível), cai no fluxo antigo.

## Testes

- Build (`tsc`) passa.
- Validado manualmente dentro do Warp: a tool `open_in_editor` abriu arquivos do `api-arvore` no editor embutido do Warp, retornando `Opened ... in Warp editor`.

## Outros

- Bump de versão: `1.1.0` → `1.2.0`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for opening files directly in the Warp terminal editor for streamlined workflows.
  * Warp is now automatically detected when available on your system.
  * Files can be opened in Warp with optional line number specification for precise navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->