### PR TITLE
feat(team-memory): capturar autor automaticamente do git config

### DIFF
--- a/packages/team-memory/src/git-identity.ts
+++ b/packages/team-memory/src/git-identity.ts
@@ -1,0 +1,45 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export interface GitIdentity {
+  name?: string;
+  email?: string;
+}
+
+const AGENT_NAMES = new Set(["kiro", "pi", "claude", "assistant", "bot"]);
+
+let cached: GitIdentity | null | undefined;
+
+async function gitConfig(key: string, cwd: string): Promise<string | undefined> {
+  try {
+    const { stdout } = await execFileAsync("git", ["config", "--get", key], { cwd });
+    const value = stdout.trim();
+    return value.length > 0 ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function resolveGitAuthor(cwd: string): Promise<string | undefined> {
+  if (cached !== undefined) {
+    return identityToAuthor(cached);
+  }
+
+  const [name, email] = await Promise.all([
+    gitConfig("user.name", cwd),
+    gitConfig("user.email", cwd),
+  ]);
+
+  cached = name || email ? { name, email } : null;
+  return identityToAuthor(cached);
+}
+
+function identityToAuthor(identity: GitIdentity | null): string | undefined {
+  if (!identity) return undefined;
+  if (identity.name && AGENT_NAMES.has(identity.name.toLowerCase())) {
+    return identity.email;
+  }
+  return identity.name || identity.email;
+}

--- a/packages/team-memory/src/store.ts
+++ b/packages/team-memory/src/store.ts
@@ -9,6 +9,7 @@ import type {
   MemoryFrontmatter,
 } from "./types.js";
 import { VALID_CATEGORIES, MemoryError } from "./types.js";
+import { resolveGitAuthor } from "./git-identity.js";
 
 function detectSteeringTargets(workspaceRoot: string): string[] {
   const targets: string[] = [];
@@ -296,13 +297,15 @@ export class MemoryStore {
     const id = `${date}-${slug}`;
     const filePath = join(catDir, `${id}.md`);
 
+    const author = params.author || (await resolveGitAuthor(this.workspaceRoot));
+
     const fm: Record<string, unknown> = {
       title: params.title,
       category: params.category,
       date,
       status: "active",
     };
-    if (params.author) fm.author = params.author;
+    if (author) fm.author = author;
     if (params.tags?.length) fm.tags = params.tags;
 
     const fileContent = `${this.buildFrontmatter(fm)}\n\n${params.content}\n`;
@@ -314,7 +317,7 @@ export class MemoryStore {
       title: params.title,
       category: params.category,
       date,
-      author: params.author,
+      author,
       tags: params.tags || [],
       status: "active",
       content: params.content,


### PR DESCRIPTION
## Resumo

Segunda camada da feature **Team Memory Graph Dashboard**: garantir que toda memória nova tenha `author` preenchido automaticamente, sem o usuário digitar nada.

Hoje o `store.add` aceita `author` opcional, mas nenhum ponto de entrada (tools `add_memory`, `/memory add`, `/capture`) o preenche — por isso só 87 de 438 memórias têm autor.

## O que faz

- `src/git-identity.ts`: resolve `user.name`/`user.email` do `git config` (cacheado), ignorando nomes de agente (kiro, pi, claude...) caindo pro email.
- `store.add`: usa o autor do git como **fallback** quando `author` não é passado explicitamente. Quem chama com autor explícito continua funcionando igual.

## Por que git config

Decisão tomada no refinement: é a fonte sempre presente e casa com quem commita as memórias (auto-sync futuro). Identidade canônica = email.

## Complementa o backfill

O PR https://github.com/arvoreeducacao/arvore-hub/pull/28 popula o **passado** (42 memórias com autoria confiável via git log). Este PR cuida do **futuro**: daqui pra frente nenhuma memória fica sem autor.

## Testado

- `pnpm lint` (tsc --noEmit) e `pnpm build`: OK.
- Teste end-to-end: criada memória num repo temporário com `git config user.name 'Test Dev'` → arquivo gerado com `author: Test Dev` automaticamente.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Memory entries now automatically include Git author information when an explicit author is not provided, streamlining record creation and improving attribution tracking for better team collaboration visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->