### PR TITLE
feat(bee-context): inject Bee personal facts into the system prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Monorepo for custom PI extensions used across Arvore projects.
 | Package | Description |
 |---------|-------------|
 | `@arvoretech/pi-team-memory` | Team memory with proactive capture hooks |
+| `@arvoretech/pi-bee-context` | Injects confirmed personal facts from the Bee wearable assistant into the system prompt |
 
 ## Development
 

--- a/packages/bee-context/README.md
+++ b/packages/bee-context/README.md
@@ -1,0 +1,44 @@
+# @arvoretech/pi-bee-context
+
+PI extension that injects your confirmed personal facts from the [Bee](https://bee.computer) wearable assistant into the system prompt, so the LLM can give more personalized responses.
+
+## How it works
+
+- On `session_start`, runs `bee facts list --json` and caches the confirmed facts in memory.
+- On `before_agent_start`, appends the facts (grouped by tag) to the turn's system prompt. Facts never pollute the conversation history.
+- Fails gracefully: if the `bee` CLI is missing, unauthenticated, or times out, the extension injects nothing and the agent runs normally.
+
+## Requirements
+
+The [`bee` CLI](https://bee.computer) must be installed and authenticated:
+
+```bash
+bee status
+```
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `/bee-refresh` | Re-fetch facts from Bee and update the injected context (the cache is built at session start). |
+| `/bee-show` | Show the facts currently injected. |
+
+## Privacy
+
+Bee facts can include sensitive personal information (health, beliefs, relationships). The injected block instructs the model to treat them as sensitive, but the content is sent to whichever model provider you use. Only enable this extension where you are comfortable with that.
+
+## Usage
+
+### Global (all projects)
+
+```bash
+ln -s $(pwd)/packages/bee-context/dist ~/.pi/agent/extensions/bee-context
+```
+
+### Project-local
+
+```json
+{
+  "extensions": ["./path/to/arvore-pi-extensions/packages/bee-context"]
+}
+```

--- a/packages/bee-context/package.json
+++ b/packages/bee-context/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@arvoretech/pi-bee-context",
+  "version": "1.0.0",
+  "description": "PI extension that injects confirmed personal facts from the Bee wearable assistant into the system prompt for personalized responses",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "lint": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": ">=0.74.0"
+  },
+  "devDependencies": {
+    "@earendil-works/pi-coding-agent": "latest",
+    "@earendil-works/pi-ai": "latest",
+    "@types/node": "^20.10.0",
+    "typescript": "^5.3.0"
+  },
+  "pi": {
+    "extensions": [
+      "./dist/index.js"
+    ]
+  },
+  "keywords": [
+    "pi",
+    "extension",
+    "bee",
+    "context",
+    "personalization",
+    "facts"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/arvoreeducacao/arvore-pi-extensions.git",
+    "directory": "packages/bee-context"
+  },
+  "author": "Arvore",
+  "license": "MIT"
+}

--- a/packages/bee-context/src/index.ts
+++ b/packages/bee-context/src/index.ts
@@ -1,0 +1,120 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+const execFileAsync = promisify(execFile);
+
+const FACTS_LIMIT = 100;
+const FACTS_FETCH_TIMEOUT_MS = 8000;
+const MAX_OUTPUT_BYTES = 1024 * 1024;
+
+interface BeeFact {
+  id: number;
+  text: string;
+  tags?: string[];
+  created_at?: number;
+  confirmed?: boolean;
+}
+
+interface FactsState {
+  facts: BeeFact[];
+  fetchedAt: number;
+  error?: string;
+}
+
+function parseFacts(stdout: string): BeeFact[] {
+  const payload = JSON.parse(stdout) as { facts?: BeeFact[] };
+  if (!payload || !Array.isArray(payload.facts)) return [];
+  return payload.facts.filter(
+    (fact): fact is BeeFact => Boolean(fact) && typeof fact.text === "string",
+  );
+}
+
+async function fetchFacts(signal?: AbortSignal): Promise<FactsState> {
+  try {
+    const { stdout } = await execFileAsync(
+      "bee",
+      ["facts", "list", "--limit", String(FACTS_LIMIT), "--json"],
+      { timeout: FACTS_FETCH_TIMEOUT_MS, signal, maxBuffer: MAX_OUTPUT_BYTES },
+    );
+    const facts = parseFacts(stdout).filter((fact) => fact.confirmed !== false);
+    return { facts, fetchedAt: Date.now() };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { facts: [], fetchedAt: Date.now(), error: message };
+  }
+}
+
+function renderFactsBlock(facts: BeeFact[]): string {
+  if (facts.length === 0) return "";
+
+  const grouped = new Map<string, string[]>();
+  for (const fact of facts) {
+    const tag = fact.tags?.[0] ?? "general";
+    const bucket = grouped.get(tag) ?? [];
+    bucket.push(fact.text);
+    grouped.set(tag, bucket);
+  }
+
+  const sections: string[] = [];
+  for (const [tag, items] of [...grouped.entries()].sort()) {
+    sections.push(`### ${tag}`);
+    for (const item of items) sections.push(`- ${item}`);
+  }
+
+  return [
+    "## User Personal Context (from Bee)",
+    "The following are confirmed facts about the user gathered from their personal Bee assistant.",
+    "Use them to personalize responses, anticipate needs, and adapt tone. Treat as sensitive: never echo verbatim unless relevant, never expose to third parties.",
+    "",
+    sections.join("\n"),
+  ].join("\n");
+}
+
+export default function (pi: ExtensionAPI): void {
+  let state: FactsState = { facts: [], fetchedAt: 0 };
+
+  pi.on("session_start", async (_event, ctx) => {
+    state = await fetchFacts(ctx.signal);
+    ctx.ui.setStatus(
+      "bee",
+      state.error ? "bee: facts unavailable" : `bee: ${state.facts.length} facts`,
+    );
+  });
+
+  pi.on("before_agent_start", async (event) => {
+    if (state.facts.length === 0) return;
+    const block = renderFactsBlock(state.facts);
+    if (!block) return;
+    return { systemPrompt: `${event.systemPrompt}\n\n${block}` };
+  });
+
+  pi.registerCommand("bee-refresh", {
+    description: "Re-fetch personal facts from Bee and update the injected context",
+    handler: async (_args, ctx) => {
+      ctx.ui.setStatus("bee", "bee: refreshing...");
+      state = await fetchFacts(ctx.signal);
+      if (state.error) {
+        ctx.ui.setStatus("bee", "bee: facts unavailable");
+        ctx.ui.notify(`Bee facts refresh failed: ${state.error}`, "error");
+        return;
+      }
+      ctx.ui.setStatus("bee", `bee: ${state.facts.length} facts`);
+      ctx.ui.notify(`Bee facts refreshed (${state.facts.length} confirmed).`, "info");
+    },
+  });
+
+  pi.registerCommand("bee-show", {
+    description: "Show the personal facts currently injected from Bee",
+    handler: async (_args, ctx) => {
+      if (state.facts.length === 0) {
+        ctx.ui.notify(
+          state.error ? `No Bee facts (last error: ${state.error})` : "No Bee facts loaded.",
+          state.error ? "error" : "info",
+        );
+        return;
+      }
+      ctx.ui.notify(renderFactsBlock(state.facts), "info");
+    },
+  });
+}

--- a/packages/bee-context/tsconfig.json
+++ b/packages/bee-context/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,11 +16,26 @@ importers:
         specifier: ^5.3.0
         version: 5.9.3
 
+  packages/bee-context:
+    devDependencies:
+      '@earendil-works/pi-ai':
+        specifier: latest
+        version: 0.79.1(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-coding-agent':
+        specifier: latest
+        version: 0.79.1(ws@8.20.0)(zod@4.4.3)
+      '@types/node':
+        specifier: ^20.10.0
+        version: 20.19.39
+      typescript:
+        specifier: ^5.3.0
+        version: 5.9.3
+
   packages/elevenlabs-stt:
     devDependencies:
       '@earendil-works/pi-coding-agent':
         specifier: latest
-        version: 0.79.0(ws@8.20.0)(zod@4.4.3)
+        version: 0.79.0
       '@earendil-works/pi-tui':
         specifier: latest
         version: 0.79.0
@@ -273,6 +288,10 @@ packages:
     resolution: {integrity: sha512-jQOtYjRGZ7+XC/olw9euLd2V03vkAPO8u0sSnQoLbyOQZz66dEBZrklTESk34Sf3AaeBSua28wjZR48ch1aXJQ==}
     engines: {node: '>=22.19.0'}
 
+  '@earendil-works/pi-agent-core@0.79.1':
+    resolution: {integrity: sha512-PBPjBa2YBm9jauiLtHAKaSfVJ4Dvm3/nK/bR/oHebLjwBCS2tGx3aQDX7MSGAOXi6BejlhzbB/z82BkyAyNjjQ==}
+    engines: {node: '>=22.19.0'}
+
   '@earendil-works/pi-ai@0.74.0':
     resolution: {integrity: sha512-7M7qcrZY/KEkH4wFkX3eqzvmKru4O88wezNKoN0KD2m4aAOmp9tdW2xCmUgSTSWlKB7b2Xw9QtAgrzHtg6t6iw==}
     engines: {node: '>=20.0.0'}
@@ -288,8 +307,8 @@ packages:
     engines: {node: '>=22.19.0'}
     hasBin: true
 
-  '@earendil-works/pi-ai@0.79.0':
-    resolution: {integrity: sha512-D/2aDoe9vcCbqAztALQcKkdqXGuaQcqAzLm8LfUhNaorwoIHkwnaAuDVlo+OkF5clpEwS8Z1bk2o8NiSrwEdsA==}
+  '@earendil-works/pi-ai@0.79.1':
+    resolution: {integrity: sha512-UnORwrcsTNLm4StEvoM8iEom0u87Te7BXEWxhec3iNXygWD6eEBosUoq9ddcveqtj/QpUZBMPWUu81cCtZxzkQ==}
     engines: {node: '>=22.19.0'}
     hasBin: true
 
@@ -313,6 +332,11 @@ packages:
     engines: {node: '>=22.19.0'}
     hasBin: true
 
+  '@earendil-works/pi-coding-agent@0.79.1':
+    resolution: {integrity: sha512-dLnje4U5H3/ZytJpvhjhPINeDT/yvx85e4OH/ziMQRLpPlfNP12/peY9jRQd4W11Xth2+y2xGAFwS+NeVf2ZwA==}
+    engines: {node: '>=22.19.0'}
+    hasBin: true
+
   '@earendil-works/pi-tui@0.74.0':
     resolution: {integrity: sha512-1aIfXZp7D/z+1VlZX8BZcs6pgO8rjmil7kwyhctNDsWvce3Yfl8GVgu4eq+I0Mjhr8Cj+ipBiv9CLIzdoyCOIQ==}
     engines: {node: '>=20.0.0'}
@@ -327,6 +351,10 @@ packages:
 
   '@earendil-works/pi-tui@0.79.0':
     resolution: {integrity: sha512-qAQWMruW7YKbk2hPcTD4INtXfvIySXifbPQ+mFY5j3J8yf2tfElkh+gGPuBvgPKPT0z9WiAkd7iySCuQq0txuQ==}
+    engines: {node: '>=22.19.0'}
+
+  '@earendil-works/pi-tui@0.79.1':
+    resolution: {integrity: sha512-YvZCMfSE0YDSLNklAwMY6LC6SyEgnP0zMOoioTLNnXFNdexrCexMJdee7iDJsNcFlKt7+DVLccomuURtZS1C6g==}
     engines: {node: '>=22.19.0'}
 
   '@emnapi/runtime@1.10.0':
@@ -2202,9 +2230,23 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-agent-core@0.79.0(ws@8.20.0)(zod@4.4.3)':
+  '@earendil-works/pi-agent-core@0.79.0':
     dependencies:
-      '@earendil-works/pi-ai': 0.79.0(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.79.1(ws@8.20.0)(zod@4.4.3)
+      ignore: 7.0.5
+      typebox: 1.1.38
+      yaml: 2.9.0
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-agent-core@0.79.1(ws@8.20.0)(zod@4.4.3)':
+    dependencies:
+      '@earendil-works/pi-ai': 0.79.1(ws@8.20.0)(zod@4.4.3)
       ignore: 7.0.5
       typebox: 1.1.38
       yaml: 2.9.0
@@ -2278,7 +2320,7 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-ai@0.79.0(ws@8.20.0)(zod@4.4.3)':
+  '@earendil-works/pi-ai@0.79.1(ws@8.20.0)(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
       '@aws-sdk/client-bedrock-runtime': 3.1048.0
@@ -2390,11 +2432,40 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-coding-agent@0.79.0(ws@8.20.0)(zod@4.4.3)':
+  '@earendil-works/pi-coding-agent@0.79.0':
     dependencies:
-      '@earendil-works/pi-agent-core': 0.79.0(ws@8.20.0)(zod@4.4.3)
-      '@earendil-works/pi-ai': 0.79.0(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-agent-core': 0.79.0
+      '@earendil-works/pi-ai': 0.79.1(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-tui': 0.79.0
+      '@silvia-odwyer/photon-node': 0.3.4
+      chalk: 5.6.2
+      cross-spawn: 7.0.6
+      diff: 8.0.4
+      glob: 13.0.6
+      highlight.js: 10.7.3
+      hosted-git-info: 9.0.3
+      ignore: 7.0.5
+      jiti: 2.7.0
+      minimatch: 10.2.5
+      proper-lockfile: 4.1.2
+      typebox: 1.1.38
+      undici: 8.3.0
+      yaml: 2.9.0
+    optionalDependencies:
+      '@mariozechner/clipboard': 0.3.9
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-coding-agent@0.79.1(ws@8.20.0)(zod@4.4.3)':
+    dependencies:
+      '@earendil-works/pi-agent-core': 0.79.1(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.79.1(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-tui': 0.79.1
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
       cross-spawn: 7.0.6
@@ -2440,6 +2511,11 @@ snapshots:
       marked: 15.0.12
 
   '@earendil-works/pi-tui@0.79.0':
+    dependencies:
+      get-east-asian-width: 1.6.0
+      marked: 15.0.12
+
+  '@earendil-works/pi-tui@0.79.1':
     dependencies:
       get-east-asian-width: 1.6.0
       marked: 15.0.12


### PR DESCRIPTION
## Summary

Adds a new PI extension `@arvoretech/pi-bee-context` that injects the user's confirmed personal facts from the [Bee](https://bee.computer) wearable assistant into the system prompt, enabling more personalized LLM responses.

## How it works

- **`session_start`** — runs `bee facts list --limit 100 --json` via the local `bee` CLI, filters confirmed facts, and caches them in memory. Shows `bee: N facts` in the footer status.
- **`before_agent_start`** — appends the facts (grouped by tag) to the turn's system prompt. Facts never pollute the conversation history.
- **Commands** — `/bee-refresh` re-fetches on demand; `/bee-show` displays what is currently injected.
- **Graceful failure** — if the `bee` CLI is missing, unauthenticated, or times out (8s), the extension injects nothing and the agent runs normally.

## Design notes

- Uses the `bee` CLI directly via `execFile` instead of the PI MCP layer, so it does not duplicate the stdio MCP server or couple to the MCP gateway.
- Project follows the existing monorepo conventions (`src/index.ts` → `tsc` build, `tsc --noEmit` lint, `pi.extensions` → `dist`).

## Privacy

Bee facts can include sensitive personal information (health, beliefs, relationships). The injected block instructs the model to treat them as sensitive, but the content is sent to whichever model provider is in use. This is inherent to the feature and documented in the package README.

## Testing

- `pnpm --filter @arvoretech/pi-bee-context build` — passes
- `pnpm --filter @arvoretech/pi-bee-context lint` — passes
- `pnpm build` (full workspace) — passes
- Verified `bee facts list --json` parsing and tag-grouping against the live CLI (34 confirmed facts across 5 tags)
- Loaded the compiled extension and confirmed handlers (`session_start`, `before_agent_start`) and commands (`/bee-refresh`, `/bee-show`) register correctly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Bee context extension that injects confirmed personal facts from your Bee wearable assistant into the system prompt for enhanced personalization.
  * Introduced `/bee-refresh` and `/bee-show` commands to manage and display injected personal facts.
  * Extension gracefully handles missing or unauthenticated Bee CLI setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->