### PR TITLE
fix(elevenlabs-stt): use ctrl+alt+r as macOS default shortcut

### DIFF
--- a/packages/elevenlabs-stt/README.md
+++ b/packages/elevenlabs-stt/README.md
@@ -36,7 +36,7 @@ The extension auto-detects the audio input backend:
 | Env var | Default | Description |
 |---------|---------|-------------|
 | `ELEVENLABS_API_KEY` | — | **Required.** ElevenLabs API key used for transcription. |
-| `ELEVENLABS_STT_SHORTCUT` | `ctrl+alt+t` (Linux/Windows), `ctrl+super+t` (macOS) | Keyboard shortcut that toggles recording. On macOS, `super` is the Cmd key. |
+| `ELEVENLABS_STT_SHORTCUT` | `ctrl+alt+t` (Linux/Windows), `ctrl+alt+r` (macOS) | Keyboard shortcut that toggles recording. On macOS, `alt` is the Option key. Avoid `super` (Cmd) — terminals usually don't forward it to pi. |
 
 > Some terminals and window managers reserve `ctrl+alt+t` / `ctrl+cmd+t`. If the shortcut doesn't reach pi, set `ELEVENLABS_STT_SHORTCUT` to another combination (e.g. `alt+t`, `ctrl+alt+r`).
 

--- a/packages/elevenlabs-stt/package.json
+++ b/packages/elevenlabs-stt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-elevenlabs-stt",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "PI extension for push-to-talk speech-to-text using the ElevenLabs Scribe API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/elevenlabs-stt/src/index.ts
+++ b/packages/elevenlabs-stt/src/index.ts
@@ -6,7 +6,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { listInputDevices } from "./devices.js";
 
-const DEFAULT_SHORTCUT: KeyId = process.platform === "darwin" ? "ctrl+super+t" : "ctrl+alt+t";
+const DEFAULT_SHORTCUT: KeyId = process.platform === "darwin" ? "ctrl+alt+r" : "ctrl+alt+t";
 const STATUS_KEY = "elevenlabs-stt";
 const MODEL_ID = "scribe_v2";
 const API_URL = "https://api.elevenlabs.io/v1/speech-to-text";


### PR DESCRIPTION
## Resumo

O atalho padrão de gravação no macOS usava `super` (tecla Cmd). Terminais geralmente **não encaminham** o modificador Cmd para o pi via stdin, então o shortcut nunca chegava na extensão e a gravação não ativava.

Trocado o default do macOS para `ctrl+alt+r` (Ctrl+Opt+R), que usa apenas modificadores entregues pelo terminal. Linux/Windows continuam com `ctrl+alt+t`.

## Mudanças
- `src/index.ts` — `DEFAULT_SHORTCUT` no macOS agora é `ctrl+alt+r`
- `README.md` — doc atualizada do default e nota sobre evitar `super`/Cmd
- `package.json` — bump de versão 1.0.1 → 1.0.2

## Testes
- `tsc` (build) passa sem erros

## Notas
Em alguns terminais a tecla Option pode estar configurada para compor caracteres especiais. Caso `ctrl+alt+r` não pegue, configurar a Option como modificador real (ex.: iTerm2 → Option key = Esc+) ou sobrescrever via `ELEVENLABS_STT_SHORTCUT`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated default push-to-talk keyboard shortcut for macOS from Cmd+Ctrl+T to Option+Ctrl+R

* **Documentation**
  * Updated keyboard shortcut guidance for macOS users

<!-- end of auto-generated comment: release notes by coderabbit.ai -->