### PR TITLE
feat(kokoro-tts): add TTS extension to speak assistant responses

### DIFF
--- a/packages/kokoro-tts/README.md
+++ b/packages/kokoro-tts/README.md
@@ -1,0 +1,43 @@
+# @arvoretech/pi-kokoro-tts
+
+PI extension that speaks the assistant's responses out loud using a [Kokoro-FastAPI](https://github.com/remsky/Kokoro-FastAPI) text-to-speech endpoint.
+
+Pairs with [`@arvoretech/pi-elevenlabs-stt`](../elevenlabs-stt) to enable a full voice loop: speak to pi (STT), pi answers in text, and this extension reads the answer back to you (TTS).
+
+## What it does
+
+Registers a keyboard shortcut that toggles **voice mode**. While voice mode is on, every final assistant response is streamed to the Kokoro endpoint (`POST /v1/audio/speech`) and played through `ffplay` as it arrives.
+
+- **Toggle voice mode**: press the shortcut (default `ctrl+super+s` on macOS, `ctrl+alt+s` elsewhere). The footer shows `🔊 voice on` while enabled.
+- Audio streams in `pcm` (24 kHz mono) directly into `ffplay`, so playback starts before the full response is synthesized.
+- A new response interrupts any playback already in progress.
+- The voice-mode state is persisted in the session and restored on `--resume`.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `/say [text]` | Speak the given text. With no argument, repeats the last spoken response. |
+| `/tts-stop` | Stop the current playback. |
+
+## Requirements
+
+- [`ffplay`](https://ffmpeg.org/) on `PATH` (ships with `ffmpeg`; used to play the audio stream).
+- A reachable Kokoro-FastAPI endpoint (see configuration).
+
+## Configuration
+
+| Env var | Default | Description |
+|---------|---------|-------------|
+| `KOKORO_TTS_URL` | `https://tts.arvore.com.br/v1` | Base URL of the Kokoro-FastAPI OpenAI-compatible API (without trailing slash). |
+| `KOKORO_TTS_API_KEY` | falls back to `ARVORE_TTS_API_KEY` | API key sent as the `X-API-Key` header. Required by the Arvore Kokoro gateway. |
+| `KOKORO_TTS_VOICE` | `pf_dora` | Voice name. `pf_dora` / `pm_alex` / `pm_santa` are the Brazilian Portuguese voices. Combinations like `pf_dora+af_heart` are supported by Kokoro. |
+| `KOKORO_TTS_MODEL` | `kokoro` | Model name sent in the request. |
+| `KOKORO_TTS_SPEED` | `1` | Speaking speed multiplier (`0.25`–`4`). |
+| `KOKORO_TTS_SHORTCUT` | `ctrl+super+s` (macOS), `ctrl+alt+s` (other) | Shortcut that toggles voice mode. On macOS, `super` is the Cmd key. |
+
+## Notes
+
+- Markdown is stripped before synthesis: code blocks, links, headings, and URLs are removed or simplified so the speech sounds natural.
+- Responses are truncated to 4000 characters per utterance.
+- Requires interactive (TUI) mode for the shortcut and footer status.

--- a/packages/kokoro-tts/README.md
+++ b/packages/kokoro-tts/README.md
@@ -17,6 +17,8 @@ Registers a keyboard shortcut that toggles **voice mode**. While voice mode is o
 
 | Command | Description |
 |---------|-------------|
+| `/voice` | Toggle voice mode on/off. |
+| `/voice-select` | Select the Kokoro voice (e.g. `pf_dora`, `pm_alex`, `af_heart`). |
 | `/say [text]` | Speak the given text. With no argument, repeats the last spoken response. |
 | `/tts-stop` | Stop the current playback. |
 
@@ -34,6 +36,7 @@ Registers a keyboard shortcut that toggles **voice mode**. While voice mode is o
 | `KOKORO_TTS_VOICE` | `pf_dora` | Voice name. `pf_dora` / `pm_alex` / `pm_santa` are the Brazilian Portuguese voices. Combinations like `pf_dora+af_heart` are supported by Kokoro. |
 | `KOKORO_TTS_MODEL` | `kokoro` | Model name sent in the request. |
 | `KOKORO_TTS_SPEED` | `1` | Speaking speed multiplier (`0.25`–`4`). |
+| `KOKORO_TTS_STREAMING` | `true` | Stream audio in chunks as the response arrives (low latency). Set to `false`/`0`/`off`/`no` to synthesize and play only the final response. |
 | `KOKORO_TTS_SHORTCUT` | `ctrl+super+s` (macOS), `ctrl+alt+s` (other) | Shortcut that toggles voice mode. On macOS, `super` is the Cmd key. |
 
 ## Notes
@@ -41,3 +44,4 @@ Registers a keyboard shortcut that toggles **voice mode**. While voice mode is o
 - Markdown is stripped before synthesis: code blocks, links, headings, and URLs are removed or simplified so the speech sounds natural.
 - Responses are truncated to 4000 characters per utterance.
 - Requires interactive (TUI) mode for the shortcut and footer status.
+- `/voice-select` opens an interactive picker (TUI only) listing the available PT/EN voices fetched from the endpoint, with the current voice marked. The selected voice is persisted in the session and restored on `--resume`, the same way the voice-mode state is. Voice mode itself is toggled with `/voice` or the shortcut.

--- a/packages/kokoro-tts/package.json
+++ b/packages/kokoro-tts/package.json
@@ -17,7 +17,7 @@
     "@earendil-works/pi-coding-agent": ">=0.74.0"
   },
   "devDependencies": {
-    "@earendil-works/pi-coding-agent": "latest",
+    "@earendil-works/pi-coding-agent": "0.79.1",
     "@types/node": "^20.10.0",
     "typescript": "^5.3.0"
   },

--- a/packages/kokoro-tts/package.json
+++ b/packages/kokoro-tts/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@arvoretech/pi-kokoro-tts",
+  "version": "1.0.0",
+  "description": "PI extension that speaks the assistant's responses out loud using a Kokoro-FastAPI text-to-speech endpoint",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "lint": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": ">=0.74.0"
+  },
+  "devDependencies": {
+    "@earendil-works/pi-coding-agent": "latest",
+    "@types/node": "^20.10.0",
+    "typescript": "^5.3.0"
+  },
+  "pi": {
+    "extensions": [
+      "./dist/index.js"
+    ]
+  },
+  "keywords": [
+    "pi",
+    "extension",
+    "text-to-speech",
+    "tts",
+    "kokoro",
+    "voice"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/arvoreeducacao/arvore-pi-extensions.git",
+    "directory": "packages/kokoro-tts"
+  },
+  "author": "Arvore",
+  "license": "MIT"
+}

--- a/packages/kokoro-tts/src/index.ts
+++ b/packages/kokoro-tts/src/index.ts
@@ -12,6 +12,7 @@ const DEFAULT_VOICE = "pf_dora";
 const DEFAULT_MODEL = "kokoro";
 const MAX_SPEAK_CHARS = 4000;
 const MIN_CHUNK_CHARS = 60;
+const FETCH_TIMEOUT_MS = 15000;
 
 interface VoiceState {
   enabled: boolean;
@@ -75,7 +76,22 @@ async function fetchVoices(): Promise<string[]> {
   const apiKey = resolveApiKey();
   const headers: Record<string, string> = {};
   if (apiKey) headers["x-api-key"] = apiKey;
-  const response = await fetch(`${baseUrl}/audio/voices`, { headers });
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  let response: Response;
+  try {
+    response = await fetch(`${baseUrl}/audio/voices`, {
+      headers,
+      signal: controller.signal,
+    });
+  } catch (error) {
+    if (controller.signal.aborted) {
+      throw new Error(`request timed out after ${FETCH_TIMEOUT_MS}ms`);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
   if (!response.ok) throw new Error(`HTTP ${response.status}`);
   const data = (await response.json()) as { voices?: unknown };
   const voices = Array.isArray(data.voices) ? data.voices.filter((v): v is string => typeof v === "string") : [];
@@ -105,7 +121,8 @@ function resolveStreaming(): boolean {
 }
 
 function hasBinary(binary: string): boolean {
-  return spawnSync("which", [binary], { stdio: "ignore" }).status === 0;
+  const detector = process.platform === "win32" ? "where" : "which";
+  return spawnSync(detector, [binary], { stdio: "ignore" }).status === 0;
 }
 
 function describe(error: unknown): string {

--- a/packages/kokoro-tts/src/index.ts
+++ b/packages/kokoro-tts/src/index.ts
@@ -1,0 +1,506 @@
+import type {
+  ExtensionAPI,
+  ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
+
+const STATUS_KEY = "kokoro-tts";
+const STATE_ENTRY_TYPE = "kokoro-tts-state";
+const SAMPLE_RATE = 24000;
+const DEFAULT_BASE_URL = "https://tts.arvore.com.br/v1";
+const DEFAULT_VOICE = "pf_dora";
+const DEFAULT_MODEL = "kokoro";
+const MAX_SPEAK_CHARS = 4000;
+const MIN_CHUNK_CHARS = 60;
+
+interface VoiceState {
+  enabled: boolean;
+  voice?: string;
+}
+
+const VOICE_ENTRY_TYPE = "kokoro-tts-voice";
+
+interface ActivePlayback {
+  process: ChildProcess;
+  controller: AbortController;
+}
+
+function resolveBaseUrl(): string {
+  const configured = process.env.KOKORO_TTS_URL?.trim();
+  return (configured ? configured : DEFAULT_BASE_URL).replace(/\/$/, "");
+}
+
+function resolveEnvVoice(): string {
+  const configured = process.env.KOKORO_TTS_VOICE?.trim();
+  return configured ? configured : DEFAULT_VOICE;
+}
+
+function languageLabel(voice: string): string {
+  const map: Record<string, string> = {
+    pf: "PT feminino",
+    pm: "PT masculino",
+    af: "EN-US fem",
+    am: "EN-US masc",
+    bf: "EN-UK fem",
+    bm: "EN-UK masc",
+    ef: "ES fem",
+    em: "ES masc",
+    ff: "FR fem",
+    hf: "HI fem",
+    hm: "HI masc",
+    if: "IT fem",
+    im: "IT masc",
+    jf: "JP fem",
+    jm: "JP masc",
+    zf: "ZH fem",
+    zm: "ZH masc",
+  };
+  return map[voice.slice(0, 2)] ?? "outro";
+}
+
+const ALLOWED_VOICE_PREFIXES = ["pf", "pm", "af", "am"];
+
+function sortVoices(voices: string[]): string[] {
+  const rank = (v: string): number => {
+    if (v.startsWith("pf") || v.startsWith("pm")) return 0;
+    return 1;
+  };
+  return voices
+    .filter((v) => ALLOWED_VOICE_PREFIXES.includes(v.slice(0, 2)))
+    .sort((a, b) => rank(a) - rank(b) || a.localeCompare(b));
+}
+
+async function fetchVoices(): Promise<string[]> {
+  const baseUrl = resolveBaseUrl();
+  const apiKey = resolveApiKey();
+  const headers: Record<string, string> = {};
+  if (apiKey) headers["x-api-key"] = apiKey;
+  const response = await fetch(`${baseUrl}/audio/voices`, { headers });
+  if (!response.ok) throw new Error(`HTTP ${response.status}`);
+  const data = (await response.json()) as { voices?: unknown };
+  const voices = Array.isArray(data.voices) ? data.voices.filter((v): v is string => typeof v === "string") : [];
+  return voices;
+}
+
+function resolveApiKey(): string | undefined {
+  const key = process.env.KOKORO_TTS_API_KEY?.trim() || process.env.ARVORE_TTS_API_KEY?.trim();
+  return key ? key : undefined;
+}
+
+function resolveModel(): string {
+  const configured = process.env.KOKORO_TTS_MODEL?.trim();
+  return configured ? configured : DEFAULT_MODEL;
+}
+
+function resolveSpeed(): number {
+  const raw = Number.parseFloat(process.env.KOKORO_TTS_SPEED ?? "");
+  if (Number.isFinite(raw) && raw >= 0.25 && raw <= 4) return raw;
+  return 1;
+}
+
+function resolveStreaming(): boolean {
+  const raw = process.env.KOKORO_TTS_STREAMING?.trim().toLowerCase();
+  if (raw === "0" || raw === "false" || raw === "off" || raw === "no") return false;
+  return true;
+}
+
+function hasBinary(binary: string): boolean {
+  return spawnSync("which", [binary], { stdio: "ignore" }).status === 0;
+}
+
+function describe(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function truncate(text: string, max: number): string {
+  return text.length > max ? `${text.slice(0, max)}…` : text;
+}
+
+function extractText(message: unknown): string {
+  const content = (message as { content?: unknown })?.content;
+  if (typeof content === "string") return content.trim();
+  if (!Array.isArray(content)) return "";
+  const parts: string[] = [];
+  for (const block of content) {
+    if (block && typeof block === "object" && (block as { type?: string }).type === "text") {
+      const text = (block as { text?: unknown }).text;
+      if (typeof text === "string") parts.push(text);
+    }
+  }
+  return parts.join(" ").trim();
+}
+
+function sanitizeForSpeech(text: string): string {
+  return text
+    .replace(/```[\s\S]*?```/g, " ")
+    .replace(/`[^`]*`/g, " ")
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, " ")
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1")
+    .replace(/^\s{0,3}#{1,6}\s+/gm, "")
+    .replace(/[*_~>#|]/g, " ")
+    .replace(/https?:\/\/\S+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function splitSpeakable(buffer: string): { chunks: string[]; rest: string } {
+  const chunks: string[] = [];
+  let rest = buffer;
+  const boundary = /[.!?…:;\n]+\s/g;
+  let match: RegExpExecArray | null;
+  let lastIndex = 0;
+  while ((match = boundary.exec(rest)) !== null) {
+    const end = match.index + match[0].length;
+    const candidate = rest.slice(lastIndex, end).trim();
+    if (candidate.length >= MIN_CHUNK_CHARS) {
+      chunks.push(candidate);
+      lastIndex = end;
+    }
+  }
+  rest = rest.slice(lastIndex);
+  return { chunks, rest };
+}
+
+export default function kokoroTts(pi: ExtensionAPI): void {
+  let state: VoiceState = { enabled: false };
+  let lastSpoken: string | null = null;
+  let playback: ActivePlayback | null = null;
+
+  const streamingEnabled = resolveStreaming();
+  let liveBuffer = "";
+  let liveActive = false;
+  let pending = "";
+  let queue: Promise<void> = Promise.resolve();
+  let speakGeneration = 0;
+
+  pi.on("session_start", async (_event, ctx) => {
+    state = restoreState(ctx);
+    refreshStatus(ctx);
+  });
+
+  pi.on("session_shutdown", async () => {
+    stopPlayback();
+  });
+
+  pi.registerCommand("voice", {
+    description: "Toggle Kokoro voice mode (speak assistant responses out loud)",
+    handler: async (_args, ctx) => {
+      state = { ...state, enabled: !state.enabled };
+      persistState(pi, state);
+      refreshStatus(ctx);
+      if (!state.enabled) {
+        interrupt();
+        ctx.ui.notify("Voice mode off.", "info");
+      } else {
+        ctx.ui.notify("Voice mode on — responses will be spoken.", "info");
+      }
+    },
+  });
+
+  pi.registerCommand("voice-select", {
+    description: "Choose the Kokoro TTS voice",
+    handler: async (_args, ctx) => {
+      if (!ctx.hasUI) {
+        ctx.ui.notify("voice-select requires interactive mode", "error");
+        return;
+      }
+      let voices: string[];
+      try {
+        voices = await fetchVoices();
+      } catch (error) {
+        ctx.ui.notify(`Failed to list voices: ${describe(error)}`, "error");
+        return;
+      }
+      if (voices.length === 0) {
+        ctx.ui.notify("No voices returned by the endpoint.", "warning");
+        return;
+      }
+      const current = state.voice ?? resolveEnvVoice();
+      const sorted = sortVoices(voices);
+      const items = sorted.map((v) => {
+        const active = v === current ? "  \u2713" : "";
+        return `${v}  (${languageLabel(v)})${active}`;
+      });
+      const choice = await ctx.ui.select("Select voice", items);
+      if (choice === undefined) return;
+      const index = items.indexOf(choice);
+      const voice = sorted[index];
+      if (!voice) return;
+      state = { ...state, voice };
+      persistState(pi, state);
+      interrupt();
+      ctx.ui.notify(`Voice set to ${voice}.`, "info");
+      enqueueSpeak("Pronto, essa \u00e9 a nova voz.", ctx);
+    },
+  });
+
+  pi.registerCommand("say", {
+    description: "Speak arbitrary text (or the last response) via Kokoro TTS",
+    handler: async (args, ctx) => {
+      const text = args.trim() ? args.trim() : lastSpoken;
+      if (!text) {
+        ctx.ui.notify("Nothing to say. Provide text or wait for a response.", "info");
+        return;
+      }
+      interrupt();
+      enqueueSpeak(text, ctx);
+    },
+  });
+
+  pi.registerCommand("tts-stop", {
+    description: "Stop the current Kokoro TTS playback",
+    handler: async (_args, ctx) => {
+      interrupt();
+      ctx.ui.notify("Playback stopped.", "info");
+    },
+  });
+
+  pi.on("message_start", async (event, _ctx) => {
+    const message = (event as { message?: unknown }).message;
+    const role = (message as { role?: string })?.role;
+    if (role === "user") {
+      interrupt();
+      return;
+    }
+    if (!state.enabled || !streamingEnabled) return;
+    if (role !== "assistant") return;
+    resetLive();
+    liveActive = true;
+  });
+
+  pi.on("message_update", async (event, ctx) => {
+    if (!state.enabled || !streamingEnabled || !liveActive) return;
+    const message = (event as { message?: unknown }).message;
+    if ((message as { role?: string })?.role !== "assistant") return;
+    const full = extractText(message);
+    if (full.length <= liveBuffer.length) return;
+    const delta = full.slice(liveBuffer.length);
+    liveBuffer = full;
+    pending += delta;
+    const { chunks, rest } = splitSpeakable(pending);
+    pending = rest;
+    for (const chunk of chunks) {
+      const clean = sanitizeForSpeech(chunk);
+      if (clean) enqueueSpeak(clean, ctx);
+    }
+  });
+
+  pi.on("message_end", async (event, ctx) => {
+    if (!state.enabled) return;
+    const message = (event as { message?: unknown }).message;
+    if ((message as { role?: string })?.role !== "assistant") return;
+
+    const full = sanitizeForSpeech(extractText(message));
+    if (full) lastSpoken = full;
+
+    if (streamingEnabled && liveActive) {
+      const tail = sanitizeForSpeech(pending);
+      resetLive();
+      if (tail) enqueueSpeak(tail, ctx);
+      return;
+    }
+
+    if (!full) return;
+    stopPlayback();
+    enqueueSpeak(full, ctx);
+  });
+
+  function resetLive(): void {
+    liveActive = false;
+    liveBuffer = "";
+    pending = "";
+  }
+
+  function refreshStatus(ctx: ExtensionContext): void {
+    if (state.enabled) {
+      ctx.ui.setStatus(STATUS_KEY, "🔊 voice on — /voice to toggle");
+    } else {
+      ctx.ui.setStatus(STATUS_KEY, undefined);
+    }
+  }
+
+  function stopPlayback(): void {
+    const active = playback;
+    if (!active) return;
+    playback = null;
+    active.controller.abort();
+    const child = active.process;
+    if (child.exitCode === null && child.signalCode === null) {
+      child.kill("SIGKILL");
+    }
+  }
+
+  function interrupt(): void {
+    speakGeneration += 1;
+    queue = Promise.resolve();
+    resetLive();
+    stopPlayback();
+  }
+
+  function enqueueSpeak(text: string, ctx: ExtensionContext): void {
+    const generation = speakGeneration;
+    queue = queue
+      .then(() => {
+        if (generation !== speakGeneration) return;
+        return speak(text, ctx);
+      })
+      .catch(() => undefined);
+  }
+
+  async function speak(rawText: string, ctx: ExtensionContext): Promise<void> {
+    if (!hasBinary("ffplay")) {
+      ctx.ui.notify("ffplay not found — install ffmpeg to use Kokoro TTS", "error");
+      return;
+    }
+
+    const text = truncate(rawText, MAX_SPEAK_CHARS);
+    if (!text) return;
+
+    const controller = new AbortController();
+    const baseUrl = resolveBaseUrl();
+    const apiKey = resolveApiKey();
+
+    ctx.ui.setStatus(STATUS_KEY, "🔊 speaking…");
+
+    const headers: Record<string, string> = { "content-type": "application/json" };
+    if (apiKey) headers["x-api-key"] = apiKey;
+
+    let response: Response;
+    try {
+      response = await fetch(`${baseUrl}/audio/speech`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          model: resolveModel(),
+          input: text,
+          voice: state.voice ?? resolveEnvVoice(),
+          response_format: "pcm",
+          speed: resolveSpeed(),
+          stream: true,
+        }),
+        signal: controller.signal,
+      });
+    } catch (error) {
+      if (controller.signal.aborted) return;
+      ctx.ui.notify(`Kokoro request failed: ${describe(error)}`, "error");
+      refreshStatus(ctx);
+      return;
+    }
+
+    if (!response.ok || !response.body) {
+      const detail = await response.text().catch(() => "");
+      ctx.ui.notify(
+        `Kokoro HTTP ${response.status}${detail ? ` — ${truncate(detail, 200)}` : ""}`,
+        "error",
+      );
+      refreshStatus(ctx);
+      return;
+    }
+
+    const child = spawn(
+      "ffplay",
+      [
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-nodisp",
+        "-autoexit",
+        "-f",
+        "s16le",
+        "-ar",
+        String(SAMPLE_RATE),
+        "-ch_layout",
+        "mono",
+        "-i",
+        "pipe:0",
+      ],
+      { stdio: ["pipe", "ignore", "ignore"] },
+    );
+
+    const active: ActivePlayback = { process: child, controller };
+    playback = active;
+
+    child.stdin?.on("error", () => {
+      controller.abort();
+    });
+
+    child.on("error", () => {
+      if (playback === active) {
+        playback = null;
+        controller.abort();
+        ctx.ui.notify("ffplay failed to start", "error");
+        refreshStatus(ctx);
+      }
+    });
+
+    await new Promise<void>((resolve) => {
+      child.once("exit", () => {
+        if (playback === active) {
+          playback = null;
+          refreshStatus(ctx);
+        }
+        resolve();
+      });
+
+      void pump(response, child, active, controller, ctx).then(() => {
+        try {
+          if (child.stdin && !child.stdin.destroyed) child.stdin.end();
+        } catch {
+          // ignore
+        }
+      });
+    });
+  }
+
+  async function pump(
+    response: Response,
+    child: ChildProcess,
+    active: ActivePlayback,
+    controller: AbortController,
+    ctx: ExtensionContext,
+  ): Promise<void> {
+    try {
+      const reader = response.body!.getReader();
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (playback !== active || controller.signal.aborted) break;
+        const stdin = child.stdin;
+        if (!value || !stdin || stdin.destroyed || !stdin.writable) break;
+        try {
+          if (!stdin.write(value)) {
+            await new Promise<void>((resolve) => {
+              const done = () => resolve();
+              stdin.once("drain", done);
+              stdin.once("error", done);
+              stdin.once("close", done);
+            });
+          }
+        } catch {
+          break;
+        }
+      }
+    } catch (error) {
+      if (!controller.signal.aborted) {
+        ctx.ui.notify(`Kokoro stream error: ${describe(error)}`, "error");
+      }
+    }
+  }
+}
+
+function persistState(pi: ExtensionAPI, state: VoiceState): void {
+  pi.appendEntry(STATE_ENTRY_TYPE, state);
+}
+
+function restoreState(ctx: ExtensionContext): VoiceState {
+  let result: VoiceState = { enabled: false };
+  for (const entry of ctx.sessionManager.getEntries()) {
+    if (entry.type !== "custom" || entry.customType !== STATE_ENTRY_TYPE) continue;
+    const data = entry.data as { enabled?: unknown; voice?: unknown } | null;
+    result = {
+      enabled: data?.enabled === true,
+      voice: typeof data?.voice === "string" ? data.voice : undefined,
+    };
+  }
+  return result;
+}

--- a/packages/kokoro-tts/tsconfig.json
+++ b/packages/kokoro-tts/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,18 @@ importers:
         specifier: ^5.3.0
         version: 5.9.3
 
+  packages/kokoro-tts:
+    devDependencies:
+      '@earendil-works/pi-coding-agent':
+        specifier: latest
+        version: 0.79.1(ws@8.20.0)(zod@4.4.3)
+      '@types/node':
+        specifier: ^20.10.0
+        version: 20.19.39
+      typescript:
+        specifier: ^5.3.0
+        version: 5.9.3
+
   packages/open-editor:
     devDependencies:
       '@earendil-works/pi-ai':
@@ -334,6 +346,10 @@ packages:
     resolution: {integrity: sha512-oPwVRkkAvyKPWyM7E4k+EaTNmynbYn7ZLG/LBh9BUnMNb2gvpMp+VQ420R6JCJ20uogSqrHnWTyosSa/rU8lVw==}
     engines: {node: '>=22.19.0'}
 
+  '@earendil-works/pi-agent-core@0.79.1':
+    resolution: {integrity: sha512-PBPjBa2YBm9jauiLtHAKaSfVJ4Dvm3/nK/bR/oHebLjwBCS2tGx3aQDX7MSGAOXi6BejlhzbB/z82BkyAyNjjQ==}
+    engines: {node: '>=22.19.0'}
+
   '@earendil-works/pi-ai@0.74.0':
     resolution: {integrity: sha512-7M7qcrZY/KEkH4wFkX3eqzvmKru4O88wezNKoN0KD2m4aAOmp9tdW2xCmUgSTSWlKB7b2Xw9QtAgrzHtg6t6iw==}
     engines: {node: '>=20.0.0'}
@@ -346,6 +362,11 @@ packages:
 
   '@earendil-works/pi-ai@0.78.1':
     resolution: {integrity: sha512-CM2pkTs1iupG/maw381lC9Q/Y/aQaMGK7GILc28ttImD0ci3LDwKroDsGkWbly5JIy3iqxdRxB9JlG7vvzCzTg==}
+    engines: {node: '>=22.19.0'}
+    hasBin: true
+
+  '@earendil-works/pi-ai@0.79.1':
+    resolution: {integrity: sha512-UnORwrcsTNLm4StEvoM8iEom0u87Te7BXEWxhec3iNXygWD6eEBosUoq9ddcveqtj/QpUZBMPWUu81cCtZxzkQ==}
     engines: {node: '>=22.19.0'}
     hasBin: true
 
@@ -364,6 +385,11 @@ packages:
     engines: {node: '>=22.19.0'}
     hasBin: true
 
+  '@earendil-works/pi-coding-agent@0.79.1':
+    resolution: {integrity: sha512-dLnje4U5H3/ZytJpvhjhPINeDT/yvx85e4OH/ziMQRLpPlfNP12/peY9jRQd4W11Xth2+y2xGAFwS+NeVf2ZwA==}
+    engines: {node: '>=22.19.0'}
+    hasBin: true
+
   '@earendil-works/pi-tui@0.74.0':
     resolution: {integrity: sha512-1aIfXZp7D/z+1VlZX8BZcs6pgO8rjmil7kwyhctNDsWvce3Yfl8GVgu4eq+I0Mjhr8Cj+ipBiv9CLIzdoyCOIQ==}
     engines: {node: '>=20.0.0'}
@@ -374,6 +400,10 @@ packages:
 
   '@earendil-works/pi-tui@0.78.1':
     resolution: {integrity: sha512-07GVQo/38a0yvIPlWDr3RJn1B8gk3ZuIX9h2oIQ+Biyu3JN0KppWmgWHfaWRydQgse5JtC++KDw5MWaIRnV0mw==}
+    engines: {node: '>=22.19.0'}
+
+  '@earendil-works/pi-tui@0.79.1':
+    resolution: {integrity: sha512-YvZCMfSE0YDSLNklAwMY6LC6SyEgnP0zMOoioTLNnXFNdexrCexMJdee7iDJsNcFlKt7+DVLccomuURtZS1C6g==}
     engines: {node: '>=22.19.0'}
 
   '@emnapi/runtime@1.10.0':
@@ -2538,6 +2568,20 @@ snapshots:
       - ws
       - zod
 
+  '@earendil-works/pi-agent-core@0.79.1(ws@8.20.0)(zod@4.4.3)':
+    dependencies:
+      '@earendil-works/pi-ai': 0.79.1(ws@8.20.0)(zod@4.4.3)
+      ignore: 7.0.5
+      typebox: 1.1.38
+      yaml: 2.9.0
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
   '@earendil-works/pi-ai@0.74.0(ws@8.20.0)(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
@@ -2581,6 +2625,26 @@ snapshots:
       - zod
 
   '@earendil-works/pi-ai@0.78.1(ws@8.20.0)(zod@4.4.3)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
+      '@aws-sdk/client-bedrock-runtime': 3.1048.0
+      '@google/genai': 1.52.0
+      '@mistralai/mistralai': 2.2.1
+      '@smithy/node-http-handler': 4.7.3
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      openai: 6.26.0(ws@8.20.0)(zod@4.4.3)
+      partial-json: 0.1.7
+      typebox: 1.1.38
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-ai@0.79.1(ws@8.20.0)(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
       '@aws-sdk/client-bedrock-runtime': 3.1048.0
@@ -2692,6 +2756,35 @@ snapshots:
       - ws
       - zod
 
+  '@earendil-works/pi-coding-agent@0.79.1(ws@8.20.0)(zod@4.4.3)':
+    dependencies:
+      '@earendil-works/pi-agent-core': 0.79.1(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.79.1(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-tui': 0.79.1
+      '@silvia-odwyer/photon-node': 0.3.4
+      chalk: 5.6.2
+      cross-spawn: 7.0.6
+      diff: 8.0.4
+      glob: 13.0.6
+      highlight.js: 10.7.3
+      hosted-git-info: 9.0.3
+      ignore: 7.0.5
+      jiti: 2.7.0
+      minimatch: 10.2.5
+      proper-lockfile: 4.1.2
+      typebox: 1.1.38
+      undici: 8.3.0
+      yaml: 2.9.0
+    optionalDependencies:
+      '@mariozechner/clipboard': 0.3.9
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
   '@earendil-works/pi-tui@0.74.0':
     dependencies:
       '@types/mime-types': 2.1.4
@@ -2708,6 +2801,11 @@ snapshots:
       marked: 15.0.12
 
   '@earendil-works/pi-tui@0.78.1':
+    dependencies:
+      get-east-asian-width: 1.6.0
+      marked: 15.0.12
+
+  '@earendil-works/pi-tui@0.79.1':
     dependencies:
       get-east-asian-width: 1.6.0
       marked: 15.0.12

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
   packages/kokoro-tts:
     devDependencies:
       '@earendil-works/pi-coding-agent':
-        specifier: latest
+        specifier: 0.79.1
         version: 0.79.1(ws@8.20.0)(zod@4.4.3)
       '@types/node':
         specifier: ^20.10.0


### PR DESCRIPTION
## What

Adds the `@arvoretech/pi-kokoro-tts` PI extension — a text-to-speech layer that speaks the assistant's responses out loud using a [Kokoro-FastAPI](https://github.com/remsky/Kokoro-FastAPI) endpoint.

## How it works

- Registers a **voice mode** toggle (command `/voice`, shortcut `ctrl+super+s` on macOS / `ctrl+alt+s` elsewhere). The footer shows `🔊 voice on` while enabled.
- While enabled, assistant responses are streamed to `POST /v1/audio/speech` and played through `ffplay` as PCM (24 kHz mono), so playback starts before the full response is synthesized.
- Streaming mode chunks the response on sentence boundaries for low-latency speech; a new response or user message interrupts any playback in progress.
- Voice-mode state is persisted in the session and restored on `--resume`.

## Commands

| Command | Description |
|---------|-------------|
| `/voice` | Toggle voice mode |
| `/voice-select` | Pick the Kokoro voice (PT/EN voices) |
| `/say [text]` | Speak text, or repeat the last response |
| `/tts-stop` | Stop current playback |

## Configuration

All via env vars (no secrets hardcoded): `KOKORO_TTS_URL` (default `https://tts.arvore.com.br/v1`), `KOKORO_TTS_API_KEY` / `ARVORE_TTS_API_KEY`, `KOKORO_TTS_VOICE` (default `pf_dora`), `KOKORO_TTS_MODEL`, `KOKORO_TTS_SPEED`, `KOKORO_TTS_STREAMING`.

## Requirements

- `ffplay` on PATH (ships with `ffmpeg`)
- A reachable Kokoro-FastAPI endpoint

## Notes

- Markdown is stripped before synthesis (code blocks, links, headings, URLs).
- On merge to `main`, CI publishes `@arvoretech/pi-kokoro-tts@1.0.0` to npm (trusted publishing / provenance).

## Tested

- `pnpm build`, `pnpm lint` pass locally for all workspace packages.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Kokoro TTS “voice mode” extension with streamed text-to-speech playback.
  * `/voice` toggles voice mode on/off, with a live UI status indicator.
  * `/voice-select` lets you choose from available voices.
  * `/say` speaks text aloud; `/tts-stop` stops current playback/interupts speech.
  * Voice settings persist across sessions and auto-speak assistant replies when enabled.
* **Documentation**
  * Added README with setup, configuration, and usage details for the extension.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->