### PR TITLE
feat(plan-mode): Cursor-style plan mode extension with hard tool gate

### DIFF
--- a/packages/plan-mode/README.md
+++ b/packages/plan-mode/README.md
@@ -12,10 +12,16 @@ physically cannot touch code until you approve the plan with `/build`.
 - **Hard gate**: hides `edit`/`write` via `setActiveTools` AND blocks them in
   `tool_call` (defense in depth). `bash` is allowlisted (blocks `rm`,
   `git commit`, `kubectl apply`, `aws ... delete`, `mix ecto`, redirects, etc.).
-- **Plan generation**: the agent asks clarifying questions, researches the
-  codebase, and produces a numbered plan under a `Plan:` header.
-- **Workspace storage**: on approval the plan is saved to
-  `.pi/plans/{date}-{slug}.md` — versionable and shareable.
+- **Business + pedagogical refinement**: the plan prompt drives clarifying
+  questions across business, users/pedagogy (edtech), and technical concerns —
+  with selectable options instead of free text where possible.
+- **Auto-suggest**: when a prompt looks complex (implement, refactor, migrate,
+  architecture, etc.) the extension offers to enter plan mode via a select dialog.
+- **Plan generation**: the agent researches the codebase and produces a numbered
+  plan under a `Plan:` header.
+- **Workspace storage + editor**: the plan is saved to `.pi/plans/{date}-{slug}.md`
+  as soon as it is generated. `/plan-open` opens it in Warp (or `$EDITOR`) so you
+  can review and edit it directly.
 - **Manual handoff**: nothing executes until you run `/build`.
 - **Progress tracking**: numbered steps become a todo list; completed steps are
   marked with `[DONE:n]` and shown in a widget during execution.
@@ -24,6 +30,7 @@ physically cannot touch code until you approve the plan with `/build`.
 ## Commands
 
 - `/plan` — toggle plan mode (read-only, edits blocked). `Ctrl+Alt+P` too.
+- `/plan-open` — open the current plan `.md` in Warp / `$EDITOR` to review and edit.
 - `/build` — approve the current plan, save it to `.pi/plans/`, exit plan mode and execute.
 - `/todos` — show plan progress.
 - `--plan` — flag to start directly in plan mode.

--- a/packages/plan-mode/README.md
+++ b/packages/plan-mode/README.md
@@ -1,0 +1,60 @@
+# @arvoretech/pi-plan-mode
+
+Cursor-style **plan mode** for PI with a real **hard tool gate**.
+
+While plan mode is active the agent is locked into read-only exploration:
+`edit` and `write` are blocked and `bash` is restricted to a read-only
+allowlist — not by prompt discipline, but by the `tool_call` gate. The agent
+physically cannot touch code until you approve the plan with `/build`.
+
+## Features
+
+- **Hard gate**: hides `edit`/`write` via `setActiveTools` AND blocks them in
+  `tool_call` (defense in depth). `bash` is allowlisted (blocks `rm`,
+  `git commit`, `kubectl apply`, `aws ... delete`, `mix ecto`, redirects, etc.).
+- **Plan generation**: the agent asks clarifying questions, researches the
+  codebase, and produces a numbered plan under a `Plan:` header.
+- **Workspace storage**: on approval the plan is saved to
+  `.pi/plans/{date}-{slug}.md` — versionable and shareable.
+- **Manual handoff**: nothing executes until you run `/build`.
+- **Progress tracking**: numbered steps become a todo list; completed steps are
+  marked with `[DONE:n]` and shown in a widget during execution.
+- **Session persistence**: state survives `/resume`.
+
+## Commands
+
+- `/plan` — toggle plan mode (read-only, edits blocked). `Ctrl+Alt+P` too.
+- `/build` — approve the current plan, save it to `.pi/plans/`, exit plan mode and execute.
+- `/todos` — show plan progress.
+- `--plan` — flag to start directly in plan mode.
+
+## Flow
+
+1. `/plan` → agent asks questions, explores, and outputs a `Plan:` block.
+2. Numbered steps become a todo list. Review/edit the plan (still locked).
+3. `/build` → saves the `.md`, restores tools, executes in order with `[DONE:n]` tracking.
+4. When every step completes, execution mode ends and normal access is restored.
+
+## Usage
+
+### Global (all projects)
+
+```bash
+ln -s $(pwd)/packages/plan-mode/dist ~/.pi/agent/extensions/plan-mode
+```
+
+### Project-local
+
+```json
+{
+  "extensions": ["./path/to/arvore-pi-extensions/packages/plan-mode"]
+}
+```
+
+## Development
+
+```bash
+pnpm install
+pnpm --filter @arvoretech/pi-plan-mode build
+pnpm --filter @arvoretech/pi-plan-mode lint
+```

--- a/packages/plan-mode/README.md
+++ b/packages/plan-mode/README.md
@@ -13,8 +13,10 @@ physically cannot touch code until you approve the plan with `/build`.
   `tool_call` (defense in depth). `bash` is allowlisted (blocks `rm`,
   `git commit`, `kubectl apply`, `aws ... delete`, `mix ecto`, redirects, etc.).
 - **Business + pedagogical refinement**: the plan prompt drives clarifying
-  questions across business, users/pedagogy (edtech), and technical concerns —
-  with selectable options instead of free text where possible.
+  questions across business, users/pedagogy (edtech), and technical concerns,
+  asked through a bundled `questionnaire` tool that renders selectable options
+  (single = option list, multiple = tabbed), with a "type something" fallback
+  instead of free text.
 - **Auto-suggest**: when a prompt looks complex (implement, refactor, migrate,
   architecture, etc.) the extension offers to enter plan mode via a select dialog.
 - **Plan generation**: the agent researches the codebase and produces a numbered

--- a/packages/plan-mode/README.md
+++ b/packages/plan-mode/README.md
@@ -58,7 +58,7 @@ ln -s $(pwd)/packages/plan-mode/dist ~/.pi/agent/extensions/plan-mode
 
 ```json
 {
-  "extensions": ["./path/to/arvore-pi-extensions/packages/plan-mode"]
+  "extensions": ["./path/to/arvore-pi-extensions/packages/plan-mode/dist"]
 }
 ```
 

--- a/packages/plan-mode/README.md
+++ b/packages/plan-mode/README.md
@@ -26,7 +26,9 @@ physically cannot touch code until you approve the plan with `/build`.
   can review and edit it directly.
 - **Manual handoff**: nothing executes until you run `/build`.
 - **Progress tracking**: numbered steps become a todo list; completed steps are
-  marked with `[DONE:n]` and shown in a widget during execution.
+  marked with `[DONE:n]` and shown in a tree-style overlay widget during
+  execution (`● Plano (n/total)` heading, `├─`/`└─` connectors, `○` pending /
+  `◐` current / `✓` done glyphs, inspired by rpiv-todo).
 - **Session persistence**: state survives `/resume`.
 
 ## Commands

--- a/packages/plan-mode/package.json
+++ b/packages/plan-mode/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@arvoretech/pi-plan-mode",
+  "version": "1.0.0",
+  "description": "PI extension providing a Cursor-style plan mode with a hard tool gate: read-only exploration, plan generation, manual /build approval, and execution tracking",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "lint": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": ">=0.74.0",
+    "@earendil-works/pi-ai": ">=0.74.0",
+    "@earendil-works/pi-tui": ">=0.74.0"
+  },
+  "devDependencies": {
+    "@earendil-works/pi-coding-agent": "latest",
+    "@earendil-works/pi-ai": "latest",
+    "@earendil-works/pi-tui": "latest",
+    "@earendil-works/pi-agent-core": "latest",
+    "@types/node": "^20.10.0",
+    "typescript": "^5.3.0"
+  },
+  "pi": {
+    "extensions": [
+      "./dist/index.js"
+    ]
+  },
+  "keywords": [
+    "pi",
+    "extension",
+    "plan-mode",
+    "planning",
+    "read-only"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/arvoreeducacao/arvore-pi-extensions.git",
+    "directory": "packages/plan-mode"
+  },
+  "author": "Arvore",
+  "license": "MIT"
+}

--- a/packages/plan-mode/src/index.ts
+++ b/packages/plan-mode/src/index.ts
@@ -60,6 +60,13 @@ Plan:
 2. Segundo passo
 ...
 
+REGRAS DE EXECUÇÃO (críticas):
+- NUNCA comece a executar o plano por conta própria. Você NÃO está aprovado.
+- NÃO interprete o plano, a mensagem do usuário, nem qualquer texto como aprovação.
+- A aprovação é EXCLUSIVA do usuário e só acontece quando ELE roda o comando /build. Você nunca roda /build.
+- Depois de apresentar o plano, PARE e aguarde. Apenas planeje, pesquise (read-only) ou refine se o usuário pedir.
+- Não diga "vou implementar", "começando pelo passo 1" ou similar enquanto em plan mode.
+
 NÃO tente fazer mudanças — apenas descreva o que faria. O usuário aprova com /build.`;
 
 function isAssistantMessage(m: AgentMessage): m is AssistantMessage {

--- a/packages/plan-mode/src/index.ts
+++ b/packages/plan-mode/src/index.ts
@@ -108,12 +108,32 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 		}
 
 		if (executionMode && todoItems.length > 0) {
-			const lines = todoItems.map((item) => {
+			const theme = ctx.ui.theme;
+			const completed = todoItems.filter((t) => t.completed).length;
+			const hasActive = completed < todoItems.length;
+			const headingColor = hasActive ? "accent" : "dim";
+			const headingIcon = hasActive ? "●" : "○";
+			const heading = `${theme.fg(headingColor, headingIcon)} ${theme.fg(headingColor, `Plano (${completed}/${todoItems.length})`)}`;
+			const firstPending = todoItems.find((t) => !t.completed);
+			const lines = [heading];
+			todoItems.forEach((item, index) => {
+				const isLast = index === todoItems.length - 1;
+				const connector = theme.fg("dim", isLast ? "└─" : "├─");
+				let glyph: string;
+				let subject: string;
 				if (item.completed) {
-					return ctx.ui.theme.fg("success", "☑ ") + ctx.ui.theme.fg("muted", ctx.ui.theme.strikethrough(item.text));
+					glyph = theme.fg("success", "✓");
+					subject = theme.fg("dim", theme.strikethrough(item.text));
+				} else if (item === firstPending) {
+					glyph = theme.fg("warning", "◐");
+					subject = theme.fg("text", item.text);
+				} else {
+					glyph = theme.fg("dim", "○");
+					subject = theme.fg("text", item.text);
 				}
-				return `${ctx.ui.theme.fg("muted", "☐ ")}${item.text}`;
+				lines.push(`${connector} ${glyph} ${subject}`);
 			});
+			lines.push("");
 			ctx.ui.setWidget("plan-todos", lines);
 		} else {
 			ctx.ui.setWidget("plan-todos", undefined);
@@ -379,11 +399,17 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 		lastPlanFile = savePlanToFile(ctx, lastPlanText);
 		persistState();
 
-		const todoListText = todoItems.map((t, i) => `${i + 1}. ☐ ${t.text}`).join("\n");
+		const total = todoItems.length;
+		const treeLines = todoItems
+			.map((t, i) => {
+				const connector = i === total - 1 ? "└─" : "├─";
+				return `${connector} ○ ${t.text}`;
+			})
+			.join("\n");
 		pi.sendMessage(
 			{
 				customType: "plan-todo-list",
-				content: `**Plano (${todoItems.length} passos):**\n\n${todoListText}\n\nSalvo em \`${lastPlanFile}\`.\n_Use \`/plan-open\` para abrir no editor, \`/build\` para aprovar e executar, ou continue refinando._`,
+				content: `● **Plano (0/${total})**\n\n${treeLines}\n\nSalvo em \`${lastPlanFile}\`.\n_Use \`/plan-open\` para abrir no editor, \`/build\` para aprovar e executar, ou continue refinando._`,
 				display: true,
 			},
 			{ triggerTurn: false },

--- a/packages/plan-mode/src/index.ts
+++ b/packages/plan-mode/src/index.ts
@@ -17,6 +17,7 @@ import {
 	slugify,
 	type TodoItem,
 } from "./utils.js";
+import registerQuestionnaire from "./questionnaire.js";
 
 const PLAN_MODE_TOOLS = ["read", "bash", "grep", "find", "ls", "questionnaire"];
 const NORMAL_MODE_TOOLS = ["read", "bash", "edit", "write"];
@@ -73,6 +74,8 @@ function getTextContent(message: AssistantMessage): string {
 }
 
 export default function planModeExtension(pi: ExtensionAPI): void {
+	registerQuestionnaire(pi);
+
 	let planModeEnabled = false;
 	let executionMode = false;
 	let todoItems: TodoItem[] = [];

--- a/packages/plan-mode/src/index.ts
+++ b/packages/plan-mode/src/index.ts
@@ -299,7 +299,8 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 		}
 
 		if (event.toolName === "bash") {
-			const command = event.input.command as string;
+			const command = event.input?.command;
+			if (typeof command !== "string") return;
 			if (!isSafeCommand(command)) {
 				return {
 					block: true,
@@ -391,13 +392,15 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 			}
 		}
 
-		if (!planChanged || todoItems.length === 0 || lastPlanText === lastShownPlan || !ctx.hasUI) {
+		if (!planChanged || todoItems.length === 0 || lastPlanText === lastShownPlan) {
 			return;
 		}
 
 		lastShownPlan = lastPlanText;
 		lastPlanFile = savePlanToFile(ctx, lastPlanText);
 		persistState();
+
+		if (!ctx.hasUI) return;
 
 		const total = todoItems.length;
 		const treeLines = todoItems
@@ -445,15 +448,17 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 					break;
 				}
 			}
-			const messages: AssistantMessage[] = [];
-			for (let i = executeIndex + 1; i < entries.length; i++) {
-				const entry = entries[i];
-				if (entry.type === "message" && "message" in entry && isAssistantMessage(entry.message as AgentMessage)) {
-					messages.push(entry.message as AssistantMessage);
+			if (executeIndex !== -1) {
+				const messages: AssistantMessage[] = [];
+				for (let i = executeIndex + 1; i < entries.length; i++) {
+					const entry = entries[i];
+					if (entry.type === "message" && "message" in entry && isAssistantMessage(entry.message as AgentMessage)) {
+						messages.push(entry.message as AssistantMessage);
+					}
 				}
+				const allText = messages.map(getTextContent).join("\n");
+				markCompletedSteps(allText, todoItems);
 			}
-			const allText = messages.map(getTextContent).join("\n");
-			markCompletedSteps(allText, todoItems);
 		}
 
 		if (planModeEnabled) {

--- a/packages/plan-mode/src/index.ts
+++ b/packages/plan-mode/src/index.ts
@@ -1,0 +1,347 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import type { AssistantMessage, TextContent } from "@earendil-works/pi-ai";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { Key } from "@earendil-works/pi-tui";
+import {
+	extractPlanSection,
+	extractPlanTitle,
+	extractTodoItems,
+	isSafeCommand,
+	markCompletedSteps,
+	slugify,
+	type TodoItem,
+} from "./utils.js";
+
+const PLAN_MODE_TOOLS = ["read", "bash", "grep", "find", "ls", "questionnaire"];
+const NORMAL_MODE_TOOLS = ["read", "bash", "edit", "write"];
+const MUTATING_TOOLS = new Set(["edit", "write"]);
+
+const PLAN_INSTRUCTIONS = `[PLAN MODE ATIVO]
+Você está em plan mode — modo somente-leitura para análise segura antes de codar.
+
+Restrições (impostas por hard gate, não apenas instrução):
+- Você só pode usar: read, bash, grep, find, ls, questionnaire
+- edit e write estão BLOQUEADOS — qualquer tentativa é rejeitada pelo gate
+- bash está restrito a um allowlist de comandos somente-leitura
+
+Faça perguntas de esclarecimento usando a tool questionnaire antes de assumir escopo.
+Pesquise o codebase com read/grep/find para montar contexto real.
+
+Produza um plano detalhado e numerado sob um header "Plan:":
+
+# Título curto do plano
+
+Plan:
+1. Primeiro passo
+2. Segundo passo
+...
+
+NÃO tente fazer mudanças — apenas descreva o que faria. O usuário aprova com /build.`;
+
+function isAssistantMessage(m: AgentMessage): m is AssistantMessage {
+	return m.role === "assistant" && Array.isArray(m.content);
+}
+
+function getTextContent(message: AssistantMessage): string {
+	return message.content
+		.filter((block): block is TextContent => block.type === "text")
+		.map((block) => block.text)
+		.join("\n");
+}
+
+export default function planModeExtension(pi: ExtensionAPI): void {
+	let planModeEnabled = false;
+	let executionMode = false;
+	let todoItems: TodoItem[] = [];
+	let lastPlanText = "";
+	let lastPlanFile: string | undefined;
+
+	pi.registerFlag("plan", {
+		description: "Iniciar em plan mode (exploração somente-leitura)",
+		type: "boolean",
+		default: false,
+	});
+
+	function updateStatus(ctx: ExtensionContext): void {
+		if (executionMode && todoItems.length > 0) {
+			const completed = todoItems.filter((t) => t.completed).length;
+			ctx.ui.setStatus("plan-mode", ctx.ui.theme.fg("accent", `📋 ${completed}/${todoItems.length}`));
+		} else if (planModeEnabled) {
+			ctx.ui.setStatus("plan-mode", ctx.ui.theme.fg("warning", "⏸ plan (locked)"));
+		} else {
+			ctx.ui.setStatus("plan-mode", undefined);
+		}
+
+		if (executionMode && todoItems.length > 0) {
+			const lines = todoItems.map((item) => {
+				if (item.completed) {
+					return ctx.ui.theme.fg("success", "☑ ") + ctx.ui.theme.fg("muted", ctx.ui.theme.strikethrough(item.text));
+				}
+				return `${ctx.ui.theme.fg("muted", "☐ ")}${item.text}`;
+			});
+			ctx.ui.setWidget("plan-todos", lines);
+		} else {
+			ctx.ui.setWidget("plan-todos", undefined);
+		}
+	}
+
+	function enablePlanMode(ctx: ExtensionContext): void {
+		planModeEnabled = true;
+		executionMode = false;
+		todoItems = [];
+		pi.setActiveTools(PLAN_MODE_TOOLS);
+		ctx.ui.notify(`Plan mode ativado (locked). Tools: ${PLAN_MODE_TOOLS.join(", ")}. Aprove com /build.`, "info");
+		updateStatus(ctx);
+	}
+
+	function disablePlanMode(ctx: ExtensionContext): void {
+		planModeEnabled = false;
+		pi.setActiveTools(NORMAL_MODE_TOOLS);
+		ctx.ui.notify("Plan mode desativado. Acesso total restaurado.", "info");
+		updateStatus(ctx);
+	}
+
+	function togglePlanMode(ctx: ExtensionContext): void {
+		if (planModeEnabled) {
+			disablePlanMode(ctx);
+		} else {
+			enablePlanMode(ctx);
+		}
+	}
+
+	function persistState(): void {
+		pi.appendEntry("plan-mode", {
+			enabled: planModeEnabled,
+			todos: todoItems,
+			executing: executionMode,
+			planFile: lastPlanFile,
+		});
+	}
+
+	function savePlanToFile(ctx: ExtensionContext, planText: string): string {
+		const title = extractPlanTitle(planText);
+		const date = new Date().toISOString().slice(0, 10);
+		const slug = slugify(title) || "plano";
+		const dir = join(ctx.cwd, ".pi", "plans");
+		mkdirSync(dir, { recursive: true });
+		const file = join(dir, `${date}-${slug}.md`);
+		const body = `# ${title}\n\n_Gerado em ${new Date().toISOString()} via plan mode._\n\n${extractPlanSection(planText)}\n`;
+		writeFileSync(file, body, "utf8");
+		return file;
+	}
+
+	pi.registerCommand("plan", {
+		description: "Alternar plan mode (exploração somente-leitura, edits bloqueados)",
+		handler: async (_args, ctx) => togglePlanMode(ctx),
+	});
+
+	pi.registerCommand("build", {
+		description: "Aprovar o plano atual e executá-lo (sai do plan mode)",
+		handler: async (_args, ctx) => {
+			if (!planModeEnabled) {
+				ctx.ui.notify("Não há plano pendente. Use /plan primeiro.", "warning");
+				return;
+			}
+			if (todoItems.length === 0 && !lastPlanText) {
+				ctx.ui.notify("Nenhum plano detectado ainda. Peça ao agente para gerar um plano sob 'Plan:'.", "warning");
+				return;
+			}
+
+			if (lastPlanText) {
+				lastPlanFile = savePlanToFile(ctx, lastPlanText);
+				ctx.ui.notify(`Plano salvo em ${lastPlanFile}`, "info");
+			}
+
+			planModeEnabled = false;
+			executionMode = todoItems.length > 0;
+			pi.setActiveTools(NORMAL_MODE_TOOLS);
+			updateStatus(ctx);
+			persistState();
+
+			const execMessage =
+				todoItems.length > 0
+					? `Plano aprovado. Execute em ordem, começando por: ${todoItems[0].text}\nApós concluir cada passo, inclua a tag [DONE:n] na resposta.`
+					: "Plano aprovado. Execute o plano que você acabou de criar.";
+			pi.sendMessage({ customType: "plan-mode-execute", content: execMessage, display: true }, { triggerTurn: true });
+		},
+	});
+
+	pi.registerCommand("todos", {
+		description: "Mostrar o progresso do plano atual",
+		handler: async (_args, ctx) => {
+			if (todoItems.length === 0) {
+				ctx.ui.notify("Sem todos. Crie um plano com /plan.", "info");
+				return;
+			}
+			const list = todoItems.map((item, i) => `${i + 1}. ${item.completed ? "✓" : "○"} ${item.text}`).join("\n");
+			ctx.ui.notify(`Progresso do plano:\n${list}`, "info");
+		},
+	});
+
+	pi.registerShortcut(Key.ctrlAlt("p"), {
+		description: "Alternar plan mode",
+		handler: async (ctx) => togglePlanMode(ctx),
+	});
+
+	pi.on("tool_call", async (event) => {
+		if (!planModeEnabled) return;
+
+		if (MUTATING_TOOLS.has(event.toolName)) {
+			return {
+				block: true,
+				reason: `Plan mode ativo: ${event.toolName} bloqueado. O plano precisa ser aprovado com /build antes de qualquer edição.`,
+			};
+		}
+
+		if (event.toolName === "bash") {
+			const command = event.input.command as string;
+			if (!isSafeCommand(command)) {
+				return {
+					block: true,
+					reason: `Plan mode: comando bloqueado (não está no allowlist somente-leitura).\nComando: ${command}\nUse /plan para sair do plan mode ou /build para aprovar o plano.`,
+				};
+			}
+		}
+	});
+
+	pi.on("context", async (event) => {
+		if (planModeEnabled) return;
+		return {
+			messages: event.messages.filter((m) => {
+				const msg = m as AgentMessage & { customType?: string };
+				if (msg.customType === "plan-mode-context") return false;
+				if (msg.role !== "user") return true;
+				const content = msg.content;
+				if (typeof content === "string") {
+					return !content.includes("[PLAN MODE ATIVO]");
+				}
+				if (Array.isArray(content)) {
+					return !content.some((c) => c.type === "text" && (c as TextContent).text?.includes("[PLAN MODE ATIVO]"));
+				}
+				return true;
+			}),
+		};
+	});
+
+	pi.on("before_agent_start", async () => {
+		if (planModeEnabled) {
+			return {
+				message: { customType: "plan-mode-context", content: PLAN_INSTRUCTIONS, display: false },
+			};
+		}
+
+		if (executionMode && todoItems.length > 0) {
+			const remaining = todoItems.filter((t) => !t.completed);
+			const todoList = remaining.map((t) => `${t.step}. ${t.text}`).join("\n");
+			return {
+				message: {
+					customType: "plan-execution-context",
+					content: `[EXECUTANDO PLANO — acesso total às tools]\n\nPassos restantes:\n${todoList}\n\nExecute cada passo em ordem. Após concluir um passo, inclua a tag [DONE:n] na resposta.`,
+					display: false,
+				},
+			};
+		}
+	});
+
+	pi.on("turn_end", async (event, ctx) => {
+		if (!executionMode || todoItems.length === 0) return;
+		if (!isAssistantMessage(event.message)) return;
+		const text = getTextContent(event.message);
+		if (markCompletedSteps(text, todoItems) > 0) {
+			updateStatus(ctx);
+		}
+		persistState();
+	});
+
+	pi.on("agent_end", async (event, ctx) => {
+		if (executionMode && todoItems.length > 0) {
+			if (todoItems.every((t) => t.completed)) {
+				const completedList = todoItems.map((t) => `~~${t.text}~~`).join("\n");
+				pi.sendMessage(
+					{ customType: "plan-complete", content: `**Plano concluído!** ✓\n\n${completedList}`, display: true },
+					{ triggerTurn: false },
+				);
+				executionMode = false;
+				todoItems = [];
+				lastPlanText = "";
+				pi.setActiveTools(NORMAL_MODE_TOOLS);
+				updateStatus(ctx);
+				persistState();
+			}
+			return;
+		}
+
+		if (!planModeEnabled) return;
+
+		const lastAssistant = [...event.messages].reverse().find(isAssistantMessage);
+		if (lastAssistant) {
+			const text = getTextContent(lastAssistant);
+			const extracted = extractTodoItems(text);
+			if (extracted.length > 0) {
+				todoItems = extracted;
+				lastPlanText = text;
+			}
+		}
+
+		if (todoItems.length > 0 && ctx.hasUI) {
+			const todoListText = todoItems.map((t, i) => `${i + 1}. ☐ ${t.text}`).join("\n");
+			pi.sendMessage(
+				{
+					customType: "plan-todo-list",
+					content: `**Plano (${todoItems.length} passos):**\n\n${todoListText}\n\n_Revise/edite e rode \`/build\` para aprovar e executar, ou continue refinando._`,
+					display: true,
+				},
+				{ triggerTurn: false },
+			);
+			persistState();
+		}
+	});
+
+	pi.on("session_start", async (_event, ctx) => {
+		if (pi.getFlag("plan") === true) {
+			planModeEnabled = true;
+		}
+
+		const entries = ctx.sessionManager.getEntries();
+		const planModeEntry = entries
+			.filter((e: { type: string; customType?: string }) => e.type === "custom" && e.customType === "plan-mode")
+			.pop() as
+			| { data?: { enabled: boolean; todos?: TodoItem[]; executing?: boolean; planFile?: string } }
+			| undefined;
+
+		if (planModeEntry?.data) {
+			planModeEnabled = planModeEntry.data.enabled ?? planModeEnabled;
+			todoItems = planModeEntry.data.todos ?? todoItems;
+			executionMode = planModeEntry.data.executing ?? executionMode;
+			lastPlanFile = planModeEntry.data.planFile ?? lastPlanFile;
+		}
+
+		const isResume = planModeEntry !== undefined;
+		if (isResume && executionMode && todoItems.length > 0) {
+			let executeIndex = -1;
+			for (let i = entries.length - 1; i >= 0; i--) {
+				const entry = entries[i] as { type: string; customType?: string };
+				if (entry.customType === "plan-mode-execute") {
+					executeIndex = i;
+					break;
+				}
+			}
+			const messages: AssistantMessage[] = [];
+			for (let i = executeIndex + 1; i < entries.length; i++) {
+				const entry = entries[i];
+				if (entry.type === "message" && "message" in entry && isAssistantMessage(entry.message as AgentMessage)) {
+					messages.push(entry.message as AssistantMessage);
+				}
+			}
+			const allText = messages.map(getTextContent).join("\n");
+			markCompletedSteps(allText, todoItems);
+		}
+
+		if (planModeEnabled) {
+			pi.setActiveTools(PLAN_MODE_TOOLS);
+		}
+		updateStatus(ctx);
+	});
+}

--- a/packages/plan-mode/src/index.ts
+++ b/packages/plan-mode/src/index.ts
@@ -1,3 +1,4 @@
+import { spawn } from "node:child_process";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
@@ -5,10 +6,13 @@ import type { AssistantMessage, TextContent } from "@earendil-works/pi-ai";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { Key } from "@earendil-works/pi-tui";
 import {
+	buildWarpUri,
 	extractPlanSection,
 	extractPlanTitle,
 	extractTodoItems,
+	isInsideWarp,
 	isSafeCommand,
+	looksComplex,
 	markCompletedSteps,
 	slugify,
 	type TodoItem,
@@ -19,17 +23,34 @@ const NORMAL_MODE_TOOLS = ["read", "bash", "edit", "write"];
 const MUTATING_TOOLS = new Set(["edit", "write"]);
 
 const PLAN_INSTRUCTIONS = `[PLAN MODE ATIVO]
-Você está em plan mode — modo somente-leitura para análise segura antes de codar.
+Você está em plan mode — modo somente-leitura para análise e refinamento antes de codar. Esta é uma plataforma de educação (edtech), então o contexto de negócio e pedagógico importa tanto quanto o técnico.
 
 Restrições (impostas por hard gate, não apenas instrução):
 - Você só pode usar: read, bash, grep, find, ls, questionnaire
 - edit e write estão BLOQUEADOS — qualquer tentativa é rejeitada pelo gate
 - bash está restrito a um allowlist de comandos somente-leitura
 
-Faça perguntas de esclarecimento usando a tool questionnaire antes de assumir escopo.
-Pesquise o codebase com read/grep/find para montar contexto real.
+Antes de planejar, ENTENDA o problema por completo. Faça perguntas de esclarecimento usando a tool questionnaire, cobrindo:
 
-Produza um plano detalhado e numerado sob um header "Plan:":
+Negócio e produto:
+- Qual problema concreto e mensurável estamos resolvendo? O que acontece hoje que mostra que ele existe?
+- Qual o impacto de não fazer nada? Qual a prioridade?
+- O que está dentro do escopo agora e o que fica explicitamente de fora?
+
+Usuários e pedagogia:
+- Quem é diretamente impactado: aluno, professor, escola, coordenação, editora?
+- Há variação por perfil, plano, série/ano, ou tipo de conteúdo?
+- Há implicação pedagógica (avaliação, leitura, fluência, antifraude) que precisa ser respeitada?
+
+Técnico:
+- Quais repositórios e sistemas são afetados?
+- Quais alternativas estamos descartando e por quê?
+- Happy path, erros, falhas de rede, timeouts, escala esperada e máxima?
+- Padrões de UX, código, arquitetura e acessibilidade a seguir?
+
+Sempre que fizer uma pergunta com alternativas, ofereça opções claras para o usuário escolher (não peça texto livre quando opções resolvem). Pesquise o codebase com read/grep/find para basear tudo em fatos, não suposições.
+
+Quando tiver contexto suficiente, produza um plano detalhado e numerado sob um header "Plan:":
 
 # Título curto do plano
 
@@ -56,7 +77,9 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 	let executionMode = false;
 	let todoItems: TodoItem[] = [];
 	let lastPlanText = "";
+	let lastShownPlan = "";
 	let lastPlanFile: string | undefined;
+	let suggestedThisSession = false;
 
 	pi.registerFlag("plan", {
 		description: "Iniciar em plan mode (exploração somente-leitura)",
@@ -91,6 +114,8 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 		planModeEnabled = true;
 		executionMode = false;
 		todoItems = [];
+		lastPlanText = "";
+		lastShownPlan = "";
 		pi.setActiveTools(PLAN_MODE_TOOLS);
 		ctx.ui.notify(`Plan mode ativado (locked). Tools: ${PLAN_MODE_TOOLS.join(", ")}. Aprove com /build.`, "info");
 		updateStatus(ctx);
@@ -132,6 +157,19 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 		return file;
 	}
 
+	function openInEditor(filePath: string, cwd: string): boolean {
+		if (isInsideWarp()) {
+			spawn("open", [buildWarpUri(filePath)], { detached: true, stdio: "ignore", cwd }).unref();
+			return true;
+		}
+		const editor = process.env.EDITOR;
+		if (editor) {
+			spawn(editor, [filePath], { detached: true, stdio: "ignore", cwd }).unref();
+			return true;
+		}
+		return false;
+	}
+
 	pi.registerCommand("plan", {
 		description: "Alternar plan mode (exploração somente-leitura, edits bloqueados)",
 		handler: async (_args, ctx) => togglePlanMode(ctx),
@@ -168,6 +206,25 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 		},
 	});
 
+	pi.registerCommand("plan-open", {
+		description: "Abrir o plano atual no editor (Warp/$EDITOR) para revisar e editar",
+		handler: async (_args, ctx) => {
+			if (!lastPlanFile) {
+				if (lastPlanText) {
+					lastPlanFile = savePlanToFile(ctx, lastPlanText);
+				} else {
+					ctx.ui.notify("Nenhum plano para abrir ainda. Gere um plano primeiro.", "warning");
+					return;
+				}
+			}
+			if (openInEditor(lastPlanFile, ctx.cwd)) {
+				ctx.ui.notify(`Abrindo ${lastPlanFile} no editor.`, "info");
+			} else {
+				ctx.ui.notify(`Plano salvo em ${lastPlanFile} (sem editor detectado).`, "info");
+			}
+		},
+	});
+
 	pi.registerCommand("todos", {
 		description: "Mostrar o progresso do plano atual",
 		handler: async (_args, ctx) => {
@@ -183,6 +240,22 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 	pi.registerShortcut(Key.ctrlAlt("p"), {
 		description: "Alternar plan mode",
 		handler: async (ctx) => togglePlanMode(ctx),
+	});
+
+	pi.on("input", async (event, ctx) => {
+		if (planModeEnabled || executionMode || suggestedThisSession || !ctx.hasUI) return;
+		if (event.source !== "interactive") return;
+		if (event.text.startsWith("/") || event.text.startsWith("!")) return;
+		if (!looksComplex(event.text)) return;
+
+		suggestedThisSession = true;
+		const choice = await ctx.ui.select("Essa tarefa parece complexa. Quer planejar antes de codar?", [
+			"Sim, entrar em plan mode (refinar antes de codar)",
+			"Não, seguir direto",
+		]);
+		if (choice?.startsWith("Sim")) {
+			enablePlanMode(ctx);
+		}
 	});
 
 	pi.on("tool_call", async (event) => {
@@ -266,6 +339,7 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 				executionMode = false;
 				todoItems = [];
 				lastPlanText = "";
+				lastShownPlan = "";
 				pi.setActiveTools(NORMAL_MODE_TOOLS);
 				updateStatus(ctx);
 				persistState();
@@ -276,27 +350,34 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 		if (!planModeEnabled) return;
 
 		const lastAssistant = [...event.messages].reverse().find(isAssistantMessage);
+		let planChanged = false;
 		if (lastAssistant) {
 			const text = getTextContent(lastAssistant);
 			const extracted = extractTodoItems(text);
-			if (extracted.length > 0) {
+			if (extracted.length > 0 && text !== lastPlanText) {
 				todoItems = extracted;
 				lastPlanText = text;
+				planChanged = true;
 			}
 		}
 
-		if (todoItems.length > 0 && ctx.hasUI) {
-			const todoListText = todoItems.map((t, i) => `${i + 1}. ☐ ${t.text}`).join("\n");
-			pi.sendMessage(
-				{
-					customType: "plan-todo-list",
-					content: `**Plano (${todoItems.length} passos):**\n\n${todoListText}\n\n_Revise/edite e rode \`/build\` para aprovar e executar, ou continue refinando._`,
-					display: true,
-				},
-				{ triggerTurn: false },
-			);
-			persistState();
+		if (!planChanged || todoItems.length === 0 || lastPlanText === lastShownPlan || !ctx.hasUI) {
+			return;
 		}
+
+		lastShownPlan = lastPlanText;
+		lastPlanFile = savePlanToFile(ctx, lastPlanText);
+		persistState();
+
+		const todoListText = todoItems.map((t, i) => `${i + 1}. ☐ ${t.text}`).join("\n");
+		pi.sendMessage(
+			{
+				customType: "plan-todo-list",
+				content: `**Plano (${todoItems.length} passos):**\n\n${todoListText}\n\nSalvo em \`${lastPlanFile}\`.\n_Use \`/plan-open\` para abrir no editor, \`/build\` para aprovar e executar, ou continue refinando._`,
+				display: true,
+			},
+			{ triggerTurn: false },
+		);
 	});
 
 	pi.on("session_start", async (_event, ctx) => {

--- a/packages/plan-mode/src/questionnaire.ts
+++ b/packages/plan-mode/src/questionnaire.ts
@@ -1,0 +1,441 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Type } from "@earendil-works/pi-ai";
+import {
+	Editor,
+	type EditorTheme,
+	Key,
+	matchesKey,
+	Text,
+	visibleWidth,
+	wrapTextWithAnsi,
+} from "@earendil-works/pi-tui";
+
+// Types
+interface QuestionOption {
+	value: string;
+	label: string;
+	description?: string;
+}
+
+type RenderOption = QuestionOption & { isOther?: boolean };
+
+interface Question {
+	id: string;
+	label: string;
+	prompt: string;
+	options: QuestionOption[];
+	allowOther: boolean;
+}
+
+interface Answer {
+	id: string;
+	value: string;
+	label: string;
+	wasCustom: boolean;
+	index?: number;
+}
+
+interface QuestionnaireResult {
+	questions: Question[];
+	answers: Answer[];
+	cancelled: boolean;
+}
+
+// Schema
+const QuestionOptionSchema = Type.Object({
+	value: Type.String({ description: "The value returned when selected" }),
+	label: Type.String({ description: "Display label for the option" }),
+	description: Type.Optional(Type.String({ description: "Optional description shown below label" })),
+});
+
+const QuestionSchema = Type.Object({
+	id: Type.String({ description: "Unique identifier for this question" }),
+	label: Type.Optional(
+		Type.String({
+			description: "Short contextual label for tab bar, e.g. 'Scope', 'Priority' (defaults to Q1, Q2)",
+		}),
+	),
+	prompt: Type.String({ description: "The full question text to display" }),
+	options: Type.Array(QuestionOptionSchema, { description: "Available options to choose from" }),
+	allowOther: Type.Optional(Type.Boolean({ description: "Allow 'Type something' option (default: true)" })),
+});
+
+const QuestionnaireParams = Type.Object({
+	questions: Type.Array(QuestionSchema, { description: "Questions to ask the user" }),
+});
+
+function errorResult(
+	message: string,
+	questions: Question[] = [],
+): { content: { type: "text"; text: string }[]; details: QuestionnaireResult } {
+	return {
+		content: [{ type: "text", text: message }],
+		details: { questions, answers: [], cancelled: true },
+	};
+}
+
+export default function questionnaire(pi: ExtensionAPI) {
+	pi.registerTool({
+		name: "questionnaire",
+		label: "Questionnaire",
+		description:
+			"Ask the user one or more questions. Use for clarifying requirements, getting preferences, or confirming decisions. For single questions, shows a simple option list. For multiple questions, shows a tab-based interface.",
+		parameters: QuestionnaireParams,
+
+		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+			if (ctx.mode !== "tui") {
+				return errorResult("Error: UI not available (running in non-interactive mode)");
+			}
+			if (params.questions.length === 0) {
+				return errorResult("Error: No questions provided");
+			}
+
+			// Normalize questions with defaults
+			const questions: Question[] = params.questions.map((q, i) => ({
+				...q,
+				label: q.label || `Q${i + 1}`,
+				allowOther: q.allowOther !== false,
+			}));
+
+			const isMulti = questions.length > 1;
+			const totalTabs = questions.length + 1; // questions + Submit
+
+			const result = await ctx.ui.custom<QuestionnaireResult>((tui, theme, _kb, done) => {
+				// State
+				let currentTab = 0;
+				let optionIndex = 0;
+				let inputMode = false;
+				let inputQuestionId: string | null = null;
+				let cachedLines: string[] | undefined;
+				const answers = new Map<string, Answer>();
+
+				// Editor for "Type something" option
+				const editorTheme: EditorTheme = {
+					borderColor: (s) => theme.fg("accent", s),
+					selectList: {
+						selectedPrefix: (t) => theme.fg("accent", t),
+						selectedText: (t) => theme.fg("accent", t),
+						description: (t) => theme.fg("muted", t),
+						scrollInfo: (t) => theme.fg("dim", t),
+						noMatch: (t) => theme.fg("warning", t),
+					},
+				};
+				const editor = new Editor(tui, editorTheme);
+
+				// Helpers
+				function refresh() {
+					cachedLines = undefined;
+					tui.requestRender();
+				}
+
+				function submit(cancelled: boolean) {
+					done({ questions, answers: Array.from(answers.values()), cancelled });
+				}
+
+				function currentQuestion(): Question | undefined {
+					return questions[currentTab];
+				}
+
+				function currentOptions(): RenderOption[] {
+					const q = currentQuestion();
+					if (!q) return [];
+					const opts: RenderOption[] = [...q.options];
+					if (q.allowOther) {
+						opts.push({ value: "__other__", label: "Type something.", isOther: true });
+					}
+					return opts;
+				}
+
+				function allAnswered(): boolean {
+					return questions.every((q) => answers.has(q.id));
+				}
+
+				function advanceAfterAnswer() {
+					if (!isMulti) {
+						submit(false);
+						return;
+					}
+					if (currentTab < questions.length - 1) {
+						currentTab++;
+					} else {
+						currentTab = questions.length; // Submit tab
+					}
+					optionIndex = 0;
+					refresh();
+				}
+
+				function saveAnswer(questionId: string, value: string, label: string, wasCustom: boolean, index?: number) {
+					answers.set(questionId, { id: questionId, value, label, wasCustom, index });
+				}
+
+				// Editor submit callback
+				editor.onSubmit = (value) => {
+					if (!inputQuestionId) return;
+					const trimmed = value.trim() || "(no response)";
+					saveAnswer(inputQuestionId, trimmed, trimmed, true);
+					inputMode = false;
+					inputQuestionId = null;
+					editor.setText("");
+					advanceAfterAnswer();
+				};
+
+				function handleInput(data: string) {
+					// Input mode: route to editor
+					if (inputMode) {
+						if (matchesKey(data, Key.escape)) {
+							inputMode = false;
+							inputQuestionId = null;
+							editor.setText("");
+							refresh();
+							return;
+						}
+						editor.handleInput(data);
+						refresh();
+						return;
+					}
+
+					const q = currentQuestion();
+					const opts = currentOptions();
+
+					// Tab navigation (multi-question only)
+					if (isMulti) {
+						if (matchesKey(data, Key.tab) || matchesKey(data, Key.right)) {
+							currentTab = (currentTab + 1) % totalTabs;
+							optionIndex = 0;
+							refresh();
+							return;
+						}
+						if (matchesKey(data, Key.shift("tab")) || matchesKey(data, Key.left)) {
+							currentTab = (currentTab - 1 + totalTabs) % totalTabs;
+							optionIndex = 0;
+							refresh();
+							return;
+						}
+					}
+
+					// Submit tab
+					if (currentTab === questions.length) {
+						if (matchesKey(data, Key.enter) && allAnswered()) {
+							submit(false);
+						} else if (matchesKey(data, Key.escape)) {
+							submit(true);
+						}
+						return;
+					}
+
+					// Option navigation
+					if (matchesKey(data, Key.up)) {
+						optionIndex = Math.max(0, optionIndex - 1);
+						refresh();
+						return;
+					}
+					if (matchesKey(data, Key.down)) {
+						optionIndex = Math.min(opts.length - 1, optionIndex + 1);
+						refresh();
+						return;
+					}
+
+					// Select option
+					if (matchesKey(data, Key.enter) && q) {
+						const opt = opts[optionIndex];
+						if (opt.isOther) {
+							inputMode = true;
+							inputQuestionId = q.id;
+							editor.setText("");
+							refresh();
+							return;
+						}
+						saveAnswer(q.id, opt.value, opt.label, false, optionIndex + 1);
+						advanceAfterAnswer();
+						return;
+					}
+
+					// Cancel
+					if (matchesKey(data, Key.escape)) {
+						submit(true);
+					}
+				}
+
+				function render(width: number): string[] {
+					if (cachedLines) return cachedLines;
+
+					const lines: string[] = [];
+					const renderWidth = Math.max(1, width);
+					const q = currentQuestion();
+					const opts = currentOptions();
+
+					function addWrapped(text: string) {
+						lines.push(...wrapTextWithAnsi(text, renderWidth));
+					}
+
+					function addWrappedWithPrefix(prefix: string, text: string) {
+						const prefixWidth = visibleWidth(prefix);
+						if (prefixWidth >= renderWidth) {
+							addWrapped(prefix + text);
+							return;
+						}
+						const wrapped = wrapTextWithAnsi(text, renderWidth - prefixWidth);
+						const continuationPrefix = " ".repeat(prefixWidth);
+						for (let i = 0; i < wrapped.length; i++) {
+							lines.push(`${i === 0 ? prefix : continuationPrefix}${wrapped[i]}`);
+						}
+					}
+
+					lines.push(theme.fg("accent", "─".repeat(renderWidth)));
+
+					// Tab bar (multi-question only)
+					if (isMulti) {
+						const tabs: string[] = ["← "];
+						for (let i = 0; i < questions.length; i++) {
+							const isActive = i === currentTab;
+							const isAnswered = answers.has(questions[i].id);
+							const lbl = questions[i].label;
+							const box = isAnswered ? "■" : "□";
+							const color = isAnswered ? "success" : "muted";
+							const text = ` ${box} ${lbl} `;
+							const styled = isActive ? theme.bg("selectedBg", theme.fg("text", text)) : theme.fg(color, text);
+							tabs.push(`${styled} `);
+						}
+						const canSubmit = allAnswered();
+						const isSubmitTab = currentTab === questions.length;
+						const submitText = " ✓ Submit ";
+						const submitStyled = isSubmitTab
+							? theme.bg("selectedBg", theme.fg("text", submitText))
+							: theme.fg(canSubmit ? "success" : "dim", submitText);
+						tabs.push(`${submitStyled} →`);
+						addWrappedWithPrefix(" ", tabs.join(""));
+						lines.push("");
+					}
+
+					// Helper to render options list
+					function renderOptions() {
+						for (let i = 0; i < opts.length; i++) {
+							const opt = opts[i];
+							const selected = i === optionIndex;
+							const isOther = opt.isOther === true;
+							const prefix = selected ? theme.fg("accent", "> ") : "  ";
+							const label = `${i + 1}. ${opt.label}${isOther && inputMode ? " ✎" : ""}`;
+							const color = selected || (isOther && inputMode) ? "accent" : "text";
+
+							addWrappedWithPrefix(prefix, theme.fg(color, label));
+							if (opt.description) {
+								addWrappedWithPrefix("     ", theme.fg("muted", opt.description));
+							}
+						}
+					}
+
+					// Content
+					if (inputMode && q) {
+						addWrappedWithPrefix(" ", theme.fg("text", q.prompt));
+						lines.push("");
+						// Show options for reference
+						renderOptions();
+						lines.push("");
+						addWrappedWithPrefix(" ", theme.fg("muted", "Your answer:"));
+						for (const line of editor.render(Math.max(1, renderWidth - 2))) {
+							lines.push(` ${line}`);
+						}
+						lines.push("");
+						addWrappedWithPrefix(" ", theme.fg("dim", "Enter to submit • Esc to cancel"));
+					} else if (currentTab === questions.length) {
+						addWrappedWithPrefix(" ", theme.fg("accent", theme.bold("Ready to submit")));
+						lines.push("");
+						for (const question of questions) {
+							const answer = answers.get(question.id);
+							if (answer) {
+								const prefix = answer.wasCustom ? "(wrote) " : "";
+								const summary = `${theme.fg("muted", `${question.label}: `)}${theme.fg("text", prefix + answer.label)}`;
+								addWrappedWithPrefix(" ", summary);
+							}
+						}
+						lines.push("");
+						if (allAnswered()) {
+							addWrappedWithPrefix(" ", theme.fg("success", "Press Enter to submit"));
+						} else {
+							const missing = questions
+								.filter((q) => !answers.has(q.id))
+								.map((q) => q.label)
+								.join(", ");
+							addWrappedWithPrefix(" ", theme.fg("warning", `Unanswered: ${missing}`));
+						}
+					} else if (q) {
+						addWrappedWithPrefix(" ", theme.fg("text", q.prompt));
+						lines.push("");
+						renderOptions();
+					}
+
+					lines.push("");
+					if (!inputMode) {
+						const help = isMulti
+							? "Tab/←→ navigate • ↑↓ select • Enter confirm • Esc cancel"
+							: "↑↓ navigate • Enter select • Esc cancel";
+						addWrappedWithPrefix(" ", theme.fg("dim", help));
+					}
+					lines.push(theme.fg("accent", "─".repeat(renderWidth)));
+
+					cachedLines = lines;
+					return lines;
+				}
+
+				return {
+					render,
+					invalidate: () => {
+						cachedLines = undefined;
+					},
+					handleInput,
+				};
+			});
+
+			if (result.cancelled) {
+				return {
+					content: [{ type: "text", text: "User cancelled the questionnaire" }],
+					details: result,
+				};
+			}
+
+			const answerLines = result.answers.map((a) => {
+				const qLabel = questions.find((q) => q.id === a.id)?.label || a.id;
+				if (a.wasCustom) {
+					return `${qLabel}: user wrote: ${a.label}`;
+				}
+				return `${qLabel}: user selected: ${a.index}. ${a.label}`;
+			});
+
+			return {
+				content: [{ type: "text", text: answerLines.join("\n") }],
+				details: result,
+			};
+		},
+
+		renderCall(args, theme, _context) {
+			const qs = (args.questions as Question[]) || [];
+			const count = qs.length;
+			const labels = qs.map((q) => q.label || q.id).join(", ");
+			let text = theme.fg("toolTitle", theme.bold("questionnaire "));
+			text += theme.fg("muted", `${count} question${count !== 1 ? "s" : ""}`);
+			if (labels) {
+				text += theme.fg("dim", ` (${labels})`);
+			}
+			return new Text(text, 0, 0);
+		},
+
+		renderResult(result, _options, theme, _context) {
+			const details = result.details as QuestionnaireResult | undefined;
+			if (!details) {
+				const text = result.content[0];
+				return new Text(text?.type === "text" ? text.text : "", 0, 0);
+			}
+			if (details.cancelled) {
+				return new Text(theme.fg("warning", "Cancelled"), 0, 0);
+			}
+			const lines = details.answers.map((a) => {
+				if (a.wasCustom) {
+					return `${theme.fg("success", "✓ ")}${theme.fg("accent", a.id)}: ${theme.fg("muted", "(wrote) ")}${a.label}`;
+				}
+				const display = a.index ? `${a.index}. ${a.label}` : a.label;
+				return `${theme.fg("success", "✓ ")}${theme.fg("accent", a.id)}: ${display}`;
+			});
+			return new Text(lines.join("\n"), 0, 0);
+		},
+	});
+}

--- a/packages/plan-mode/src/utils.ts
+++ b/packages/plan-mode/src/utils.ts
@@ -92,7 +92,17 @@ const SAFE_PATTERNS = [
 	/^\s*eza\b/,
 ];
 
+const UNSAFE_SAFE_COMMAND_PATTERNS = [
+	/\bcurl\b[^\n]*(\|\s*(sh|bash|zsh|python|node)\b|(?:^|\s)(-o|-O|--output)\b)/i,
+	/\bwget\b[^\n]*(\|\s*(sh|bash|zsh|python|node)\b)/i,
+	/\bfind\b[^\n]*\s-(delete|exec|ok)\b/i,
+	/\bsed\b[^\n]*(\s-i\b|\bw\s+\S+)/i,
+	/\bgit\s+diff\b[^\n]*\s--output(=|\s+)/i,
+	/\bawk\b[^\n]*\bprint\b[^\n]*>\s*\S+/i,
+];
+
 export function isSafeCommand(command: string): boolean {
+	if (UNSAFE_SAFE_COMMAND_PATTERNS.some((p) => p.test(command))) return false;
 	const isDestructive = DESTRUCTIVE_PATTERNS.some((p) => p.test(command));
 	const isSafe = SAFE_PATTERNS.some((p) => p.test(command));
 	return !isDestructive && isSafe;
@@ -133,14 +143,15 @@ export function extractTodoItems(message: string): TodoItem[] {
 	const numberedPattern = /^\s*(\d+)[.)]\s+\*{0,2}([^*\n]+)/gm;
 
 	for (const match of planSection.matchAll(numberedPattern)) {
+		const parsedStep = Number(match[1]);
 		const text = match[2]
 			.trim()
 			.replace(/\*{1,2}$/, "")
 			.trim();
 		if (text.length > 5 && !text.startsWith("`") && !text.startsWith("/") && !text.startsWith("-")) {
 			const cleaned = cleanStepText(text);
-			if (cleaned.length > 3) {
-				items.push({ step: items.length + 1, text: cleaned, completed: false });
+			if (cleaned.length > 3 && Number.isFinite(parsedStep)) {
+				items.push({ step: parsedStep, text: cleaned, completed: false });
 			}
 		}
 	}
@@ -157,12 +168,16 @@ export function extractDoneSteps(message: string): number[] {
 }
 
 export function markCompletedSteps(text: string, items: TodoItem[]): number {
-	const doneSteps = extractDoneSteps(text);
+	const doneSteps = new Set(extractDoneSteps(text));
+	let updated = 0;
 	for (const step of doneSteps) {
 		const item = items.find((t) => t.step === step);
-		if (item) item.completed = true;
+		if (item && !item.completed) {
+			item.completed = true;
+			updated += 1;
+		}
 	}
-	return doneSteps.length;
+	return updated;
 }
 
 export function slugify(text: string): string {

--- a/packages/plan-mode/src/utils.ts
+++ b/packages/plan-mode/src/utils.ts
@@ -193,3 +193,31 @@ export function extractPlanSection(message: string): string {
 	const start = message.indexOf(headerMatch[0]);
 	return message.slice(start).trim();
 }
+
+export function isInsideWarp(): boolean {
+	return process.env.TERM_PROGRAM === "WarpTerminal" || Boolean(process.env.WARP_IS_LOCAL_SHELL_SESSION);
+}
+
+export function buildWarpUri(filePath: string, line?: number): string {
+	const params = new URLSearchParams({ path: filePath });
+	if (line && line > 0) params.set("line", String(line));
+	return `warp://action/open_file_editor?${params.toString()}`;
+}
+
+const COMPLEXITY_PATTERNS = [
+	/\bimplementar?\b/i,
+	/\bcriar?\s+(uma?\s+)?(feature|funcionalidade|m[oó]dulo|endpoint|servi[cç]o|fluxo|integra[cç][aã]o)/i,
+	/\brefatorar?\b/i,
+	/\bmigrar?\b/i,
+	/\barquitetura\b/i,
+	/\bv[aá]rios?\s+(arquivos|reposit[oó]rios|servi[cç]os)/i,
+	/\bm[uú]ltiplos?\b/i,
+	/\bdo\s+zero\b/i,
+	/\bend[\s-]?to[\s-]?end\b/i,
+	/\bplaneje?\b/i,
+];
+
+export function looksComplex(text: string): boolean {
+	if (text.trim().length < 25) return false;
+	return COMPLEXITY_PATTERNS.some((p) => p.test(text));
+}

--- a/packages/plan-mode/src/utils.ts
+++ b/packages/plan-mode/src/utils.ts
@@ -1,0 +1,195 @@
+const DESTRUCTIVE_PATTERNS = [
+	/\brm\b/i,
+	/\brmdir\b/i,
+	/\bmv\b/i,
+	/\bcp\b/i,
+	/\bmkdir\b/i,
+	/\btouch\b/i,
+	/\bchmod\b/i,
+	/\bchown\b/i,
+	/\bchgrp\b/i,
+	/\bln\b/i,
+	/\btee\b/i,
+	/\btruncate\b/i,
+	/\bdd\b/i,
+	/\bshred\b/i,
+	/(^|[^<])>(?!>)/,
+	/>>/,
+	/\bnpm\s+(install|uninstall|update|ci|link|publish)/i,
+	/\byarn\s+(add|remove|install|publish)/i,
+	/\bpnpm\s+(add|remove|install|publish)/i,
+	/\bpip\s+(install|uninstall)/i,
+	/\bapt(-get)?\s+(install|remove|purge|update|upgrade)/i,
+	/\bbrew\s+(install|uninstall|upgrade)/i,
+	/\bgit\s+(add|commit|push|pull|merge|rebase|reset|checkout|branch\s+-[dD]|stash|cherry-pick|revert|tag|init|clone)/i,
+	/\bmix\s+(deps\.get|ecto\.|phx\.gen|format)/i,
+	/\bsudo\b/i,
+	/\bsu\b/i,
+	/\bkill\b/i,
+	/\bpkill\b/i,
+	/\bkillall\b/i,
+	/\breboot\b/i,
+	/\bshutdown\b/i,
+	/\bsystemctl\s+(start|stop|restart|enable|disable)/i,
+	/\bservice\s+\S+\s+(start|stop|restart)/i,
+	/\b(vim?|nano|emacs|code|subl)\b/i,
+	/\bkubectl\s+(apply|delete|edit|scale|patch|rollout)/i,
+	/\baws\s+\S+\s+(create|delete|put|update|modify|terminate|remove)/i,
+];
+
+const SAFE_PATTERNS = [
+	/^\s*cat\b/,
+	/^\s*head\b/,
+	/^\s*tail\b/,
+	/^\s*less\b/,
+	/^\s*more\b/,
+	/^\s*grep\b/,
+	/^\s*find\b/,
+	/^\s*ls\b/,
+	/^\s*pwd\b/,
+	/^\s*echo\b/,
+	/^\s*printf\b/,
+	/^\s*wc\b/,
+	/^\s*sort\b/,
+	/^\s*uniq\b/,
+	/^\s*diff\b/,
+	/^\s*file\b/,
+	/^\s*stat\b/,
+	/^\s*du\b/,
+	/^\s*df\b/,
+	/^\s*tree\b/,
+	/^\s*which\b/,
+	/^\s*whereis\b/,
+	/^\s*type\b/,
+	/^\s*env\b/,
+	/^\s*printenv\b/,
+	/^\s*uname\b/,
+	/^\s*whoami\b/,
+	/^\s*id\b/,
+	/^\s*date\b/,
+	/^\s*cal\b/,
+	/^\s*uptime\b/,
+	/^\s*ps\b/,
+	/^\s*top\b/,
+	/^\s*htop\b/,
+	/^\s*free\b/,
+	/^\s*git\s+(status|log|diff|show|branch|remote|config\s+--get)/i,
+	/^\s*git\s+ls-/i,
+	/^\s*npm\s+(list|ls|view|info|search|outdated|audit)/i,
+	/^\s*yarn\s+(list|info|why|audit)/i,
+	/^\s*pnpm\s+(list|why|outdated|audit)/i,
+	/^\s*mix\s+(help|deps(\.tree)?|hex\.info)/i,
+	/^\s*node\s+--version/i,
+	/^\s*python\s+--version/i,
+	/^\s*curl\s/i,
+	/^\s*wget\s+-O\s*-/i,
+	/^\s*jq\b/,
+	/^\s*sed\s+-n/i,
+	/^\s*awk\b/,
+	/^\s*rg\b/,
+	/^\s*fd\b/,
+	/^\s*bat\b/,
+	/^\s*eza\b/,
+];
+
+export function isSafeCommand(command: string): boolean {
+	const isDestructive = DESTRUCTIVE_PATTERNS.some((p) => p.test(command));
+	const isSafe = SAFE_PATTERNS.some((p) => p.test(command));
+	return !isDestructive && isSafe;
+}
+
+export interface TodoItem {
+	step: number;
+	text: string;
+	completed: boolean;
+}
+
+export function cleanStepText(text: string): string {
+	let cleaned = text
+		.replace(/\*{1,2}([^*]+)\*{1,2}/g, "$1")
+		.replace(/`([^`]+)`/g, "$1")
+		.replace(
+			/^(Use|Run|Execute|Create|Write|Read|Check|Verify|Update|Modify|Add|Remove|Delete|Install)\s+(the\s+)?/i,
+			"",
+		)
+		.replace(/\s+/g, " ")
+		.trim();
+
+	if (cleaned.length > 0) {
+		cleaned = cleaned.charAt(0).toUpperCase() + cleaned.slice(1);
+	}
+	if (cleaned.length > 60) {
+		cleaned = `${cleaned.slice(0, 57)}...`;
+	}
+	return cleaned;
+}
+
+export function extractTodoItems(message: string): TodoItem[] {
+	const items: TodoItem[] = [];
+	const headerMatch = message.match(/\*{0,2}Plan:\*{0,2}\s*\n/i);
+	if (!headerMatch) return items;
+
+	const planSection = message.slice(message.indexOf(headerMatch[0]) + headerMatch[0].length);
+	const numberedPattern = /^\s*(\d+)[.)]\s+\*{0,2}([^*\n]+)/gm;
+
+	for (const match of planSection.matchAll(numberedPattern)) {
+		const text = match[2]
+			.trim()
+			.replace(/\*{1,2}$/, "")
+			.trim();
+		if (text.length > 5 && !text.startsWith("`") && !text.startsWith("/") && !text.startsWith("-")) {
+			const cleaned = cleanStepText(text);
+			if (cleaned.length > 3) {
+				items.push({ step: items.length + 1, text: cleaned, completed: false });
+			}
+		}
+	}
+	return items;
+}
+
+export function extractDoneSteps(message: string): number[] {
+	const steps: number[] = [];
+	for (const match of message.matchAll(/\[DONE:(\d+)\]/gi)) {
+		const step = Number(match[1]);
+		if (Number.isFinite(step)) steps.push(step);
+	}
+	return steps;
+}
+
+export function markCompletedSteps(text: string, items: TodoItem[]): number {
+	const doneSteps = extractDoneSteps(text);
+	for (const step of doneSteps) {
+		const item = items.find((t) => t.step === step);
+		if (item) item.completed = true;
+	}
+	return doneSteps.length;
+}
+
+export function slugify(text: string): string {
+	return text
+		.toLowerCase()
+		.normalize("NFD")
+		.replace(/[\u0300-\u036f]/g, "")
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-+|-+$/g, "")
+		.slice(0, 60);
+}
+
+export function extractPlanTitle(message: string): string {
+	const titleMatch = message.match(/^#\s+(.+)$/m);
+	if (titleMatch) return titleMatch[1].trim();
+	const headerMatch = message.match(/\*{0,2}Plan:\*{0,2}/i);
+	if (headerMatch) {
+		const before = message.slice(0, message.indexOf(headerMatch[0])).trim();
+		const lastLine = before.split("\n").filter(Boolean).pop();
+		if (lastLine) return lastLine.replace(/^#+\s*/, "").trim();
+	}
+	return "plano";
+}
+
+export function extractPlanSection(message: string): string {
+	const headerMatch = message.match(/\*{0,2}Plan:\*{0,2}\s*\n/i);
+	if (!headerMatch) return message.trim();
+	const start = message.indexOf(headerMatch[0]);
+	return message.slice(start).trim();
+}

--- a/packages/plan-mode/tsconfig.json
+++ b/packages/plan-mode/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,6 +73,27 @@ importers:
         specifier: ^5.3.0
         version: 5.9.3
 
+  packages/plan-mode:
+    devDependencies:
+      '@earendil-works/pi-agent-core':
+        specifier: latest
+        version: 0.79.4(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-ai':
+        specifier: latest
+        version: 0.79.4(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-coding-agent':
+        specifier: latest
+        version: 0.79.4(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-tui':
+        specifier: latest
+        version: 0.79.4
+      '@types/node':
+        specifier: ^20.10.0
+        version: 20.19.39
+      typescript:
+        specifier: ^5.3.0
+        version: 5.9.3
+
   packages/team-memory:
     devDependencies:
       '@earendil-works/pi-ai':
@@ -3255,7 +3276,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 8.59.3
       debug: 4.4.3
       minimatch: 10.2.5
-      semver: 7.7.4
+      semver: 7.8.0
       tinyglobby: 0.2.16
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3


### PR DESCRIPTION
## Summary

Adds `@arvoretech/pi-plan-mode`, a Cursor-style **plan mode** for PI with a real **hard tool gate**.

While plan mode is active, the agent is locked into read-only exploration — `edit`/`write` are blocked and `bash` is restricted to a read-only allowlist, enforced by the `tool_call` gate (not by prompt discipline). The agent physically cannot touch code until the plan is approved with `/build`.

## What it does

- **Hard gate (defense in depth)**: hides `edit`/`write` via `setActiveTools` AND blocks them in `tool_call`. `bash` is allowlisted (blocks `rm`, `git commit`, `kubectl apply`, `aws ... delete`, `mix ecto`, shell redirects, etc.).
- **Plan generation**: agent asks clarifying questions, researches the codebase, and outputs a numbered plan under a `Plan:` header.
- **Workspace storage**: on `/build`, the plan is saved to `.pi/plans/{date}-{slug}.md` (versionable, shareable).
- **Manual handoff**: nothing executes until `/build` is run explicitly.
- **Progress tracking**: numbered steps become a todo list; completed steps marked with `[DONE:n]` and shown in a widget during execution.
- **Session persistence**: state survives `/resume`.

## Commands

- `/plan` — toggle plan mode (or `Ctrl+Alt+P`)
- `/build` — approve, save the plan, exit plan mode, execute
- `/todos` — show progress
- `--plan` — start directly in plan mode

## Tested

- `pnpm --filter @arvoretech/pi-plan-mode build` — clean (tsc)
- `pnpm --filter @arvoretech/pi-plan-mode lint` — clean (tsc --noEmit)
- 7 pure-logic tests against compiled `dist/` passing (command allowlist, plan/todo/title extraction, `[DONE:n]` marking)

## Notes

Follows the existing package convention (src→dist, scoped name, peerDeps, `pi.extensions` pointing to `dist`). Mirrors the official pi `plan-mode` example but adds the hard gate, `.pi/plans/` storage, and manual `/build` handoff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

- Introduced Plan Mode—a read-only exploration workflow (Ctrl+Alt+P / `/plan`) that blocks state-changing actions (including restricted shell execution)
- Generate, approve, and save plans to the `.pi/plans/` workspace folder
- Track plan progress with numbered todos and completion markers (`/todos`, `[DONE:n]`)
- Resume prior plan sessions and execution progress with `/resume`
- Improved plan handling with `/build` to exit approval and `/plan-open` to open the saved plan
<!-- end of auto-generated comment: release notes by coderabbit.ai -->