### PR TITLE
feat: add turn-notification extension

### DIFF
--- a/packages/turn-notification/README.md
+++ b/packages/turn-notification/README.md
@@ -1,0 +1,21 @@
+# @arvoretech/pi-turn-notification
+
+Pi extension that sends a macOS desktop notification at the end of each agent turn.
+
+Uses `osascript` to trigger native macOS notifications with the "Glass" sound.
+
+## Install
+
+```bash
+pnpm add @arvoretech/pi-turn-notification
+```
+
+## Usage
+
+Add to your `.pi/config.json`:
+
+```json
+{
+  "extensions": ["@arvoretech/pi-turn-notification"]
+}
+```

--- a/packages/turn-notification/package.json
+++ b/packages/turn-notification/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@arvoretech/pi-turn-notification",
+  "version": "1.0.0",
+  "description": "PI extension that sends a macOS desktop notification at the end of each agent turn",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "lint": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": ">=0.74.0"
+  },
+  "devDependencies": {
+    "@earendil-works/pi-coding-agent": "latest",
+    "@types/node": "^20.10.0",
+    "typescript": "^5.3.0"
+  },
+  "pi": {
+    "extensions": [
+      "./dist/index.js"
+    ]
+  },
+  "keywords": [
+    "pi",
+    "extension",
+    "notification",
+    "macos"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/arvoreeducacao/arvore-pi-extensions.git",
+    "directory": "packages/turn-notification"
+  },
+  "author": "Arvore",
+  "license": "MIT"
+}

--- a/packages/turn-notification/src/index.ts
+++ b/packages/turn-notification/src/index.ts
@@ -10,18 +10,19 @@ function notify(body: string): void {
   execFile("osascript", ["-e", script], () => {});
 }
 
-function extractText(message: { content?: Array<{ type: string; text?: string }> }): string {
-  if (!message?.content) return "Turn completed";
-  const text = message.content
+function extractText(messages: Array<{ role?: string; content?: Array<{ type: string; text?: string }> }>): string {
+  const last = [...messages].reverse().find((m) => m.role === "assistant");
+  if (!last?.content) return "Done";
+  const text = last.content
     .filter((block) => block.type === "text" && block.text)
     .map((block) => block.text!)
     .join(" ")
     .trim();
-  return text || "Turn completed";
+  return text || "Done";
 }
 
 export default function turnNotificationExtension(api: ExtensionAPI): void {
-  api.on("turn_end", async (event) => {
-    notify(extractText(event.message as any));
+  api.on("agent_end", async (event) => {
+    notify(extractText(event.messages as any));
   });
 }

--- a/packages/turn-notification/src/index.ts
+++ b/packages/turn-notification/src/index.ts
@@ -1,0 +1,27 @@
+import { execFile } from "node:child_process";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+const TITLE = "Pi";
+const MAX_BODY_LEN = 100;
+
+function notify(body: string): void {
+  const truncated = body.length > MAX_BODY_LEN ? `${body.slice(0, MAX_BODY_LEN)}…` : body;
+  const script = `display notification "${truncated.replace(/"/g, '\\"')}" with title "${TITLE}" sound name "Glass"`;
+  execFile("osascript", ["-e", script], () => {});
+}
+
+function extractText(message: { content?: Array<{ type: string; text?: string }> }): string {
+  if (!message?.content) return "Turn completed";
+  const text = message.content
+    .filter((block) => block.type === "text" && block.text)
+    .map((block) => block.text!)
+    .join(" ")
+    .trim();
+  return text || "Turn completed";
+}
+
+export default function turnNotificationExtension(api: ExtensionAPI): void {
+  api.on("turn_end", async (event) => {
+    notify(extractText(event.message as any));
+  });
+}

--- a/packages/turn-notification/tsconfig.json
+++ b/packages/turn-notification/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,6 +161,18 @@ importers:
         specifier: ^8.59.3
         version: 8.59.3(eslint@10.4.0(jiti@2.7.0))(typescript@5.9.3)
 
+  packages/turn-notification:
+    devDependencies:
+      '@earendil-works/pi-coding-agent':
+        specifier: latest
+        version: 0.79.4(ws@8.20.0)(zod@4.4.3)
+      '@types/node':
+        specifier: ^20.10.0
+        version: 20.19.39
+      typescript:
+        specifier: ^5.3.0
+        version: 5.9.3
+
   packages/warp-tab-title:
     devDependencies:
       '@earendil-works/pi-ai':


### PR DESCRIPTION
## Summary

Adds a new Pi extension (`@arvoretech/pi-turn-notification`) that sends a macOS desktop notification at the end of each agent turn.

## How it works

- Listens to the `turn_end` event
- Extracts text content from the assistant message
- Sends a native macOS notification via `osascript` with the "Glass" sound

## Usage

Add to `.pi/config.json`:

```json
{
  "extensions": ["@arvoretech/pi-turn-notification"]
}
```