### PR TITLE
feat(turn-notification): suporte a Linux via notify-send

### DIFF
--- a/packages/turn-notification/README.md
+++ b/packages/turn-notification/README.md
@@ -1,8 +1,13 @@
 # @arvoretech/pi-turn-notification
 
-Pi extension that sends a macOS desktop notification at the end of each agent turn.
+Pi extension that sends a native desktop notification at the end of each agent turn.
 
-Uses `osascript` to trigger native macOS notifications with the "Glass" sound.
+Works on macOS and Linux:
+
+- **macOS**: uses `osascript` to trigger native notifications with the "Glass" sound.
+- **Linux**: uses `notify-send` (libnotify) for the notification, and plays a sound via `canberra-gtk-play` or `paplay` when available.
+
+On Linux, make sure `libnotify` is installed (`notify-send` binary). The sound is best-effort and silently skipped if no player is available.
 
 ## Install
 

--- a/packages/turn-notification/package.json
+++ b/packages/turn-notification/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@arvoretech/pi-turn-notification",
-  "version": "1.0.0",
-  "description": "PI extension that sends a macOS desktop notification at the end of each agent turn",
+  "version": "1.1.0",
+  "description": "PI extension that sends a native desktop notification at the end of each agent turn (macOS and Linux)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "type": "module",
@@ -30,7 +30,8 @@
     "pi",
     "extension",
     "notification",
-    "macos"
+    "macos",
+    "linux"
   ],
   "repository": {
     "type": "git",

--- a/packages/turn-notification/src/index.ts
+++ b/packages/turn-notification/src/index.ts
@@ -1,13 +1,44 @@
 import { execFile } from "node:child_process";
+import { platform } from "node:os";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 const TITLE = "Pi";
 const MAX_BODY_LEN = 100;
 
+function notifyMac(body: string): void {
+  const script = `display notification "${body.replace(/"/g, '\\"')}" with title "${TITLE}" sound name "Glass"`;
+  execFile("osascript", ["-e", script], () => {});
+}
+
+function notifyLinux(body: string): void {
+  execFile("notify-send", ["--app-name=Pi", TITLE, body], () => {});
+  playLinuxSound();
+}
+
+const LINUX_SOUNDS: Array<[string, string[]]> = [
+  ["canberra-gtk-play", ["--id=message"]],
+  ["paplay", ["/usr/share/sounds/freedesktop/stereo/message.oga"]],
+];
+
+function playLinuxSound(index = 0): void {
+  const candidate = LINUX_SOUNDS[index];
+  if (!candidate) return;
+  const [cmd, args] = candidate;
+  execFile(cmd, args, (error) => {
+    if (error) playLinuxSound(index + 1);
+  });
+}
+
 function notify(body: string): void {
   const truncated = body.length > MAX_BODY_LEN ? `${body.slice(0, MAX_BODY_LEN)}…` : body;
-  const script = `display notification "${truncated.replace(/"/g, '\\"')}" with title "${TITLE}" sound name "Glass"`;
-  execFile("osascript", ["-e", script], () => {});
+  if (platform() === "darwin") {
+    notifyMac(truncated);
+    return;
+  }
+  if (platform() === "linux") {
+    notifyLinux(truncated);
+    return;
+  }
 }
 
 function extractText(messages: Array<{ role?: string; content?: Array<{ type: string; text?: string }> }>): string {


### PR DESCRIPTION
## Resumo

Adiciona suporte a Linux na extensão `turn-notification`, que antes era exclusiva de macOS.

- Detecta o SO em runtime via `os.platform()`.
- **macOS**: mantém o comportamento original com `osascript` + som "Glass" (inalterado).
- **Linux**: dispara a notificação visual com `notify-send` (libnotify) e toca um som best-effort via `canberra-gtk-play`, com fallback para `paplay`.
- O template da mensagem (título, corpo e truncamento em 100 chars) é compartilhado entre as duas plataformas — mesmo conteúdo, só o mecanismo de exibição/som difere.
- Em SOs não suportados ou quando nenhum player de som existe, degrada silenciosamente sem erro.
- README e package.json atualizados; bump `1.0.0` → `1.1.0`.

## Testes

- `pnpm lint` (`tsc --noEmit`): sem erros.
- `pnpm build` (`tsc`): compila e gera `dist/` corretamente.
- Disparo real via `node -e "import('./dist/index.js')..."` em Linux: notificação exibida sem erro (ambiente com `notify-send`, `canberra-gtk-play` e `paplay` disponíveis).

## Notas

- `notify-send` não tem som embutido (diferente do `osascript`), por isso o som é uma chamada separada e best-effort.
- No Linux é necessário ter `libnotify` instalado para a notificação visual aparecer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended native desktop notifications to Linux (previously macOS-only).
  * Added platform-specific sound playback for macOS and Linux.

* **Documentation**
  * Updated documentation with platform-specific notification behavior.
  * Added Linux installation and configuration requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->