### PR TITLE
ci: tornar publish resiliente a falhas de pacotes individuais

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,17 +66,29 @@ jobs:
         run: npm install -g npm@latest
 
       - name: Publish packages
+        shell: bash +e {0}
         run: |
+          FAILED=""
           for pkg in packages/*/; do
             PKG_NAME=$(node -p "require('./$pkg/package.json').name")
             PKG_VERSION=$(node -p "require('./$pkg/package.json').version")
             if npm view "$PKG_NAME@$PKG_VERSION" version 2>/dev/null; then
-              echo "$PKG_NAME@$PKG_VERSION already published, skipping."
-            else
-              echo "Publishing $PKG_NAME@$PKG_VERSION..."
+              echo "::notice::$PKG_NAME@$PKG_VERSION already published, skipping."
+              continue
+            fi
+            echo "Publishing $PKG_NAME@$PKG_VERSION..."
+            (
               cd "$pkg"
               TARBALL=$(pnpm pack --pack-destination /tmp | tail -1)
               npm publish "$TARBALL" --access public --provenance
-              cd ../..
+            )
+            if [ $? -ne 0 ]; then
+              echo "::error::Failed to publish $PKG_NAME@$PKG_VERSION"
+              FAILED="$FAILED $PKG_NAME@$PKG_VERSION"
             fi
           done
+          if [ -n "$FAILED" ]; then
+            echo "::error::The following packages failed to publish:$FAILED"
+            exit 1
+          fi
+          echo "All publishable packages processed successfully."


### PR DESCRIPTION
## Resumo

O step de publish do CI quebrava por completo quando **um único pacote** falhava no `npm publish`.

A causa: o loop roda em ordem alfabética e o GitHub Actions usa `bash -e` por padrão. Hoje o `@arvoretech/pi-memory@0.1.0` (nunca publicado) falha no meio do loop e, com o `errexit`, isso mata o step inteiro — os pacotes seguintes (`plan-mode`, `team-memory`, `turn-notification`, `warp-tab-title`) nunca chegam a publicar.

## Mudanças

- `shell: bash +e {0}` no step de publish — desliga o `errexit`, então uma falha de publish não aborta o step.
- Cada pacote publica dentro de um subshell `( ... )` isolado, evitando estado de `cd` vazando entre iterações.
- Falhas são coletadas em `FAILED`; o loop continua e os pacotes saudáveis sempre publicam.
- No final, se houve qualquer falha, o step termina com `exit 1` listando os pacotes problemáticos via `::error::` — sem perder visibilidade.

## Testes

- YAML validado (`yaml.safe_load`).
- Simulação local do loop com uma falha no meio: os pacotes seguintes continuam publicando e o step finaliza com `exit 1` listando apenas o que quebrou.

## Notas

- Isto **não resolve a raiz** do `pi-memory` não publicar (nome possivelmente não reservado no escopo / artefato faltando). Ele seguirá marcando o pipeline como vermelho, mas sem bloquear os demais pacotes. Investigação da causa raiz fica para um follow-up.