### PR TITLE
fix(pi-memory): corrige URL de prod para livros.arvore.com.br

### DIFF
--- a/packages/pi-memory/package.json
+++ b/packages/pi-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-memory",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "PI extension for cloud-based memory with RAG (Qdrant + GitHub OAuth)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/pi-memory/src/config.ts
+++ b/packages/pi-memory/src/config.ts
@@ -1,4 +1,4 @@
-const DEFAULT_API_URL = "https://api.arvore.com.br/api-arvore";
+const DEFAULT_API_URL = "https://livros.arvore.com.br/api-arvore";
 
 export interface PiMemoryConfig {
   apiUrl: string;


### PR DESCRIPTION
## Problema

`/memory-login` falhava porque o `DEFAULT_API_URL` apontava para `https://api.arvore.com.br/api-arvore`, que **não resolve DNS** (NXDOMAIN).

## Correção

Host correto do api-arvore em prod: `https://livros.arvore.com.br/api-arvore` (confirmado: `/pi-memory/search` → 401, `/auth/github/start` → 302).

Bump 0.1.0 → 0.1.2. Já publicado manualmente no npm.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Package version updated to 0.1.2
  * API endpoint configuration updated

<!-- end of auto-generated comment: release notes by coderabbit.ai -->