### PR TITLE
feat(pi-memory): tools memory_search/memory_save + steering dinâmico

### DIFF
--- a/packages/pi-memory/package.json
+++ b/packages/pi-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-memory",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "PI extension for cloud-based memory with RAG (Qdrant + GitHub OAuth)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/pi-memory/src/index.ts
+++ b/packages/pi-memory/src/index.ts
@@ -4,6 +4,7 @@ import { randomUUID } from "node:crypto";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { clearCredentials, getCredentials, saveCredentials } from "./auth.js";
 import { getConfig } from "./config.js";
+import { registerMemoryTools } from "./tools.js";
 import {
   createCurated,
   deleteSession,
@@ -114,6 +115,7 @@ async function startLoginFlow(): Promise<{ token: string; username: string; expi
 }
 
 export default function piMemoryExtension(pi: ExtensionAPI): void {
+  registerMemoryTools(pi);
   async function flush(entries: unknown[], final: boolean, setStatus: (key: string, text: string) => void): Promise<void> {
     if (incognito) {
       return;
@@ -168,8 +170,13 @@ export default function piMemoryExtension(pi: ExtensionAPI): void {
       }
 
       const memoryBlock = [
-        "## Relevant Context from Team Memory",
+        "## Team Memory (cloud)",
         "",
+        "This workspace uses a shared cloud team memory. Use the `memory_search` tool to recover",
+        "relevant decisions, conventions, incidents, domain knowledge and gotchas before non-trivial",
+        "tasks, and `memory_save` to persist durable knowledge the team should not rediscover.",
+        "",
+        "### Relevant context for the current request",
         ...results.map((r) => `- ${r.title ? `**${r.title}**: ` : ""}${r.content}`),
       ].join("\n");
 

--- a/packages/pi-memory/src/tools.ts
+++ b/packages/pi-memory/src/tools.ts
@@ -1,0 +1,97 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Type } from "@earendil-works/pi-ai";
+import { createCurated, search } from "./api.js";
+
+const CATEGORIES = ["decisions", "conventions", "incidents", "domain", "gotchas"];
+
+export function registerMemoryTools(pi: ExtensionAPI): void {
+  pi.registerTool({
+    name: "memory_search",
+    label: "Search Team Memory",
+    description:
+      "Search the team's shared memory (cloud) for relevant past decisions, conventions, incidents, domain knowledge, and gotchas. Use before starting a task to recover context, or whenever you need to know why something is the way it is.",
+    promptSnippet:
+      "memory_search — search the team's shared cloud memory for past decisions, conventions, incidents, domain knowledge and gotchas.",
+    promptGuidelines: [
+      "Before starting a non-trivial task, call memory_search to recover relevant team context.",
+      "When you learn a durable decision, convention, gotcha or domain fact worth keeping, call memory_save.",
+    ],
+    parameters: Type.Object({
+      query: Type.String({ description: "What to search for" }),
+      tier: Type.Optional(
+        Type.String({ description: "raw | curated. Omit to search both." })
+      ),
+      category: Type.Optional(
+        Type.String({ description: CATEGORIES.join(" | ") })
+      ),
+      limit: Type.Optional(Type.Number({ description: "Max results (default 10)" })),
+    }),
+    async execute(_toolCallId, params) {
+      try {
+        const results = await search(params.query, {
+          tier: params.tier,
+          category: params.category,
+          limit: params.limit,
+        });
+
+        if (results.length === 0) {
+          return {
+            content: [{ type: "text", text: "No relevant memories found." }],
+            details: { count: 0 },
+          };
+        }
+
+        const text = results
+          .map((r, i) => {
+            const header = r.title ? `**${r.title}**` : `(${r.tier})`;
+            return `${i + 1}. ${header} [${(r.score * 100).toFixed(0)}%]\n${r.content}`;
+          })
+          .join("\n\n");
+
+        return { content: [{ type: "text", text }], details: { count: results.length } };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          content: [{ type: "text", text: `memory_search failed: ${message}` }],
+          details: { count: 0 },
+          isError: true,
+        };
+      }
+    },
+  });
+
+  pi.registerTool({
+    name: "memory_save",
+    label: "Save Team Memory",
+    description:
+      "Save a curated memory to the team's shared cloud memory: a decision, convention, incident learning, domain fact, or gotcha. Use for durable knowledge the team should not have to rediscover.",
+    parameters: Type.Object({
+      title: Type.String({ description: "Short, descriptive title" }),
+      category: Type.String({ description: CATEGORIES.join(" | ") }),
+      content: Type.String({ description: "Full memory content in markdown" }),
+      tags: Type.Optional(Type.Array(Type.String(), { description: "Tags" })),
+    }),
+    async execute(_toolCallId, params) {
+      try {
+        const category = CATEGORIES.includes(params.category) ? params.category : "domain";
+        const result = await createCurated({
+          title: params.title,
+          category,
+          content: params.content,
+          tags: params.tags,
+        });
+        return {
+          content: [{ type: "text", text: `Saved curated memory (${result.id}).` }],
+          details: { id: result.id },
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          content: [{ type: "text", text: `memory_save failed: ${message}` }],
+          details: { id: "" },
+          isError: true,
+        };
+      }
+    },
+  });
+}


### PR DESCRIPTION
## O que

Faz o `pi-memory` (cloud) cobrir o que faltava para **substituir totalmente** a memória antiga (`pi-team-memory` extension + MCP `team-memory`):

- **Tools nativos** `memory_search` e `memory_save` (via `pi.registerTool`) — a IA busca e salva memória **sob demanda no meio da conversa**, substituindo `search_memories`/`add_memory` do MCP antigo.
- **promptSnippet + promptGuidelines** orientam a IA a buscar contexto antes de tarefas e salvar conhecimento durável.
- **Steering dinâmico** no `before_agent_start`: injeta instrução de uso + contexto relevante da nuvem, substituindo o `team-memories-index.md` estático que a antiga gerava.

## Por quê

A antiga tinha 3 peças (extension de captura, MCP de busca, steering index). A nova já fazia ingest automático + retrieval + curadoria, mas faltava: busca/escrita sob demanda pela IA e o índice no contexto. Este PR fecha esse gap.

## Versão

`0.2.0` (feature). Publicado no npm em seguida.

## Próximo

PR no arvore-hub remove a antiga do settings e atualiza orchestrator.md/README para usar a nova.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Memory search and save tools are now available for the coding agent.
  * Enhanced system guidance for using memory features with updated "Team Memory (cloud)" documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->