### PR TITLE
fix(pi-memory): use dynamic port for login to avoid conflicts

### DIFF
--- a/packages/pi-memory/package.json
+++ b/packages/pi-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-memory",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "PI extension for cloud-based memory with RAG (Qdrant + GitHub OAuth)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/pi-memory/src/index.ts
+++ b/packages/pi-memory/src/index.ts
@@ -1,5 +1,6 @@
 import { exec } from "node:child_process";
 import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
 import { randomUUID } from "node:crypto";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { clearCredentials, getCredentials, saveCredentials } from "./auth.js";
@@ -15,7 +16,6 @@ import {
 } from "./api.js";
 import type { IngestMessage } from "./api.js";
 
-const LOGIN_PORT = 9876;
 const LOGIN_TIMEOUT_MS = 60_000;
 const MIN_TEXT_LENGTH = 10;
 const FLUSH_DEBOUNCE_MS = 4000;
@@ -79,7 +79,8 @@ function collectMessages(entries: unknown[]): IngestMessage[] {
 async function startLoginFlow(): Promise<{ token: string; username: string; expiresIn: number }> {
   return new Promise((resolve, reject) => {
     const server = createServer((req, res) => {
-      const url = new URL(req.url ?? "", `http://localhost:${LOGIN_PORT}`);
+      const port = (server.address() as AddressInfo).port;
+      const url = new URL(req.url ?? "", `http://localhost:${port}`);
       const token = url.searchParams.get("token");
 
       if (!token) {
@@ -100,9 +101,10 @@ async function startLoginFlow(): Promise<{ token: string; username: string; expi
       });
     });
 
-    server.listen(LOGIN_PORT, () => {
+    server.listen(0, () => {
+      const port = (server.address() as AddressInfo).port;
       const config = getConfig();
-      const loginUrl = `${config.apiUrl}/auth/github/start?redirect_url=http://localhost:${LOGIN_PORT}`;
+      const loginUrl = `${config.apiUrl}/auth/github/start?redirect_url=http://localhost:${port}`;
       openBrowser(loginUrl);
     });
 


### PR DESCRIPTION
## Mudança

Substitui a porta fixa `9876` do fluxo de login OAuth por porta dinâmica (porta 0 — SO atribui uma porta livre).

## Motivação

A porta 9876 estava conflitando com outra extensão. Com porta dinâmica, o conflito é impossível.

## O que muda

- Remove `const LOGIN_PORT = 9876`
- Servidor escuta na porta `0` e captura a porta real via `server.address()`
- `redirect_url` é montado com a porta efetivamente alocada

## Versão

`0.2.0` → `0.2.1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed GitHub login flow to use dynamic port assignment instead of a fixed port, improving compatibility when the default port is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->