### PR TITLE
smart-context: route medium→opus, add toggle command

### DIFF
--- a/packages/smart-context/package.json
+++ b/packages/smart-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-smart-context",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Intelligent model routing and prompt compression for Pi/Kiro",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/smart-context/src/index.ts
+++ b/packages/smart-context/src/index.ts
@@ -11,9 +11,12 @@ export default function (pi: ExtensionAPI) {
   const store = createContentStore();
   const summarizer = createSummarizer();
   const compressor = createCompressor({ store, summarizer });
+
+  let enabled = true;
   const debug = process.env.SMART_CONTEXT_DEBUG === "1";
 
   pi.on("before_agent_start", async (event, ctx) => {
+    if (!enabled) return;
     try {
       const model = await router.pick(event.prompt, ctx);
       if (!model) {
@@ -86,12 +89,20 @@ export default function (pi: ExtensionAPI) {
     },
   });
 
+  pi.registerCommand("smart-context-toggle", {
+    description: "Enable or disable smart-context model routing",
+    handler: async (_args, ctx) => {
+      enabled = !enabled;
+      ctx.ui.notify(`smart-context routing ${enabled ? "enabled" : "disabled"}`, "info");
+    },
+  });
+
   pi.registerCommand("smart-context", {
     description: "Show smart-context compression stats",
     handler: async (_args, ctx) => {
       const s = compressor.getStats();
       ctx.ui.notify(
-        `Saved ${s.totalSaved} chars (${s.ratio}% avg) | turns ${s.turnsProcessed} | ` +
+        `[${enabled ? "on" : "off"}] Saved ${s.totalSaved} chars (${s.ratio}% avg) | turns ${s.turnsProcessed} | ` +
           `haiku ${s.haikuCalls} calls / ${s.haikuCacheHits} cached | recoverable ${s.storedItems}`,
         "info"
       );

--- a/packages/smart-context/src/router.ts
+++ b/packages/smart-context/src/router.ts
@@ -8,9 +8,11 @@ const CLASSIFICATION_PROMPT = `You are a task complexity classifier for a coding
 Rules:
 - If the user says "ok", "bora", "yes", "continue", "go ahead" etc., look at what they're agreeing TO — the previous assistant message defines the task.
 - "trivial": Simple acknowledgments with no pending task, greetings, or meta-conversation
-- "simple": Single-file fixes, typos, small changes, quick questions
-- "medium": Multi-file changes, feature implementation, debugging
-- "complex": Architecture design, large refactors, security audits, system-wide changes, performance optimization across multiple services
+- "simple": Single-file fixes, typos, small changes, quick questions with a clear answer
+- "medium": Multi-file changes, feature implementation, debugging, code review, most coding tasks
+- "complex": Architecture design, large refactors, security audits, system-wide changes, performance optimization across multiple services — ONLY use this for the most demanding tasks
+
+When in doubt between simple and medium, choose medium. When in doubt between medium and complex, choose medium.
 
 Respond with ONLY one word: trivial, simple, medium, or complex`;
 
@@ -115,9 +117,8 @@ function modelForComplexity(complexity: Complexity): string | null {
     case "simple":
       return "claude-sonnet-4-6";
     case "complex":
-      return "claude-opus-4-8";
     case "medium":
     default:
-      return "claude-sonnet-4-6";
+      return "claude-opus-4-8";
   }
 }


### PR DESCRIPTION
## Changes

- **model routing**: `medium` complexity agora vai pro Opus (antes Sonnet). Resultado: trivial→Haiku, simple→Sonnet, medium/complex→Opus
- **classification prompt**: redefinido pra `medium` capturar a maioria das coding tasks; `complex` reservado só pra casos extremos (large refactors, security audits, etc.). Tiebreaker explícito: "quando em dúvida entre medium e complex, escolha medium"
- **toggle**: novo comando `/smart-context-toggle` para enable/disable o roteamento em runtime. `/smart-context` agora mostra `[on]`/`[off]` no status

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a toggle command to enable/disable smart-context routing.
  * Updated notifications to display current routing state alongside performance metrics.
  * Refined complexity classification criteria for improved model routing decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->