### PR TITLE
fix(pi-memory): crash no login (server.address() null no handler)

### DIFF
--- a/packages/pi-memory/package.json
+++ b/packages/pi-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-memory",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "PI extension for cloud-based memory with RAG (Qdrant + GitHub OAuth)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/pi-memory/src/index.ts
+++ b/packages/pi-memory/src/index.ts
@@ -78,9 +78,10 @@ function collectMessages(entries: unknown[]): IngestMessage[] {
 
 async function startLoginFlow(): Promise<{ token: string; username: string; expiresIn: number }> {
   return new Promise((resolve, reject) => {
+    let boundPort = 0;
+
     const server = createServer((req, res) => {
-      const port = (server.address() as AddressInfo).port;
-      const url = new URL(req.url ?? "", `http://localhost:${port}`);
+      const url = new URL(req.url ?? "", `http://localhost:${boundPort || 0}`);
       const token = url.searchParams.get("token");
 
       if (!token) {
@@ -93,18 +94,28 @@ async function startLoginFlow(): Promise<{ token: string; username: string; expi
       res.end("<html><body><h2>Login successful! You can close this tab.</h2></body></html>");
       server.close();
 
-      const payload = JSON.parse(Buffer.from(token.split(".")[1], "base64url").toString());
-      resolve({
-        token,
-        username: payload.username,
-        expiresIn: (payload.exp - payload.iat) * 1000,
-      });
+      try {
+        const payload = JSON.parse(Buffer.from(token.split(".")[1], "base64url").toString());
+        resolve({
+          token,
+          username: payload.username,
+          expiresIn: (payload.exp - payload.iat) * 1000,
+        });
+      } catch (error) {
+        reject(error instanceof Error ? error : new Error("Invalid token payload"));
+      }
     });
 
     server.listen(0, () => {
-      const port = (server.address() as AddressInfo).port;
+      const address = server.address() as AddressInfo | null;
+      if (!address) {
+        server.close();
+        reject(new Error("Failed to bind login server"));
+        return;
+      }
+      boundPort = address.port;
       const config = getConfig();
-      const loginUrl = `${config.apiUrl}/auth/github/start?redirect_url=http://localhost:${port}`;
+      const loginUrl = `${config.apiUrl}/auth/github/start?redirect_url=http://localhost:${boundPort}`;
       openBrowser(loginUrl);
     });
 


### PR DESCRIPTION
## Problema

Após o `/memory-login`, o pi crashava com:
```
TypeError: Cannot read properties of null (reading 'port')
    at Server.<anonymous> .../pi-memory/dist/index.js:58
pi exiting due to uncaughtException
```

## Causa

No fix de porta efêmera (#21), `server.address().port` passou a ser lido **dentro do handler de request**. Em estados transientes (ex: callback de request chegando enquanto o server fecha), `server.address()` retorna `null` → `uncaughtException` que **derruba o pi inteiro**.

## Correção

- Captura a porta **uma vez** no callback do `listen` (`boundPort`) e reusa no handler — não chama mais `server.address()` por request.
- Guard de `null` no bind (rejeita o flow em vez de crashar).
- `try/catch` no parse do token (token malformado também derrubava).

Um erro de login nunca deve matar o agente.

bump 0.2.2 → 0.2.3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed port binding issue in GitHub OAuth login callback server to ensure accurate redirect URL generation
  * Enhanced authentication token parsing with improved error handling to gracefully manage and recover from validation failures
  * Improved GitHub OAuth login process reliability with better error recovery mechanisms and informative error messages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->