### PR TITLE
feat(pi-memory): auto re-login via refresh token (0.3.0)

### DIFF
--- a/packages/pi-memory/package.json
+++ b/packages/pi-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-memory",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "PI extension for cloud-based memory with RAG (Qdrant + GitHub OAuth)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/pi-memory/src/auth.ts
+++ b/packages/pi-memory/src/auth.ts
@@ -2,25 +2,81 @@ import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { join, dirname } from "node:path";
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
+import { getConfig } from "./config.js";
 
 export interface MemoryCredentials {
   token: string;
+  refreshToken?: string;
   username: string;
   expiresAt: number;
 }
 
 const CONFIG_DIR = join(homedir(), ".config", "pi");
 const CREDENTIALS_FILE = join(CONFIG_DIR, "memory-credentials.json");
+const EXPIRY_SKEW_MS = 60_000;
 
-export async function getCredentials(): Promise<MemoryCredentials | null> {
+async function readCredentials(): Promise<MemoryCredentials | null> {
   if (!existsSync(CREDENTIALS_FILE)) return null;
 
-  const raw = await readFile(CREDENTIALS_FILE, "utf-8");
-  const creds = JSON.parse(raw) as MemoryCredentials;
+  try {
+    const raw = await readFile(CREDENTIALS_FILE, "utf-8");
+    const creds = JSON.parse(raw) as MemoryCredentials;
+    if (!creds.token) return null;
+    return creds;
+  } catch {
+    return null;
+  }
+}
 
-  if (Date.now() > creds.expiresAt) return null;
+export async function getCredentials(): Promise<MemoryCredentials | null> {
+  const creds = await readCredentials();
+  if (!creds) return null;
 
-  return creds;
+  if (Date.now() < creds.expiresAt - EXPIRY_SKEW_MS) {
+    return creds;
+  }
+
+  if (creds.refreshToken) {
+    const refreshed = await tryRefresh(creds.refreshToken);
+    if (refreshed) return refreshed;
+  }
+
+  return null;
+}
+
+async function tryRefresh(refreshToken: string): Promise<MemoryCredentials | null> {
+  try {
+    const config = getConfig();
+    const response = await fetch(`${config.apiUrl}/auth/github/refresh`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ refresh_token: refreshToken }),
+    });
+
+    if (!response.ok) return null;
+
+    const data = (await response.json()) as {
+      access_token: string;
+      refresh_token: string;
+      expires_in: number;
+    };
+
+    const payload = JSON.parse(
+      Buffer.from(data.access_token.split(".")[1], "base64url").toString(),
+    );
+
+    const creds: MemoryCredentials = {
+      token: data.access_token,
+      refreshToken: data.refresh_token,
+      username: payload.username,
+      expiresAt: Date.now() + data.expires_in * 1000,
+    };
+
+    await saveCredentials(creds);
+    return creds;
+  } catch {
+    return null;
+  }
 }
 
 export async function saveCredentials(creds: MemoryCredentials): Promise<void> {

--- a/packages/pi-memory/src/index.ts
+++ b/packages/pi-memory/src/index.ts
@@ -76,12 +76,19 @@ function collectMessages(entries: unknown[]): IngestMessage[] {
   return messages;
 }
 
-async function startLoginFlow(): Promise<{ token: string; username: string; expiresIn: number }> {
+async function startLoginFlow(): Promise<{
+  token: string;
+  refreshToken: string | null;
+  username: string;
+  expiresIn: number;
+}> {
   return new Promise((resolve, reject) => {
+    let boundPort = 0;
+
     const server = createServer((req, res) => {
-      const port = (server.address() as AddressInfo).port;
-      const url = new URL(req.url ?? "", `http://localhost:${port}`);
+      const url = new URL(req.url ?? "", `http://localhost:${boundPort || 0}`);
       const token = url.searchParams.get("token");
+      const refreshToken = url.searchParams.get("refresh_token");
 
       if (!token) {
         res.writeHead(400);
@@ -93,18 +100,29 @@ async function startLoginFlow(): Promise<{ token: string; username: string; expi
       res.end("<html><body><h2>Login successful! You can close this tab.</h2></body></html>");
       server.close();
 
-      const payload = JSON.parse(Buffer.from(token.split(".")[1], "base64url").toString());
-      resolve({
-        token,
-        username: payload.username,
-        expiresIn: (payload.exp - payload.iat) * 1000,
-      });
+      try {
+        const payload = JSON.parse(Buffer.from(token.split(".")[1], "base64url").toString());
+        resolve({
+          token,
+          refreshToken,
+          username: payload.username,
+          expiresIn: (payload.exp - payload.iat) * 1000,
+        });
+      } catch (error) {
+        reject(error instanceof Error ? error : new Error("Invalid token payload"));
+      }
     });
 
     server.listen(0, () => {
-      const port = (server.address() as AddressInfo).port;
+      const address = server.address() as AddressInfo | null;
+      if (!address) {
+        server.close();
+        reject(new Error("Failed to bind login server"));
+        return;
+      }
+      boundPort = address.port;
       const config = getConfig();
-      const loginUrl = `${config.apiUrl}/auth/github/start?redirect_url=http://localhost:${port}`;
+      const loginUrl = `${config.apiUrl}/auth/github/start?redirect_url=http://localhost:${boundPort}`;
       openBrowser(loginUrl);
     });
 
@@ -212,6 +230,7 @@ export default function piMemoryExtension(pi: ExtensionAPI): void {
         const result = await startLoginFlow();
         await saveCredentials({
           token: result.token,
+          refreshToken: result.refreshToken ?? undefined,
           username: result.username,
           expiresAt: Date.now() + result.expiresIn,
         });


### PR DESCRIPTION
## Por quê

O token expirava em 1h, forçando `/memory-login` toda hora. Este PR renova o token **silenciosamente** (sem browser).

## O que muda

- Salva o `refresh_token` no `/memory-login` (vem do callback do OAuth).
- `getCredentials()` detecta access token expirado e **renova automaticamente** via `POST /auth/github/refresh`, sem abrir browser. Skew de 60s para renovar antes de expirar.
- Robustez: try/catch no parse do token, retorna null se o refresh falhar.
- bump 0.2.2 → **0.3.0**.

## Inclui o fix de porta (#25)

Este branch saiu antes do #25 mergear, então re-incorpora o fix do crash de login (`boundPort` capturado no `listen` em vez de `server.address()` no handler). Sem regressão.

## Validação (e2e contra backend local)

- Credencial com access **expirado** + refresh válido → `getCredentials()` renovou sozinho, novo `expiresAt` no futuro, token trocado. ✓
- build + tsc limpos.

## Dependência

Requer **api-arvore #1328** (endpoint `/auth/github/refresh`) deployado. O refresh token só passa a ser emitido após esse deploy — devs precisam fazer um `/memory-login` novo pós-deploy para receber o refresh token.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced OAuth refresh token functionality, enabling automatic session renewal without user intervention and significantly reducing re-authentication frequency while improving overall user experience.
  * Added sophisticated credential expiry management with built-in automated refresh capabilities to ensure seamless, continuous access to services.

* **Chores**
  * Package version updated to 0.3.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->