### PR TITLE
feat: add pi-ci-watch extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Monorepo for custom PI extensions used across Arvore projects.
 |---------|-------------|
 | `@arvoretech/pi-bee-context` | Injects personal facts from the Bee wearable assistant into the system prompt |
 | `@arvoretech/pi-changes-tracker` | Shows changed repos and files with `/changed` and `/changes` commands |
+| `@arvoretech/pi-ci-watch` | Monitors CI status, auto-fixes failures, and notifies on completion |
 | `@arvoretech/pi-element-inspector` | Receives inspected browser elements and pastes them into the editor |
 | `@arvoretech/pi-elevenlabs-stt` | Push-to-talk speech-to-text using ElevenLabs Scribe API |
 | `@arvoretech/pi-kokoro-tts` | Speaks assistant responses using Kokoro-FastAPI TTS |

--- a/packages/ci-watch/package.json
+++ b/packages/ci-watch/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@arvoretech/pi-ci-watch",
+  "version": "1.0.0",
+  "description": "PI extension that monitors CI status on a PR and auto-fixes failures",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "lint": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": ">=0.74.0"
+  },
+  "devDependencies": {
+    "@earendil-works/pi-coding-agent": "latest",
+    "@earendil-works/pi-ai": "latest",
+    "@types/node": "^20.10.0",
+    "typescript": "^5.3.0"
+  },
+  "pi": {
+    "extensions": [
+      "./dist/index.js"
+    ]
+  },
+  "keywords": [
+    "pi-package",
+    "pi",
+    "extension",
+    "ci",
+    "github-actions",
+    "auto-fix"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/arvoreeducacao/arvore-pi-extensions.git",
+    "directory": "packages/ci-watch"
+  },
+  "author": "Arvore",
+  "license": "MIT"
+}

--- a/packages/ci-watch/src/index.ts
+++ b/packages/ci-watch/src/index.ts
@@ -1,0 +1,316 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Type } from "@earendil-works/pi-ai";
+import { execSync } from "node:child_process";
+
+const MAX_ATTEMPTS = 3;
+const DEFAULT_POLL_MIN_MS = 30_000;
+const DEFAULT_POLL_MAX_MS = 60_000;
+const DEFAULT_POLL_STEP_MS = 15_000;
+
+interface CiCheckResult {
+  status: "pass" | "fail" | "pending" | "error";
+  failedRuns: string[];
+  logs: string;
+}
+
+interface PollConfig {
+  minMs: number;
+  maxMs: number;
+  stepMs: number;
+}
+
+function nextPollDelay(current: number, config: PollConfig): number {
+  const next = current + config.stepMs;
+  if (next > config.maxMs) return config.minMs;
+  return next;
+}
+
+function runGh(args: string, cwd: string): string {
+  return execSync(`gh ${args}`, { cwd, encoding: "utf-8", timeout: 30_000 }).trim();
+}
+
+function getCiStatus(prNumber: string, cwd: string): CiCheckResult {
+  try {
+    const output = runGh(`pr checks ${prNumber} --json name,state,bucket`, cwd);
+    const checks = JSON.parse(output) as Array<{ name: string; state: string; bucket: string }>;
+
+    const pending = checks.some((c) => c.bucket === "pending");
+    if (pending) return { status: "pending", failedRuns: [], logs: "" };
+
+    const failed = checks.filter((c) => c.bucket === "fail");
+    if (failed.length === 0) return { status: "pass", failedRuns: [], logs: "" };
+
+    return { status: "fail", failedRuns: failed.map((f) => f.name), logs: "" };
+  } catch (e) {
+    return { status: "error", failedRuns: [], logs: String(e) };
+  }
+}
+
+function getFailedLogs(prNumber: string, cwd: string): string {
+  try {
+    const branchOutput = runGh(`pr view ${prNumber} --json headRefName -q .headRefName`, cwd);
+    const runListOutput = runGh(`run list --branch ${branchOutput} --limit 5 --json databaseId,status,conclusion`, cwd);
+    const runs = JSON.parse(runListOutput) as Array<{ databaseId: number; status: string; conclusion: string }>;
+    const failedRun = runs.find((r) => r.conclusion === "failure");
+
+    if (!failedRun) return "No failed run found in recent history.";
+
+    const logs = runGh(`run view ${failedRun.databaseId} --log-failed`, cwd);
+    const truncated = logs.split("\n").slice(-100).join("\n");
+    return truncated;
+  } catch (e) {
+    return `Error fetching logs: ${String(e)}`;
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export default function (pi: ExtensionAPI) {
+  let pollConfig: PollConfig = {
+    minMs: DEFAULT_POLL_MIN_MS,
+    maxMs: DEFAULT_POLL_MAX_MS,
+    stepMs: DEFAULT_POLL_STEP_MS,
+  };
+
+  let autoMode = false;
+
+  pi.on("tool_result", async (event, ctx) => {
+    if (!autoMode) return;
+    if (event.toolName !== "bash") return;
+
+    const content = event.content;
+    if (!Array.isArray(content)) return;
+
+    const text = content.map((c: { type: string; text?: string }) => c.type === "text" ? c.text ?? "" : "").join("");
+    const pushMatch = text.match(/To github\.com[^\n]*\n.*?\[new branch\]|branch '([^']+)' set up to track|\*\s+(\S+)\s+->\s+(\S+)/);
+    if (!pushMatch) return;
+
+    const branchMatch = text.match(/branch '([^']+)' set up to track/);
+    if (!branchMatch) return;
+
+    const branch = branchMatch[1];
+    try {
+      const prOutput = runGh(`pr list --head ${branch} --json number -q .[0].number`, ctx.cwd);
+      if (prOutput) {
+        pi.sendUserMessage(
+          `CI auto-watch triggered. Monitor the CI for PR ${prOutput}. If it fails, read the error logs, fix the code, commit, push, and retry until CI passes (max 3 attempts).`,
+          { deliverAs: "followUp" }
+        );
+      }
+    } catch {}
+  });
+
+  pi.registerCommand("ci-auto", {
+    description: "Toggle automatic CI watch after every push. Usage: /ci-auto on|off",
+    handler: async (args, ctx) => {
+      const arg = args?.trim().toLowerCase();
+      if (arg === "on") {
+        autoMode = true;
+        ctx.ui.notify("🔄 CI auto-watch: ON — Pi monitorará CI automaticamente após push", "info");
+      } else if (arg === "off") {
+        autoMode = false;
+        ctx.ui.notify("⏹️ CI auto-watch: OFF", "info");
+      } else {
+        ctx.ui.notify(`CI auto-watch: ${autoMode ? "ON" : "OFF"}. Use /ci-auto on|off`, "info");
+      }
+    },
+  });
+
+  pi.registerCommand("ci-config", {
+    description: "Configure CI watch poll intervals. Usage: /ci-config <min> <max> <step> (in seconds)",
+    handler: async (args, ctx) => {
+      if (!args?.trim()) {
+        ctx.ui.notify(`Current: min=${pollConfig.minMs / 1000}s, max=${pollConfig.maxMs / 1000}s, step=${pollConfig.stepMs / 1000}s`, "info");
+        return;
+      }
+      const parts = args.trim().split(/\s+/).map(Number);
+      if (parts.length < 3 || parts.some(isNaN)) {
+        ctx.ui.notify("Usage: /ci-config <min> <max> <step> (in seconds). Ex: /ci-config 20 90 10", "error");
+        return;
+      }
+      pollConfig = { minMs: parts[0] * 1000, maxMs: parts[1] * 1000, stepMs: parts[2] * 1000 };
+      ctx.ui.notify(`✅ CI poll: ${parts[0]}s → ${parts[1]}s (step ${parts[2]}s)`, "info");
+    },
+  });
+  pi.registerTool({
+    name: "ci_watch",
+    label: "CI Watch",
+    description:
+      "Monitor CI status for a GitHub PR. Waits for CI to complete, reports the result. If CI fails, returns the failed logs so you can fix the code and push again. Use this after opening a PR to ensure CI passes.",
+    promptSnippet: "Monitor PR CI status, wait for completion, return failed logs if any",
+    promptGuidelines: [
+      "Use ci_watch after pushing a branch or opening a PR when the user asks to monitor CI.",
+      "After ci_watch reports a failure, read the logs, fix the issue, commit, push, then call ci_watch again (max 3 attempts).",
+      "Do not call ci_watch proactively — only when the user explicitly asks to watch/monitor CI.",
+    ],
+    parameters: Type.Object({
+      pr: Type.String({ description: "PR number or branch name to monitor" }),
+      attempt: Type.Optional(Type.Number({ description: "Current fix attempt (1-3). Omit for first check." })),
+    }),
+    async execute(_toolCallId, params, signal, onUpdate, ctx) {
+      const { pr } = params;
+      const attempt = params.attempt ?? 1;
+
+      if (attempt > MAX_ATTEMPTS) {
+        return {
+          content: [{ type: "text", text: `❌ CI still failing after ${MAX_ATTEMPTS} fix attempts. Manual intervention needed.` }],
+          details: { status: "max_attempts_reached", pr, attempts: MAX_ATTEMPTS },
+        };
+      }
+
+      onUpdate?.({ content: [{ type: "text", text: `⏳ Watching CI for PR ${pr} (attempt ${attempt}/${MAX_ATTEMPTS})...` }], details: {} });
+
+      let elapsed = 0;
+      let currentDelay = pollConfig.minMs;
+      const maxWait = 10 * 60 * 1000;
+
+      while (!signal?.aborted) {
+        const result = getCiStatus(pr, ctx.cwd);
+
+        if (result.status === "error") {
+          return {
+            content: [{ type: "text", text: `Error checking CI: ${result.logs}` }],
+            details: { status: "error", pr },
+          };
+        }
+
+        if (result.status === "pass") {
+          return {
+            content: [{ type: "text", text: `✅ CI passed for PR ${pr}!` }],
+            details: { status: "pass", pr, attempt },
+          };
+        }
+
+        if (result.status === "fail") {
+          const logs = getFailedLogs(pr, ctx.cwd);
+          return {
+            content: [{
+              type: "text",
+              text: `❌ CI failed for PR ${pr} (attempt ${attempt}/${MAX_ATTEMPTS}).\n\nFailed checks: ${result.failedRuns.join(", ")}\n\n--- Failed logs (last 100 lines) ---\n${logs}\n\n---\nFix the issues, commit, push, then call ci_watch again with attempt=${attempt + 1}.`,
+            }],
+            details: { status: "fail", pr, attempt, failedChecks: result.failedRuns },
+          };
+        }
+
+        if (elapsed >= maxWait) {
+          return {
+            content: [{ type: "text", text: `⏰ CI still pending after 10 minutes for PR ${pr}. Check manually.` }],
+            details: { status: "timeout", pr },
+          };
+        }
+
+        await sleep(currentDelay);
+        elapsed += currentDelay;
+        currentDelay = nextPollDelay(currentDelay, pollConfig);
+        onUpdate?.({ content: [{ type: "text", text: `⏳ CI still running for PR ${pr}... (${Math.round(elapsed / 1000)}s elapsed, next check in ${currentDelay / 1000}s)` }], details: {} });
+      }
+
+      return {
+        content: [{ type: "text", text: "CI watch cancelled." }],
+        details: { status: "cancelled", pr },
+      };
+    },
+  });
+
+  pi.registerTool({
+    name: "ci_notify",
+    label: "CI Notify",
+    description:
+      "Monitor CI status for a GitHub PR and notify when complete. Does NOT auto-fix — just watches and reports the final status. Use when you want to be notified when CI finishes.",
+    promptSnippet: "Watch PR CI and notify when done (no auto-fix)",
+    promptGuidelines: [
+      "Use ci_notify when the user wants to know when CI finishes but does NOT want auto-fix.",
+      "Use ci_watch instead when the user wants auto-fix on failure.",
+    ],
+    parameters: Type.Object({
+      pr: Type.String({ description: "PR number or branch name to monitor" }),
+    }),
+    async execute(_toolCallId, params, signal, onUpdate, ctx) {
+      const { pr } = params;
+
+      onUpdate?.({ content: [{ type: "text", text: `👀 Watching CI for PR ${pr}...` }], details: {} });
+
+      let elapsed = 0;
+      let currentDelay = pollConfig.minMs;
+      const maxWait = 15 * 60 * 1000;
+
+      while (!signal?.aborted) {
+        const result = getCiStatus(pr, ctx.cwd);
+
+        if (result.status === "error") {
+          return {
+            content: [{ type: "text", text: `Error checking CI: ${result.logs}` }],
+            details: { status: "error", pr },
+          };
+        }
+
+        if (result.status === "pass") {
+          ctx.ui.notify(`✅ CI passed for PR ${pr}!`, "info");
+          return {
+            content: [{ type: "text", text: `✅ CI passed for PR ${pr}!` }],
+            details: { status: "pass", pr },
+          };
+        }
+
+        if (result.status === "fail") {
+          const logs = getFailedLogs(pr, ctx.cwd);
+          ctx.ui.notify(`❌ CI failed for PR ${pr}`, "error");
+          return {
+            content: [{
+              type: "text",
+              text: `❌ CI failed for PR ${pr}.\n\nFailed checks: ${result.failedRuns.join(", ")}\n\n--- Failed logs (last 100 lines) ---\n${logs}`,
+            }],
+            details: { status: "fail", pr, failedChecks: result.failedRuns },
+          };
+        }
+
+        if (elapsed >= maxWait) {
+          return {
+            content: [{ type: "text", text: `⏰ CI still pending after 15 minutes for PR ${pr}. Check manually.` }],
+            details: { status: "timeout", pr },
+          };
+        }
+
+        await sleep(currentDelay);
+        elapsed += currentDelay;
+        currentDelay = nextPollDelay(currentDelay, pollConfig);
+        onUpdate?.({ content: [{ type: "text", text: `👀 CI still running for PR ${pr}... (${Math.round(elapsed / 1000)}s elapsed, next check in ${currentDelay / 1000}s)` }], details: {} });
+      }
+
+      return {
+        content: [{ type: "text", text: "CI watch cancelled." }],
+        details: { status: "cancelled", pr },
+      };
+    },
+  });
+
+  pi.registerCommand("ci-watch", {
+    description: "Monitor CI for a PR and auto-fix failures. Usage: /ci-watch <pr-number>",
+    handler: async (args, ctx) => {
+      if (!args?.trim()) {
+        ctx.ui.notify("Usage: /ci-watch <pr-number>", "error");
+        return;
+      }
+      pi.sendUserMessage(
+        `Monitor the CI for PR ${args.trim()}. If it fails, read the error logs, fix the code, commit, push, and retry until CI passes (max 3 attempts).`,
+        { deliverAs: "followUp" }
+      );
+    },
+  });
+
+  pi.registerCommand("ci-notify", {
+    description: "Watch CI for a PR and notify when done (no auto-fix). Usage: /ci-notify <pr-number>",
+    handler: async (args, ctx) => {
+      if (!args?.trim()) {
+        ctx.ui.notify("Usage: /ci-notify <pr-number>", "error");
+        return;
+      }
+      pi.sendUserMessage(
+        `Watch the CI for PR ${args.trim()} and notify me when it completes. Do not auto-fix anything.`,
+        { deliverAs: "followUp" }
+      );
+    },
+  });
+}

--- a/packages/ci-watch/tsconfig.json
+++ b/packages/ci-watch/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,10 +20,10 @@ importers:
     devDependencies:
       '@earendil-works/pi-ai':
         specifier: latest
-        version: 0.79.1(ws@8.20.0)(zod@4.4.3)
+        version: 0.79.5(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-coding-agent':
         specifier: latest
-        version: 0.79.1(ws@8.20.0)(zod@4.4.3)
+        version: 0.79.5(ws@8.20.0)(zod@4.4.3)
       '@types/node':
         specifier: ^20.10.0
         version: 20.19.39
@@ -35,10 +35,25 @@ importers:
     devDependencies:
       '@earendil-works/pi-coding-agent':
         specifier: latest
-        version: 0.79.4(ws@8.20.0)(zod@4.4.3)
+        version: 0.79.5(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-tui':
         specifier: latest
-        version: 0.79.4
+        version: 0.79.5
+      '@types/node':
+        specifier: ^20.10.0
+        version: 20.19.39
+      typescript:
+        specifier: ^5.3.0
+        version: 5.9.3
+
+  packages/ci-watch:
+    devDependencies:
+      '@earendil-works/pi-ai':
+        specifier: latest
+        version: 0.79.5(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-coding-agent':
+        specifier: latest
+        version: 0.79.5(ws@8.20.0)(zod@4.4.3)
       '@types/node':
         specifier: ^20.10.0
         version: 20.19.39
@@ -54,10 +69,10 @@ importers:
     devDependencies:
       '@earendil-works/pi-ai':
         specifier: latest
-        version: 0.79.4(ws@8.20.0)(zod@4.4.3)
+        version: 0.79.5(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-coding-agent':
         specifier: latest
-        version: 0.79.4(ws@8.20.0)(zod@4.4.3)
+        version: 0.79.5(ws@8.20.0)(zod@4.4.3)
       '@types/node':
         specifier: ^20.10.0
         version: 20.19.39
@@ -72,10 +87,10 @@ importers:
     devDependencies:
       '@earendil-works/pi-coding-agent':
         specifier: latest
-        version: 0.79.4(ws@8.20.0)(zod@4.4.3)
+        version: 0.79.0
       '@earendil-works/pi-tui':
         specifier: latest
-        version: 0.79.4
+        version: 0.79.0
       '@types/node':
         specifier: ^20.10.0
         version: 20.19.39
@@ -87,7 +102,7 @@ importers:
     devDependencies:
       '@earendil-works/pi-coding-agent':
         specifier: 0.79.1
-        version: 0.79.1(ws@8.20.0)(zod@4.4.3)
+        version: 0.79.1
       '@types/node':
         specifier: ^20.10.0
         version: 20.19.39
@@ -114,13 +129,13 @@ importers:
     devDependencies:
       '@earendil-works/pi-ai':
         specifier: latest
-        version: 0.79.4(ws@8.20.0)(zod@4.4.3)
+        version: 0.79.5(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-coding-agent':
         specifier: latest
-        version: 0.79.4(ws@8.20.0)(zod@4.4.3)
+        version: 0.79.5(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-tui':
         specifier: latest
-        version: 0.79.4
+        version: 0.79.5
       '@types/node':
         specifier: ^20.10.0
         version: 20.19.39
@@ -132,16 +147,16 @@ importers:
     devDependencies:
       '@earendil-works/pi-agent-core':
         specifier: latest
-        version: 0.79.4(ws@8.20.0)(zod@4.4.3)
+        version: 0.79.5(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-ai':
         specifier: latest
-        version: 0.79.4(ws@8.20.0)(zod@4.4.3)
+        version: 0.79.5(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-coding-agent':
         specifier: latest
-        version: 0.79.4(ws@8.20.0)(zod@4.4.3)
+        version: 0.79.5(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-tui':
         specifier: latest
-        version: 0.79.4
+        version: 0.79.5
       '@types/node':
         specifier: ^20.10.0
         version: 20.19.39
@@ -153,13 +168,13 @@ importers:
     devDependencies:
       '@earendil-works/pi-ai':
         specifier: ^0.79.4
-        version: 0.79.4(ws@8.20.0)(zod@4.4.3)
+        version: 0.79.5(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-coding-agent':
         specifier: ^0.79.4
-        version: 0.79.4(ws@8.20.0)(zod@4.4.3)
+        version: 0.79.5(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-tui':
         specifier: ^0.79.4
-        version: 0.79.4
+        version: 0.79.5
       '@types/node':
         specifier: ^20.10.0
         version: 20.19.39
@@ -204,7 +219,7 @@ importers:
     devDependencies:
       '@earendil-works/pi-coding-agent':
         specifier: latest
-        version: 0.79.4(ws@8.20.0)(zod@4.4.3)
+        version: 0.79.5(ws@8.20.0)(zod@4.4.3)
       '@types/node':
         specifier: ^20.10.0
         version: 20.19.39
@@ -405,12 +420,12 @@ packages:
     resolution: {integrity: sha512-oPwVRkkAvyKPWyM7E4k+EaTNmynbYn7ZLG/LBh9BUnMNb2gvpMp+VQ420R6JCJ20uogSqrHnWTyosSa/rU8lVw==}
     engines: {node: '>=22.19.0'}
 
-  '@earendil-works/pi-agent-core@0.79.1':
-    resolution: {integrity: sha512-PBPjBa2YBm9jauiLtHAKaSfVJ4Dvm3/nK/bR/oHebLjwBCS2tGx3aQDX7MSGAOXi6BejlhzbB/z82BkyAyNjjQ==}
+  '@earendil-works/pi-agent-core@0.79.0':
+    resolution: {integrity: sha512-jQOtYjRGZ7+XC/olw9euLd2V03vkAPO8u0sSnQoLbyOQZz66dEBZrklTESk34Sf3AaeBSua28wjZR48ch1aXJQ==}
     engines: {node: '>=22.19.0'}
 
-  '@earendil-works/pi-agent-core@0.79.4':
-    resolution: {integrity: sha512-xkaZ3yK2XbP9HYdHrrdj/6HqZPM0o/mwbjMSU4RTJyR3HjDG0ZrPz76Hg6s0W+G4u6PpJr1mGx/srCG+3eQA8A==}
+  '@earendil-works/pi-agent-core@0.79.5':
+    resolution: {integrity: sha512-yOxzx8SRJkGsZTJWfe9VACkAF4amwHUgvFShn8uoYR7/fnhF69Sz0n7TIh8qRH21fBDvo1RLex4NK/iXFQ3u2Q==}
     engines: {node: '>=22.19.0'}
 
   '@earendil-works/pi-ai@0.74.0':
@@ -428,13 +443,8 @@ packages:
     engines: {node: '>=22.19.0'}
     hasBin: true
 
-  '@earendil-works/pi-ai@0.79.1':
-    resolution: {integrity: sha512-UnORwrcsTNLm4StEvoM8iEom0u87Te7BXEWxhec3iNXygWD6eEBosUoq9ddcveqtj/QpUZBMPWUu81cCtZxzkQ==}
-    engines: {node: '>=22.19.0'}
-    hasBin: true
-
-  '@earendil-works/pi-ai@0.79.4':
-    resolution: {integrity: sha512-Z1j+YP+6ZyPBKDUoc5m0GO/o1hPK17fWeErtDgegCTpm2dcKzuFvL/7GTqHeJkVkfpeXRwO37xOfgozQbK6EUw==}
+  '@earendil-works/pi-ai@0.79.5':
+    resolution: {integrity: sha512-LwZfV8HNvT90A9n5foA/a6/JMh5n/1lh1rRzOn+68kiFitf/tz3HTBpeSNFnUL4KLIdwp1lczjl4U2EJX0egvQ==}
     engines: {node: '>=22.19.0'}
     hasBin: true
 
@@ -453,13 +463,18 @@ packages:
     engines: {node: '>=22.19.0'}
     hasBin: true
 
+  '@earendil-works/pi-coding-agent@0.79.0':
+    resolution: {integrity: sha512-pZoXk65vFR3dAzzmPNWEX61aHnT6+BaVhTyFDQAs1DyumaMeWpvzRV9ZrGxqlbVLwhrq+0LnXbaqDAFkhe2+MQ==}
+    engines: {node: '>=22.19.0'}
+    hasBin: true
+
   '@earendil-works/pi-coding-agent@0.79.1':
     resolution: {integrity: sha512-dLnje4U5H3/ZytJpvhjhPINeDT/yvx85e4OH/ziMQRLpPlfNP12/peY9jRQd4W11Xth2+y2xGAFwS+NeVf2ZwA==}
     engines: {node: '>=22.19.0'}
     hasBin: true
 
-  '@earendil-works/pi-coding-agent@0.79.4':
-    resolution: {integrity: sha512-PthzVzM5m4XH/hrU+2fVjuwuH5M4eMFWbd0NCRScH14XKpwlPc8/Fh6JDz0jQb5kTBT9oQT183YLTHVVulFL9A==}
+  '@earendil-works/pi-coding-agent@0.79.5':
+    resolution: {integrity: sha512-5fs2+N+KGkGWNWdTC54ft4jm7MzyZwj7wkTGJWudjem+3pq73qM1N+Rewfai9FxvY3IeoPFG7Tq3q3FzF0BsXQ==}
     engines: {node: '>=22.19.0'}
     hasBin: true
 
@@ -475,8 +490,12 @@ packages:
     resolution: {integrity: sha512-07GVQo/38a0yvIPlWDr3RJn1B8gk3ZuIX9h2oIQ+Biyu3JN0KppWmgWHfaWRydQgse5JtC++KDw5MWaIRnV0mw==}
     engines: {node: '>=22.19.0'}
 
-  '@earendil-works/pi-tui@0.79.4':
-    resolution: {integrity: sha512-/ZhfFiHSBMH7AbDrBQIN+UWlJnl9tSEpLYICRGGMzmNfyCqX+30NYacIhyOEaD8R5rS6wJZysAOPU0yNwigbXw==}
+  '@earendil-works/pi-tui@0.79.0':
+    resolution: {integrity: sha512-qAQWMruW7YKbk2hPcTD4INtXfvIySXifbPQ+mFY5j3J8yf2tfElkh+gGPuBvgPKPT0z9WiAkd7iySCuQq0txuQ==}
+    engines: {node: '>=22.19.0'}
+
+  '@earendil-works/pi-tui@0.79.5':
+    resolution: {integrity: sha512-u6GXJ85e8ReEa1wG0jT53HVkI6a+CccCX1yAtQOpZhiTFklv4nYdbZr3J2TAKi4QKptCPSpRJb+QqZZ4Jy6eiA==}
     engines: {node: '>=22.19.0'}
 
   '@emnapi/runtime@1.10.0':
@@ -1598,6 +1617,11 @@ packages:
     engines: {node: '>= 18'}
     hasBin: true
 
+  marked@18.0.5:
+    resolution: {integrity: sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==}
+    engines: {node: '>= 20'}
+    hasBin: true
+
   mime-db@1.54.0:
     resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
     engines: {node: '>= 0.6'}
@@ -2360,9 +2384,9 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-agent-core@0.79.1(ws@8.20.0)(zod@4.4.3)':
+  '@earendil-works/pi-agent-core@0.79.0':
     dependencies:
-      '@earendil-works/pi-ai': 0.79.4(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.79.5(ws@8.20.0)(zod@4.4.3)
       ignore: 7.0.5
       typebox: 1.1.38
       yaml: 2.9.0
@@ -2374,9 +2398,9 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-agent-core@0.79.4(ws@8.20.0)(zod@4.4.3)':
+  '@earendil-works/pi-agent-core@0.79.5(ws@8.20.0)(zod@4.4.3)':
     dependencies:
-      '@earendil-works/pi-ai': 0.79.4(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.79.5(ws@8.20.0)(zod@4.4.3)
       ignore: 7.0.5
       typebox: 1.1.38
       yaml: 2.9.0
@@ -2450,27 +2474,7 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-ai@0.79.1(ws@8.20.0)(zod@4.4.3)':
-    dependencies:
-      '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
-      '@aws-sdk/client-bedrock-runtime': 3.1048.0
-      '@google/genai': 1.52.0
-      '@mistralai/mistralai': 2.2.1
-      '@smithy/node-http-handler': 4.7.3
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
-      openai: 6.26.0(ws@8.20.0)(zod@4.4.3)
-      partial-json: 0.1.7
-      typebox: 1.1.38
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
-  '@earendil-works/pi-ai@0.79.4(ws@8.20.0)(zod@4.4.3)':
+  '@earendil-works/pi-ai@0.79.5(ws@8.20.0)(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
       '@aws-sdk/client-bedrock-runtime': 3.1048.0
@@ -2582,11 +2586,11 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-coding-agent@0.79.1(ws@8.20.0)(zod@4.4.3)':
+  '@earendil-works/pi-coding-agent@0.79.0':
     dependencies:
-      '@earendil-works/pi-agent-core': 0.79.1(ws@8.20.0)(zod@4.4.3)
-      '@earendil-works/pi-ai': 0.79.4(ws@8.20.0)(zod@4.4.3)
-      '@earendil-works/pi-tui': 0.79.4
+      '@earendil-works/pi-agent-core': 0.79.0
+      '@earendil-works/pi-ai': 0.79.5(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-tui': 0.79.5
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
       cross-spawn: 7.0.6
@@ -2611,11 +2615,40 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-coding-agent@0.79.4(ws@8.20.0)(zod@4.4.3)':
+  '@earendil-works/pi-coding-agent@0.79.1':
     dependencies:
-      '@earendil-works/pi-agent-core': 0.79.4(ws@8.20.0)(zod@4.4.3)
-      '@earendil-works/pi-ai': 0.79.4(ws@8.20.0)(zod@4.4.3)
-      '@earendil-works/pi-tui': 0.79.4
+      '@earendil-works/pi-agent-core': 0.79.5(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.79.5(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-tui': 0.79.5
+      '@silvia-odwyer/photon-node': 0.3.4
+      chalk: 5.6.2
+      cross-spawn: 7.0.6
+      diff: 8.0.4
+      glob: 13.0.6
+      highlight.js: 10.7.3
+      hosted-git-info: 9.0.3
+      ignore: 7.0.5
+      jiti: 2.7.0
+      minimatch: 10.2.5
+      proper-lockfile: 4.1.2
+      typebox: 1.1.38
+      undici: 8.3.0
+      yaml: 2.9.0
+    optionalDependencies:
+      '@mariozechner/clipboard': 0.3.9
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-coding-agent@0.79.5(ws@8.20.0)(zod@4.4.3)':
+    dependencies:
+      '@earendil-works/pi-agent-core': 0.79.5(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.79.5(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-tui': 0.79.5
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
       cross-spawn: 7.0.6
@@ -2661,10 +2694,15 @@ snapshots:
       get-east-asian-width: 1.6.0
       marked: 15.0.12
 
-  '@earendil-works/pi-tui@0.79.4':
+  '@earendil-works/pi-tui@0.79.0':
     dependencies:
       get-east-asian-width: 1.6.0
       marked: 15.0.12
+
+  '@earendil-works/pi-tui@0.79.5':
+    dependencies:
+      get-east-asian-width: 1.6.0
+      marked: 18.0.5
 
   '@emnapi/runtime@1.10.0':
     dependencies:
@@ -3371,7 +3409,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 8.59.3
       debug: 4.4.3
       minimatch: 10.2.5
-      semver: 7.8.0
+      semver: 7.7.4
       tinyglobby: 0.2.16
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
@@ -3808,6 +3846,8 @@ snapshots:
   lru-cache@7.18.3: {}
 
   marked@15.0.12: {}
+
+  marked@18.0.5: {}
 
   mime-db@1.54.0: {}
 


### PR DESCRIPTION
## Nova extension: `@arvoretech/pi-ci-watch`

Monitora CI de PRs e corrige falhas automaticamente.

### Comandos

| Comando | Descrição |
|---|---|
| `/ci-watch <pr>` | Monitora + auto-fix (até 3x) |
| `/ci-notify <pr>` | Monitora + avisa quando terminar (sem fix) |
| `/ci-auto on\|off` | Modo automático após push (default: off) |
| `/ci-config <min> <max> <step>` | Configura polling em segundos |

### Como funciona

1. Polls `gh pr checks` com intervalo inteligente (30s→45s→60s→30s...)
2. Se CI falhou: busca logs com `gh run view --log-failed`
3. Retorna os logs pro LLM corrigir, commitar e pushar
4. Repete até CI passar (max 3 tentativas)

### Modo automático

Intercepta output de `git push` e inicia watch automaticamente quando `/ci-auto on`.

### Testado

PR com erro de lint proposital → Pi detectou falha → leu log → corrigiu → CI passou ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced CI watch extension for monitoring pull request check status
  * Automatic CI failure detection with retry attempts
  * Notification system for CI completion status
  * New commands to toggle monitoring and configure polling intervals

* **Documentation**
  * Updated README with new extension entry

<!-- end of auto-generated comment: release notes by coderabbit.ai -->