### PR TITLE
fix: pin pi-tui to 0.79.5 via pnpm override

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,11 @@
   "devDependencies": {
     "typescript": "^5.3.0"
   },
+  "pnpm": {
+    "overrides": {
+      "@earendil-works/pi-tui": "0.79.5"
+    }
+  },
   "packageManager": "pnpm@10.28.0",
   "engines": {
     "node": ">=20.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@earendil-works/pi-tui': 0.79.5
+
 importers:
 
   .:
@@ -37,7 +40,7 @@ importers:
         specifier: latest
         version: 0.79.5(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-tui':
-        specifier: latest
+        specifier: 0.79.5
         version: 0.79.5
       '@types/node':
         specifier: ^20.10.0
@@ -89,8 +92,8 @@ importers:
         specifier: latest
         version: 0.79.4(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-tui':
-        specifier: latest
-        version: 0.79.4
+        specifier: 0.79.5
+        version: 0.79.5
       '@types/node':
         specifier: ^20.10.0
         version: 20.19.39
@@ -134,7 +137,7 @@ importers:
         specifier: latest
         version: 0.79.5(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-tui':
-        specifier: latest
+        specifier: 0.79.5
         version: 0.79.5
       '@types/node':
         specifier: ^20.10.0
@@ -155,8 +158,8 @@ importers:
         specifier: latest
         version: 0.79.4(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-tui':
-        specifier: latest
-        version: 0.79.4
+        specifier: 0.79.5
+        version: 0.79.5
       '@types/node':
         specifier: ^20.10.0
         version: 20.19.39
@@ -189,7 +192,7 @@ importers:
         specifier: ^0.79.4
         version: 0.79.5(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-tui':
-        specifier: ^0.79.4
+        specifier: 0.79.5
         version: 0.79.5
       '@types/node':
         specifier: ^20.10.0
@@ -210,8 +213,8 @@ importers:
         specifier: latest
         version: 0.74.0(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-tui':
-        specifier: latest
-        version: 0.74.0
+        specifier: 0.79.5
+        version: 0.79.5
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.4.0(jiti@2.7.0))
@@ -252,8 +255,8 @@ importers:
         specifier: latest
         version: 0.75.5(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-tui':
-        specifier: latest
-        version: 0.75.5
+        specifier: 0.79.5
+        version: 0.79.5
       '@types/node':
         specifier: ^20.10.0
         version: 20.19.39
@@ -507,22 +510,6 @@ packages:
     resolution: {integrity: sha512-5fs2+N+KGkGWNWdTC54ft4jm7MzyZwj7wkTGJWudjem+3pq73qM1N+Rewfai9FxvY3IeoPFG7Tq3q3FzF0BsXQ==}
     engines: {node: '>=22.19.0'}
     hasBin: true
-
-  '@earendil-works/pi-tui@0.74.0':
-    resolution: {integrity: sha512-1aIfXZp7D/z+1VlZX8BZcs6pgO8rjmil7kwyhctNDsWvce3Yfl8GVgu4eq+I0Mjhr8Cj+ipBiv9CLIzdoyCOIQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@earendil-works/pi-tui@0.75.5':
-    resolution: {integrity: sha512-LkXUM1/49pvzzeI39Y5wjBMlgafcCf67HCLhB9Z7yuXHy4XgT+VqxWcZVW5hBdhQsHZd0znjJotfGH1BzxMfiA==}
-    engines: {node: '>=22.19.0'}
-
-  '@earendil-works/pi-tui@0.78.1':
-    resolution: {integrity: sha512-07GVQo/38a0yvIPlWDr3RJn1B8gk3ZuIX9h2oIQ+Biyu3JN0KppWmgWHfaWRydQgse5JtC++KDw5MWaIRnV0mw==}
-    engines: {node: '>=22.19.0'}
-
-  '@earendil-works/pi-tui@0.79.4':
-    resolution: {integrity: sha512-/ZhfFiHSBMH7AbDrBQIN+UWlJnl9tSEpLYICRGGMzmNfyCqX+30NYacIhyOEaD8R5rS6wJZysAOPU0yNwigbXw==}
-    engines: {node: '>=22.19.0'}
 
   '@earendil-works/pi-tui@0.79.5':
     resolution: {integrity: sha512-u6GXJ85e8ReEa1wG0jT53HVkI6a+CccCX1yAtQOpZhiTFklv4nYdbZr3J2TAKi4QKptCPSpRJb+QqZZ4Jy6eiA==}
@@ -1207,9 +1194,6 @@ packages:
   '@types/jsonwebtoken@9.0.10':
     resolution: {integrity: sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==}
 
-  '@types/mime-types@2.1.4':
-    resolution: {integrity: sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w==}
-
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
@@ -1696,10 +1680,6 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
-  get-east-asian-width@1.5.0:
-    resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
-    engines: {node: '>=18'}
-
   get-east-asian-width@1.6.0:
     resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
     engines: {node: '>=18'}
@@ -1869,9 +1849,6 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
-
-  koffi@2.16.1:
-    resolution: {integrity: sha512-0Ie6CfD026dNfWSosDw9dPxPzO9Rlyo0N8m5r05S8YjytIpuilzMFDMY4IDy/8xQsTwpuVinhncD+S8n3bcYZQ==}
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -2982,7 +2959,7 @@ snapshots:
     dependencies:
       '@earendil-works/pi-agent-core': 0.74.0(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-ai': 0.74.0(ws@8.20.0)(zod@4.4.3)
-      '@earendil-works/pi-tui': 0.74.0
+      '@earendil-works/pi-tui': 0.79.5
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
       cli-highlight: 2.1.11
@@ -3016,7 +2993,7 @@ snapshots:
     dependencies:
       '@earendil-works/pi-agent-core': 0.75.5(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-ai': 0.75.5(ws@8.20.0)(zod@4.4.3)
-      '@earendil-works/pi-tui': 0.75.5
+      '@earendil-works/pi-tui': 0.79.5
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
       cross-spawn: 7.0.6
@@ -3045,7 +3022,7 @@ snapshots:
     dependencies:
       '@earendil-works/pi-agent-core': 0.78.1(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-ai': 0.78.1(ws@8.20.0)(zod@4.4.3)
-      '@earendil-works/pi-tui': 0.78.1
+      '@earendil-works/pi-tui': 0.79.5
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
       cross-spawn: 7.0.6
@@ -3074,7 +3051,7 @@ snapshots:
     dependencies:
       '@earendil-works/pi-agent-core': 0.79.1(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-ai': 0.79.4(ws@8.20.0)(zod@4.4.3)
-      '@earendil-works/pi-tui': 0.79.4
+      '@earendil-works/pi-tui': 0.79.5
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
       cross-spawn: 7.0.6
@@ -3158,31 +3135,6 @@ snapshots:
       - utf-8-validate
       - ws
       - zod
-
-  '@earendil-works/pi-tui@0.74.0':
-    dependencies:
-      '@types/mime-types': 2.1.4
-      chalk: 5.6.2
-      get-east-asian-width: 1.5.0
-      marked: 15.0.12
-      mime-types: 3.0.2
-    optionalDependencies:
-      koffi: 2.16.1
-
-  '@earendil-works/pi-tui@0.75.5':
-    dependencies:
-      get-east-asian-width: 1.6.0
-      marked: 15.0.12
-
-  '@earendil-works/pi-tui@0.78.1':
-    dependencies:
-      get-east-asian-width: 1.6.0
-      marked: 15.0.12
-
-  '@earendil-works/pi-tui@0.79.4':
-    dependencies:
-      get-east-asian-width: 1.6.0
-      marked: 15.0.12
 
   '@earendil-works/pi-tui@0.79.5':
     dependencies:
@@ -3906,8 +3858,6 @@ snapshots:
       '@types/ms': 2.1.0
       '@types/node': 20.19.39
 
-  '@types/mime-types@2.1.4': {}
-
   '@types/ms@2.1.0': {}
 
   '@types/node@20.19.39':
@@ -4469,8 +4419,6 @@ snapshots:
 
   get-caller-file@2.0.5: {}
 
-  get-east-asian-width@1.5.0: {}
-
   get-east-asian-width@1.6.0: {}
 
   get-intrinsic@1.3.0:
@@ -4655,9 +4603,6 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
-
-  koffi@2.16.1:
-    optional: true
 
   levn@0.4.1:
     dependencies:


### PR DESCRIPTION
## Problema

CI quebrando no build do `plan-mode` com `TS2345`:

```
Argument of type 'pi-tui@0.79.5 ... TUI' is not assignable to parameter of type 'pi-tui@0.79.4 ... TUI'.
Types have separate declarations of a private property 'previousLines'.
```

## Causa

O `plan-mode` resolvia **duas cópias** do `@earendil-works/pi-tui`:
- `0.79.4` — dep direta (`latest`), fixada num lockfile antigo
- `0.79.5` — peer exigido por `pi-coding-agent@0.79.4`

O `Editor` vinha de uma versão e o `tui` da outra. Como `previousLines` é private, o TS trata as classes `TUI` como nominalmente incompatíveis.

## Fix

`pnpm.overrides` fixando `@earendil-works/pi-tui` em `0.79.5` no `package.json` raiz. Reinstalado, eliminou as cópias duplicadas.

## Testado

`pnpm build` passa nos 14 pacotes do workspace.