### PR TITLE
fix(worktree): force tree-themed names for worktrees

### DIFF
--- a/packages/worktree/package.json
+++ b/packages/worktree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-worktree",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "PI extension to manage git worktrees across multi-repo workspaces with tree-themed names",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/worktree/src/index.ts
+++ b/packages/worktree/src/index.ts
@@ -297,11 +297,10 @@ export default function worktreeExtension(pi: ExtensionAPI): void {
   pi.registerTool({
     name: "create_worktree",
     label: "Create Worktree",
-    description: "Creates a new worktree for the specified repos and activates it. The worktree gets a tree-themed name and a new branch. All .env* files are symlinked into it.",
-    promptSnippet: "Create and activate a git worktree for isolated work",
+    description: "Creates a new worktree for the specified repos and activates it. The worktree gets a random tree-themed name (from a fixed pool) and a new branch. All .env* files are symlinked into it. Do NOT pass a custom name — the name is always auto-generated.",
+    promptSnippet: "Create and activate a git worktree for isolated work. Name is auto-assigned from a tree pool.",
     parameters: Type.Object({
       repos: Type.Array(Type.String(), { description: "Repo directory names to create worktrees in (e.g. ['api-arvore', 'frontend-arvore-nextjs'])" }),
-      name: Type.Optional(Type.String({ description: "Worktree name (optional, random tree name if omitted)" })),
       branch: Type.Optional(Type.String({ description: "Branch name (optional, defaults to wt/<name>)" })),
     }),
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
@@ -312,7 +311,7 @@ export default function worktreeExtension(pi: ExtensionAPI): void {
         return { content: [{ type: "text", text: `No matching repos found. Available: ${repos.map((r) => basename(r)).join(", ")}` }], details: {} };
       }
 
-      const name = params.name || pickAvailableName(targetRepos[0]) || "worktree";
+      const name = pickAvailableName(targetRepos[0]) || "worktree";
       const results: string[] = [];
 
       activeWorktreePaths.clear();


### PR DESCRIPTION
## Summary

Removes the `name` parameter from the `create_worktree` tool so the agent can no longer pass arbitrary names. Worktree names are always auto-picked from the tree pool (árvores da Árvore).

## Changes

- Removed `name` param from `create_worktree` tool schema
- Updated tool description: "Do NOT pass a custom name — the name is always auto-generated"
- Updated `promptSnippet` to reinforce auto-naming
- Bump to 1.2.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Changes**
  * Updated worktree creation: Custom worktree names are no longer supported. Worktree names are now automatically generated from a predefined pool.

* **Version Update**
  * Package version bumped to 1.2.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->