### PR TITLE
fix(worktree): auto-activate worktree after /worktree create

### DIFF
--- a/packages/worktree/package.json
+++ b/packages/worktree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-worktree",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "PI extension to manage git worktrees across multi-repo workspaces with tree-themed names",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/worktree/src/index.ts
+++ b/packages/worktree/src/index.ts
@@ -449,9 +449,19 @@ export default function worktreeExtension(pi: ExtensionAPI): void {
           const name = flags.name || pickAvailableName(targetRepos[0]) || "worktree";
           const results: string[] = [];
 
+          activeWorktreePaths.clear();
           for (const repo of targetRepos) {
             const result = createWorktree(repo, name, flags.branch);
             results.push(result.ok ? `✓ ${result.message}` : `✗ ${result.message}`);
+            if (result.ok) {
+              activeWorktreePaths.set(basename(repo), join(repo, WORKTREES_DIR, name));
+            }
+          }
+
+          if (activeWorktreePaths.size > 0) {
+            activeWorktree = name;
+            updateWidget(ctx);
+            saveState(ctx.cwd, sessionId);
           }
 
           ctx.ui.notify(results.join("\n"), "info");

--- a/packages/worktree/src/index.ts
+++ b/packages/worktree/src/index.ts
@@ -6,7 +6,7 @@ import { join, resolve, basename } from "node:path";
 
 let activeWorktree: string | null = null;
 let activeWorktreePaths: Map<string, string> = new Map();
-let worktreeMode = false;
+let worktreeMode = true;
 
 const TREE_NAMES = [
   "africanosa", "alfabetonio", "arqueoptera", "arterieira", "artilheira",


### PR DESCRIPTION
## Summary

`/worktree create` now automatically activates the newly created worktree — sets it as active, updates the widget, and persists state. No need to run `/worktree use` separately after creating.