### PR TITLE
fix(slack-agent): corrige tasks duplicadas e carrega .env do workspace

### DIFF
--- a/packages/slack-agent/docker-compose.yml
+++ b/packages/slack-agent/docker-compose.yml
@@ -3,6 +3,8 @@ services:
     build: .
     restart: unless-stopped
     user: "${UID:-501}:${GID:-20}"
+    env_file:
+      - ${HOST_WORKSPACE:-.}/.env
     environment:
       - SLACK_BOT_TOKEN=${SLACK_BOT_TOKEN}
       - SLACK_APP_TOKEN=${SLACK_APP_TOKEN}

--- a/packages/slack-agent/src/agent.ts
+++ b/packages/slack-agent/src/agent.ts
@@ -81,11 +81,19 @@ export function createAgent(config: AgentConfig) {
 
       let finished = false;
 
+      let appendQueue: Promise<unknown> = Promise.resolve();
+      function enqueueAppend(chunks: Array<Record<string, unknown>>): Promise<void> {
+        appendQueue = appendQueue
+          .then(() => streamer.append({ chunks: chunks as never }))
+          .catch(() => {});
+        return appendQueue as Promise<void>;
+      }
+
       async function flushText(): Promise<void> {
         if (!textBuffer || finished) return;
         const chunk = textBuffer;
         textBuffer = "";
-        await streamer.append({ chunks: [{ type: "markdown_text", text: chunk }] });
+        await enqueueAppend([{ type: "markdown_text", text: chunk }]);
       }
 
       function scheduleFlush(): void {
@@ -116,16 +124,13 @@ export function createAgent(config: AgentConfig) {
             taskTitles.set(toolCallId, taskId);
 
             void setStatus(title);
-            void flushText().then(() =>
-              streamer.append({
-                chunks: [{
-                  type: "task_update",
-                  id: taskId,
-                  title,
-                  status: "in_progress",
-                }],
-              })
-            ).catch(() => {});
+            void flushText();
+            void enqueueAppend([{
+              type: "task_update",
+              id: taskId,
+              title,
+              status: "in_progress",
+            }]);
             break;
           }
           case "tool_execution_end": {
@@ -141,18 +146,16 @@ export function createAgent(config: AgentConfig) {
               .join("\n")
               .slice(0, 200);
 
-            void streamer.append({
-              chunks: [{
-                type: "task_update",
-                id: taskId,
-                title: formatToolTitle(
-                  event.toolName as string,
-                  event.args as Record<string, unknown> | undefined,
-                ),
-                status: isError ? "error" : "complete",
-                ...(output ? { details: output } : {}),
-              }],
-            }).catch(() => {});
+            void enqueueAppend([{
+              type: "task_update",
+              id: taskId,
+              title: formatToolTitle(
+                event.toolName as string,
+                event.args as Record<string, unknown> | undefined,
+              ),
+              status: isError ? "error" : "complete",
+              ...(output ? { details: output } : {}),
+            }]);
             break;
           }
           case "agent_end": {
@@ -171,6 +174,7 @@ export function createAgent(config: AgentConfig) {
           finalChunks.push({ type: "markdown_text", text: textBuffer });
           textBuffer = "";
         }
+        await appendQueue.catch(() => {});
         if (finalChunks.length > 0) {
           await streamer.stop({ chunks: finalChunks });
         } else {


### PR DESCRIPTION
## Resumo

Corrige dois problemas no slack-agent (continue-on-slack):

### 1. Tasks duplicadas no Slack
As tool calls apareciam **duplicadas** no Slack — uma presa em \`in_progress\` e outra \`complete\`. Causa raiz: **race condition** nos \`streamer.append\`. Os eventos \`tool_execution_start\`, \`tool_execution_end\` e \`flushText\` disparavam appends concorrentes sem ordenação. Quando o \`complete\` chegava ao Slack antes do \`in_progress\` do mesmo \`id\` ser persistido, o Slack registrava duas tasks distintas.

**Correção:**
- Fila serial \`enqueueAppend\`: todos os appends são encadeados numa única promise, preservando ordem de emissão (\`in_progress\` → \`complete\` no mesmo \`id\`).
- \`finish()\` aguarda \`appendQueue\` drenar antes de \`streamer.stop()\`.

### 2. Credenciais dos MCP servers ausentes
O container recebia apenas 4 env vars; as ~60 vars do \`.env\` do workspace (MySQL, Postgres, Datadog, SigNoz, GitHub, etc.) não chegavam ao processo do pi, deixando os MCP servers sem credenciais.

**Correção:**
- \`docker-compose.yml\`: \`env_file\` aponta para \`\${HOST_WORKSPACE}/.env\`, injetando as credenciais no \`process.env\` repassado ao pi.

## Testes
- \`pnpm build\` (tsc) limpo.
- Imagem rebuildada e container recriado; conectado ao Slack via socket mode.
- Validado manualmente pelo Slack: tasks não duplicam mais e MCP servers funcionam.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated service configuration to support environment file loading
  
* **Refactor**
  * Improved agent streaming output handling consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->