### PR TITLE
fix(worktree): run package install in background

### DIFF
--- a/packages/worktree/package.json
+++ b/packages/worktree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-worktree",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "PI extension to manage git worktrees across multi-repo workspaces with tree-themed names",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/worktree/src/index.ts
+++ b/packages/worktree/src/index.ts
@@ -1,6 +1,6 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "@earendil-works/pi-ai";
-import { execSync, spawnSync } from "node:child_process";
+import { execSync, spawnSync, spawn } from "node:child_process";
 import { existsSync, readFileSync, appendFileSync, readdirSync, statSync, symlinkSync, writeFileSync, mkdirSync } from "node:fs";
 import { join, resolve, basename } from "node:path";
 
@@ -113,7 +113,7 @@ function symlinkEnvFiles(repoPath: string, targetDir: string): void {
   }
   if (existsSync(join(repoPath, "package.json")) && !existsSync(join(targetDir, "node_modules"))) {
     const pm = existsSync(join(repoPath, "pnpm-lock.yaml")) ? "pnpm" : existsSync(join(repoPath, "yarn.lock")) ? "yarn" : "npm";
-    spawnSync(pm, ["install"], { cwd: targetDir, encoding: "utf-8", stdio: "ignore" });
+    spawn(pm, ["install"], { cwd: targetDir, stdio: "ignore", detached: true }).unref();
   }
 }
 


### PR DESCRIPTION
## Summary

Changes `spawnSync` to `spawn` with `detached: true` + `unref()` for the package install step during worktree creation. The extension no longer blocks while dependencies are being installed.