### PR TITLE
Remove inspector WS port from status bar

### DIFF
--- a/packages/element-inspector/package.json
+++ b/packages/element-inspector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-element-inspector",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "PI extension that receives inspected browser elements and pastes them into the editor",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/element-inspector/src/index.ts
+++ b/packages/element-inspector/src/index.ts
@@ -72,7 +72,6 @@ export default function (pi: ExtensionAPI) {
       try {
         wss = await startServer(port, pi, ctx, clients);
         boundPort = port;
-        ctx.ui.setStatus("element-inspector", `Inspector ws:${port}`);
         break;
       } catch {}
     }


### PR DESCRIPTION
## O que mudou

- Remove `ctx.ui.setStatus` que exibia a porta do WebSocket abaixo do prompt (`Inspector ws:9876`)
- Bump versão do pacote para 0.1.1

A porta é um detalhe interno de comunicação entre o browser extension e o Pi — não há necessidade do usuário saber qual porta está em uso.