### PR TITLE
feat(pi-memory): auth self-healing, query de injeção rica e feedback de relevância

### DIFF
--- a/packages/pi-memory/src/api.ts
+++ b/packages/pi-memory/src/api.ts
@@ -68,6 +68,10 @@ export async function search(
   return data.results;
 }
 
+export function sendFeedback(id: string, useful: boolean): Promise<{ updated: boolean }> {
+  return request<{ updated: boolean }>("/feedback", "POST", { id, useful });
+}
+
 export async function listCandidates(): Promise<Candidate[]> {
   const data = await request<{ candidates: Candidate[] }>("/candidates", "GET");
   return data.candidates;

--- a/packages/pi-memory/src/feedback.ts
+++ b/packages/pi-memory/src/feedback.ts
@@ -1,0 +1,111 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { sendFeedback } from "./api.js";
+import type { SearchResult } from "./api.js";
+
+const GRAYZONE_MIN = 0.45;
+const GRAYZONE_MAX = 0.6;
+const MIN_TURNS_BETWEEN_ASKS = 10;
+const FEEDBACK_STATE_ENTRY = "memory-feedback-state";
+
+interface FeedbackState {
+  enabled: boolean;
+  answered: Record<string, boolean>;
+  lastAskedTurn: number;
+}
+
+const state: FeedbackState = {
+  enabled: true,
+  answered: {},
+  lastAskedTurn: -Infinity,
+};
+
+let turnCounter = 0;
+
+export function feedbackEnabled(): boolean {
+  return state.enabled;
+}
+
+export function setFeedbackEnabled(value: boolean): void {
+  state.enabled = value;
+}
+
+export function incrementTurn(): void {
+  turnCounter++;
+}
+
+export function restoreFeedbackState(pi: ExtensionAPI, entries: unknown[]): void {
+  for (const entry of entries) {
+    const typed = entry as { type?: string; customType?: string; data?: Partial<FeedbackState> };
+    if (typed.type === "custom" && typed.customType === FEEDBACK_STATE_ENTRY && typed.data) {
+      if (typeof typed.data.enabled === "boolean") {
+        state.enabled = typed.data.enabled;
+      }
+      if (typed.data.answered) {
+        state.answered = { ...state.answered, ...typed.data.answered };
+      }
+    }
+  }
+}
+
+function persist(pi: ExtensionAPI): void {
+  pi.appendEntry(FEEDBACK_STATE_ENTRY, {
+    enabled: state.enabled,
+    answered: state.answered,
+    lastAskedTurn: state.lastAskedTurn,
+  });
+}
+
+function isPromising(result: SearchResult): boolean {
+  return result.tier === "curated";
+}
+
+function pickCandidate(results: SearchResult[]): SearchResult | null {
+  const eligible = results.filter(
+    (r) =>
+      r.score >= GRAYZONE_MIN &&
+      r.score <= GRAYZONE_MAX &&
+      isPromising(r) &&
+      !(r.id in state.answered)
+  );
+  if (eligible.length === 0) {
+    return null;
+  }
+  return eligible.sort((a, b) => b.score - a.score)[0];
+}
+
+export async function maybeAskFeedback(
+  pi: ExtensionAPI,
+  ctx: { ui: { confirm(title: string, message: string): Promise<boolean> } },
+  results: SearchResult[]
+): Promise<void> {
+  if (!state.enabled) {
+    return;
+  }
+  if (turnCounter - state.lastAskedTurn < MIN_TURNS_BETWEEN_ASKS) {
+    return;
+  }
+  const candidate = pickCandidate(results);
+  if (!candidate) {
+    return;
+  }
+
+  state.lastAskedTurn = turnCounter;
+  const preview = candidate.content.length > 200 ? `${candidate.content.slice(0, 200)}…` : candidate.content;
+  const title = candidate.title ? `Memória: ${candidate.title}` : "Memória recuperada";
+
+  let useful = false;
+  try {
+    useful = await ctx.ui.confirm(title, `Essa memória foi útil agora?\n\n${preview}`);
+  } catch {
+    return;
+  }
+
+  state.answered[candidate.id] = useful;
+  persist(pi);
+
+  try {
+    await sendFeedback(candidate.id, useful);
+  } catch {
+    return;
+  }
+}

--- a/packages/pi-memory/src/index.ts
+++ b/packages/pi-memory/src/index.ts
@@ -14,7 +14,14 @@ import {
   promote,
   search,
 } from "./api.js";
-import type { IngestMessage } from "./api.js";
+import type { IngestMessage, SearchResult } from "./api.js";
+import {
+  feedbackEnabled,
+  incrementTurn,
+  maybeAskFeedback,
+  restoreFeedbackState,
+  setFeedbackEnabled,
+} from "./feedback.js";
 
 const LOGIN_TIMEOUT_MS = 60_000;
 const MIN_TEXT_LENGTH = 10;
@@ -24,6 +31,7 @@ let incognito = false;
 let sessionId = "";
 let lastFlushedTurn = -1;
 let flushTimer: ReturnType<typeof setTimeout> | null = null;
+let lastSearchResults: SearchResult[] = [];
 
 function openBrowser(url: string): void {
   const cmd =
@@ -74,6 +82,13 @@ function collectMessages(entries: unknown[]): IngestMessage[] {
   }
 
   return messages;
+}
+
+function buildSearchQuery(entries: unknown[], prompt: string): string {
+  const messages = collectMessages(entries);
+  const recent = messages.slice(-3).map((m) => m.text);
+  const combined = [...recent, prompt].join("\n").trim();
+  return combined.slice(0, 800);
 }
 
 async function startLoginFlow(): Promise<{
@@ -164,6 +179,8 @@ export default function piMemoryExtension(pi: ExtensionAPI): void {
   pi.on("session_start", async (_event, ctx) => {
     sessionId = randomUUID();
     lastFlushedTurn = -1;
+    lastSearchResults = [];
+    restoreFeedbackState(pi, ctx.sessionManager.getEntries());
 
     const creds = await getCredentials();
     ctx.ui.setStatus("memory", creds ? `memory: ${creds.username}` : "memory: not logged in");
@@ -174,6 +191,7 @@ export default function piMemoryExtension(pi: ExtensionAPI): void {
       return;
     }
     const creds = await getCredentials();
+    ctx.ui.setStatus("memory", creds ? `memory: ${creds.username}` : "memory: not logged in");
     if (!creds) {
       return;
     }
@@ -184,7 +202,9 @@ export default function piMemoryExtension(pi: ExtensionAPI): void {
         return;
       }
 
-      const results = await search(prompt.slice(0, 500), { limit: 10 });
+      const query = buildSearchQuery(ctx.sessionManager.getEntries(), prompt);
+      const results = await search(query, { limit: 10 });
+      lastSearchResults = results;
       if (results.length === 0) {
         return;
       }
@@ -207,6 +227,12 @@ export default function piMemoryExtension(pi: ExtensionAPI): void {
   });
 
   pi.on("turn_end", (_event, ctx) => {
+    incrementTurn();
+    if (feedbackEnabled() && lastSearchResults.length > 0) {
+      const results = lastSearchResults;
+      lastSearchResults = [];
+      void maybeAskFeedback(pi, ctx, results);
+    }
     if (flushTimer) {
       clearTimeout(flushTimer);
     }
@@ -258,6 +284,21 @@ export default function piMemoryExtension(pi: ExtensionAPI): void {
       const status = incognito ? "ON" : "OFF";
       ctx.ui.setStatus("memory", `memory: incognito ${status}`);
       ctx.ui.notify(`Incognito mode: ${status}`, "info");
+      return Promise.resolve();
+    },
+  });
+
+  pi.registerCommand("memory-feedback", {
+    description: "Toggle memory relevance feedback prompts: /memory-feedback <on|off>",
+    handler: (args, ctx) => {
+      const arg = args?.trim().toLowerCase();
+      if (arg === "on" || arg === "off") {
+        setFeedbackEnabled(arg === "on");
+      } else {
+        setFeedbackEnabled(!feedbackEnabled());
+      }
+      ctx.ui.setStatus("memory", `memory: feedback ${feedbackEnabled() ? "ON" : "OFF"}`);
+      ctx.ui.notify(`Memory feedback ${feedbackEnabled() ? "enabled" : "disabled"}.`, "info");
       return Promise.resolve();
     },
   });


### PR DESCRIPTION
## Resumo

Três melhorias na extensão `pi-memory`: corrige o login que não propagava entre chats, melhora a query de injeção e adiciona feedback ativo de relevância (par do endpoint `POST /pi-memory/feedback` no api-arvore).

## O que muda

- **Auth self-healing** — `before_agent_start` passa a reler as credenciais do disco a cada turn e atualizar o status. Antes, o estado de login era avaliado só uma vez no `session_start`: se você abrisse um segundo chat antes de logar, ele travava em "not logged in" e ficava pedindo `/memory-login` pra sempre. Agora, no primeiro prompt após logar em qualquer chat, os outros se corrigem sozinhos.
- **Query de injeção mais rica** — em vez de `prompt.slice(0, 500)` cru, a query é composta pelos **últimos turns + o prompt atual**, reduzindo o embedding genérico que casava com qualquer coisa (causa raiz do falso positivo).
- **Feedback ativo na zona cinzenta** — para memórias com score intermediário (0.45–0.6), a extensão pergunta via `ctx.ui.confirm` no `turn_end` se a memória foi útil, e ajusta `relevance_score` via endpoint de feedback.

## Anti-spam (não vira enquete)

- Janela de score estreita (só pergunta no intervalo cinzento)
- Teto: no máx 1 pergunta a cada N turns
- Nunca repergunta a mesma memória (resposta persistida via `appendEntry`)
- Só memória promissora (curada)
- Pergunta no `turn_end`, não-bloqueante
- Comando `/memory-feedback <on|off>` — **ON por padrão** (opt-out)

## Como foi testado

- `pnpm build` (tsc) e `pnpm lint` (tsc --noEmit) → sem erros.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added memory relevance feedback system allowing users to rate search result usefulness.
  * Introduced `/memory-feedback` command to enable or disable feedback collection.
  * Intelligent feedback prompting targets high-quality results while respecting interaction frequency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->