### PR TITLE
chore(pi-memory): bump version to 0.4.0

### DIFF
--- a/packages/pi-memory/package.json
+++ b/packages/pi-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-memory",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "PI extension for cloud-based memory with RAG (Qdrant + GitHub OAuth)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Resumo

Bump de versão da extensão `pi-memory` de `0.3.0` → `0.4.0`, referente às features mergeadas no PR #37 (auth self-healing, query de injeção rica e feedback de relevância).

## Por quê

O PR #37 entregou features novas sem breaking change mas não bumpou a versão. Minor bump conforme semver.

## Como foi testado

- `pnpm build` (tsc) → sem erros.
