### PR TITLE
fix(worktree): hub diff overlay full width

### DIFF
--- a/packages/worktree/package.json
+++ b/packages/worktree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-worktree",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "PI extension to manage git worktrees across multi-repo workspaces with tree-themed names",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/worktree/src/index.ts
+++ b/packages/worktree/src/index.ts
@@ -599,7 +599,8 @@ export default function worktreeExtension(pi: ExtensionAPI): void {
           const pagerBase = pager.split(/\s+/)[0];
           const pagerArgs = pager.split(/\s+/).slice(1).filter((a) => a !== "--paging=never");
           if (pagerBase === "delta" || pagerBase.endsWith("/delta")) {
-            pagerArgs.push("--paging=never", "--width=120");
+            const cols = Math.floor((process.stdout.columns || 200) * 0.9) - 4;
+            pagerArgs.push("--paging=never", `--width=${cols}`);
           }
 
           const stripAnsi = (s: string) => s.replace(/\x1B(?:\[[\d;]*[A-Za-z]|\].*?(?:\x07|\x1B\\)|\([A-Z]|\[[\d;]*m)/g, "").replace(/[\x00-\x09\x0B-\x1F]/g, "");
@@ -751,7 +752,7 @@ export default function worktreeExtension(pi: ExtensionAPI): void {
                 invalidate(): void {},
               };
             },
-            { overlay: true, overlayOptions: { anchor: "center", width: "85%", maxHeight: "85%" } },
+            { overlay: true, overlayOptions: { anchor: "center", width: "90%", maxHeight: "90%" } },
           );
           break;
         }


### PR DESCRIPTION
## Summary

- Hub overlay now uses `width: 100%` and `maxHeight: 90%` to fill the screen
- Removed hardcoded `--width=120` for delta — lets it use terminal width automatically
- Fixes delta side-by-side output being cut off in the diff view

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved pager behavior to optimize display settings for better readability.

* **Style**
  * Increased interactive dashboard overlay height for improved visibility and usability.

* **Chores**
  * Released version 1.2.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->