### PR TITLE
chore(ci-watch): bump to 1.0.1 to republish with dist

### DIFF
--- a/packages/ci-watch/package.json
+++ b/packages/ci-watch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-ci-watch",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "PI extension that monitors CI status on a PR and auto-fixes failures",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

`@arvoretech/pi-ci-watch@1.0.0` was published without the `dist/` folder. Since `main`/`pi.extensions` point to `dist/index.js`, pi could not load the extension ("ci-watch not available").

Because `1.0.0` is already taken on npm, the CI publish step skips it (`npm view ... && skip`), so it never self-heals. Bumping to `1.0.1` forces a fresh publish where the CI `pnpm build` generates `dist/` and the tarball includes the built output.

## Changes
- Bump `packages/ci-watch/package.json` version `1.0.0` → `1.0.1`

## Testing
- Confirmed all other packages are published correctly with their `dist/` (only ci-watch was empty on npm)
- Verified `pnpm pack` produces a tarball containing `dist/index.js`
- `1.0.1` does not yet exist on npm, so the publish guard will not skip it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released patch version 1.0.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->