### PR TITLE
feat(worktree): add attach_worktree_repos tool

### DIFF
--- a/packages/worktree/package.json
+++ b/packages/worktree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-worktree",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "description": "PI extension to manage git worktrees across multi-repo workspaces with tree-themed names",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/worktree/src/index.ts
+++ b/packages/worktree/src/index.ts
@@ -284,6 +284,7 @@ export default function worktreeExtension(pi: ExtensionAPI): void {
       "Call `get_worktree_paths` before editing files. If it returns an active worktree, ALL reads/writes/edits MUST use those paths instead of the main repo.",
       "If `get_worktree_paths` says worktree mode is ON but no worktree is active, call `create_worktree` with the repos you intend to modify before making changes.",
       "If worktree mode is OFF and no worktree is active, work in the normal repo directories as usual.",
+      "If a worktree is active but you need to edit a repo not yet in it, call `attach_worktree_repos` to add it instead of creating a new worktree.",
     ],
     parameters: Type.Object({}),
     async execute() {
@@ -350,6 +351,44 @@ export default function worktreeExtension(pi: ExtensionAPI): void {
       updateWidget(ctx);
       saveState(ctx.cwd, sessionId);
       return { content: [{ type: "text", text: `Deactivated worktree '${prev}'.` }], details: {} };
+    },
+  });
+
+  pi.registerTool({
+    name: "attach_worktree_repos",
+    label: "Attach Repos",
+    description: "Adds more repos to the currently active worktree. Use when you discover you need to edit additional repos that aren't yet part of the active worktree.",
+    promptSnippet: "Attach additional repos to the active worktree",
+    parameters: Type.Object({
+      repos: Type.Array(Type.String(), { description: "Repo directory names to add (e.g. ['frontend-arvore-nextjs'])" }),
+    }),
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      if (!activeWorktree) {
+        return { content: [{ type: "text", text: "No active worktree. Call create_worktree first." }], details: {} };
+      }
+
+      const allRepos = discoverRepos(ctx.cwd);
+      const targetRepos = allRepos.filter((r) => params.repos.includes(basename(r)) && !activeWorktreePaths.has(basename(r)));
+
+      if (targetRepos.length === 0) {
+        return { content: [{ type: "text", text: `No new repos to attach. Already active: ${[...activeWorktreePaths.keys()].join(", ")}` }], details: {} };
+      }
+
+      const results: string[] = [];
+      for (const repo of targetRepos) {
+        const result = createWorktree(repo, activeWorktree);
+        if (result.ok) {
+          activeWorktreePaths.set(basename(repo), join(repo, WORKTREES_DIR, activeWorktree));
+          results.push(`✓ ${result.message}`);
+        } else {
+          results.push(`✗ ${result.message}`);
+        }
+      }
+
+      updateWidget(ctx);
+      saveState(ctx.cwd, sessionId);
+      const context = buildWorktreeContext();
+      return { content: [{ type: "text", text: results.join("\n") + "\n\n" + context }], details: {} };
     },
   });
 


### PR DESCRIPTION
## Summary

Adds `attach_worktree_repos` tool that lets the agent expand an active worktree by adding more repos to it.

## Use case

Agent starts working on `api-arvore`, creates a worktree. Later realizes it also needs `frontend-arvore-nextjs`. Instead of creating a new worktree, it calls:

```
attach_worktree_repos({ repos: ["frontend-arvore-nextjs"] })
```

The new repo gets the same worktree name/branch, .env symlinked, install runs in background.

## Changes

- New tool `attach_worktree_repos`
- Added prompt guideline: "If a worktree is active but you need to edit a repo not yet in it, call `attach_worktree_repos`"
- Bump to 1.3.0