### PR TITLE
feat(worktree): add detach and delete tools

### DIFF
--- a/packages/worktree/package.json
+++ b/packages/worktree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-worktree",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "PI extension to manage git worktrees across multi-repo workspaces with tree-themed names",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/worktree/src/index.ts
+++ b/packages/worktree/src/index.ts
@@ -392,6 +392,75 @@ export default function worktreeExtension(pi: ExtensionAPI): void {
     },
   });
 
+  pi.registerTool({
+    name: "detach_worktree_repos",
+    label: "Detach Repos",
+    description: "Removes repos from the active worktree tracking without deleting the worktree from disk.",
+    promptSnippet: "Remove repos from the active worktree",
+    parameters: Type.Object({
+      repos: Type.Array(Type.String(), { description: "Repo directory names to remove (e.g. ['frontend-arvore-nextjs'])" }),
+    }),
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      if (!activeWorktree) {
+        return { content: [{ type: "text", text: "No active worktree." }], details: {} };
+      }
+      const removed: string[] = [];
+      for (const repo of params.repos) {
+        if (activeWorktreePaths.has(repo)) {
+          activeWorktreePaths.delete(repo);
+          removed.push(repo);
+        }
+      }
+      if (removed.length === 0) {
+        return { content: [{ type: "text", text: `None of those repos are in the active worktree. Active: ${[...activeWorktreePaths.keys()].join(", ")}` }], details: {} };
+      }
+      if (activeWorktreePaths.size === 0) {
+        activeWorktree = null;
+      }
+      updateWidget(ctx);
+      saveState(ctx.cwd, sessionId);
+      return { content: [{ type: "text", text: `Detached: ${removed.join(", ")}\n\n${buildWorktreeContext()}` }], details: {} };
+    },
+  });
+
+  pi.registerTool({
+    name: "delete_worktree",
+    label: "Delete Worktree",
+    description: "Permanently removes worktree directories and their branches from disk. Use when work is done and the worktree is no longer needed.",
+    promptSnippet: "Delete a worktree and its branches from disk",
+    parameters: Type.Object({
+      name: Type.String({ description: "Worktree name to delete (e.g. 'biografosa')" }),
+    }),
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      const allRepos = discoverRepos(ctx.cwd);
+      const results: string[] = [];
+
+      for (const repo of allRepos) {
+        const wtPath = join(repo, WORKTREES_DIR, params.name);
+        if (!existsSync(wtPath)) continue;
+        const result = removeWorktree(repo, params.name);
+        results.push(result.ok ? `✓ ${result.message}` : `✗ ${result.message}`);
+        if (result.ok) {
+          const branch = `wt/${params.name}`;
+          spawnSync("git", ["branch", "-D", branch], { cwd: repo, encoding: "utf-8" });
+        }
+      }
+
+      if (results.length === 0) {
+        return { content: [{ type: "text", text: `Worktree '${params.name}' not found in any repo.` }], details: {} };
+      }
+
+      if (activeWorktree === params.name) {
+        activeWorktree = null;
+        activeWorktreePaths.clear();
+        updateWidget(ctx);
+        saveState(ctx.cwd, sessionId);
+      }
+
+      return { content: [{ type: "text", text: results.join("\n") }], details: {} };
+    },
+  });
+
   pi.registerCommand("worktree", {
     description: "Manage git worktrees with tree-themed names across repos",
     handler: async (args, ctx) => {


### PR DESCRIPTION
## Summary

Adds two new tools for worktree lifecycle management:

### `detach_worktree_repos`
Removes repos from the active worktree tracking without deleting anything from disk. Use when the agent no longer needs to edit a repo but wants to keep the worktree for later.

### `delete_worktree`
Permanently removes worktree directories AND deletes the `wt/<name>` branch from all repos. Use when work is done and cleanup is needed.

- If the deleted worktree was active, it's automatically deactivated
- Bump to 1.4.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added capability to detach repositories from active worktree sessions without deleting their worktree directories and automatically manage session state.
  * Added capability to permanently delete worktrees from disk across all repositories and clean up associated branches.

* **Chores**
  * Version bumped to 1.4.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->