### PR TITLE
feat(worktree): add /worktree shell command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules/
 dist/
 *.log
 .DS_Store
+
+.worktrees/

--- a/packages/worktree/package.json
+++ b/packages/worktree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-worktree",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "PI extension to manage git worktrees across multi-repo workspaces with tree-themed names",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/worktree/package.json
+++ b/packages/worktree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-worktree",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "PI extension to manage git worktrees across multi-repo workspaces with tree-themed names",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/worktree/src/index.ts
+++ b/packages/worktree/src/index.ts
@@ -880,7 +880,7 @@ export default function worktreeExtension(pi: ExtensionAPI): void {
             return;
           }
 
-          const paths = flags.all ? [...activeWorktreePaths.values()] : [activeWorktreePaths.values().next().value!];
+          const paths = "all" in flags ? [...activeWorktreePaths.values()] : [activeWorktreePaths.values().next().value!];
 
           for (const wtPath of paths) {
             if (inTmux) {

--- a/packages/worktree/src/index.ts
+++ b/packages/worktree/src/index.ts
@@ -890,7 +890,8 @@ export default function worktreeExtension(pi: ExtensionAPI): void {
                 spawn("tmux", ["split-window", "-v", "-c", paths[i]], { stdio: "ignore" });
               }
             } else {
-              spawn("open", [`warp://action/new_tab?path=${encodeURIComponent(paths[i])}`], { detached: true, stdio: "ignore" }).unref();
+              const opener = process.platform === "darwin" ? "open" : "xdg-open";
+              spawn(opener, [`warp://action/new_tab?path=${encodeURIComponent(paths[i])}`], { detached: true, stdio: "ignore" }).unref();
             }
           }
 

--- a/packages/worktree/src/index.ts
+++ b/packages/worktree/src/index.ts
@@ -882,11 +882,15 @@ export default function worktreeExtension(pi: ExtensionAPI): void {
 
           const paths = "all" in flags ? [...activeWorktreePaths.values()] : [activeWorktreePaths.values().next().value!];
 
-          for (const wtPath of paths) {
+          for (let i = 0; i < paths.length; i++) {
             if (inTmux) {
-              spawn("tmux", ["split-window", "-h", "-c", wtPath], { stdio: "ignore" });
+              if (i === 0) {
+                spawn("tmux", ["split-window", "-h", "-c", paths[i]], { stdio: "ignore" });
+              } else {
+                spawn("tmux", ["split-window", "-v", "-c", paths[i]], { stdio: "ignore" });
+              }
             } else {
-              spawn("open", [`warp://action/new_tab?path=${encodeURIComponent(wtPath)}`], { detached: true, stdio: "ignore" }).unref();
+              spawn("open", [`warp://action/new_tab?path=${encodeURIComponent(paths[i])}`], { detached: true, stdio: "ignore" }).unref();
             }
           }
 

--- a/packages/worktree/src/index.ts
+++ b/packages/worktree/src/index.ts
@@ -170,7 +170,7 @@ function formatHelp(): string {
     "  stop              — deactivate current worktree",
     "  mode   [on|off]   — toggle worktree mode (agent auto-creates worktrees)",
     "  hub               — interactive dashboard: list worktrees, PR status, view diffs",
-    "  shell [--all]     — open tmux pane or Warp tab in the worktree (tmux/Warp only)",
+    "  shell             — open tmux panes or Warp tabs in the worktree (tmux/Warp only)",
     "  list   [--repos repo1,repo2]",
     "  delete <name> [--repos repo1,repo2]",
     "",
@@ -880,7 +880,7 @@ export default function worktreeExtension(pi: ExtensionAPI): void {
             return;
           }
 
-          const paths = "all" in flags ? [...activeWorktreePaths.values()] : [activeWorktreePaths.values().next().value!];
+          const paths = [...activeWorktreePaths.values()];
 
           for (let i = 0; i < paths.length; i++) {
             if (inTmux) {

--- a/packages/worktree/src/index.ts
+++ b/packages/worktree/src/index.ts
@@ -170,6 +170,7 @@ function formatHelp(): string {
     "  stop              — deactivate current worktree",
     "  mode   [on|off]   — toggle worktree mode (agent auto-creates worktrees)",
     "  hub               — interactive dashboard: list worktrees, PR status, view diffs",
+    "  shell [--all]     — open tmux pane or Warp tab in the worktree (tmux/Warp only)",
     "  list   [--repos repo1,repo2]",
     "  delete <name> [--repos repo1,repo2]",
     "",
@@ -862,6 +863,35 @@ export default function worktreeExtension(pi: ExtensionAPI): void {
             },
             { overlay: true, overlayOptions: { anchor: "center", width: "90%", maxHeight: "90%" } },
           );
+          break;
+        }
+
+        case "shell": {
+          if (!activeWorktree || activeWorktreePaths.size === 0) {
+            ctx.ui.notify("No active worktree. Use /worktree use <name> first.", "warning");
+            return;
+          }
+
+          const inTmux = !!process.env.TMUX;
+          const inWarp = process.env.TERM_PROGRAM === "WarpTerminal" || !!process.env.WARP_IS_LOCAL_SHELL_SESSION;
+
+          if (!inTmux && !inWarp) {
+            ctx.ui.notify("shell requires tmux or Warp Terminal.", "error");
+            return;
+          }
+
+          const paths = flags.all ? [...activeWorktreePaths.values()] : [activeWorktreePaths.values().next().value!];
+
+          for (const wtPath of paths) {
+            if (inTmux) {
+              spawn("tmux", ["split-window", "-h", "-c", wtPath], { stdio: "ignore" });
+            } else {
+              spawn("open", [`warp://action/new_tab?path=${encodeURIComponent(wtPath)}`], { detached: true, stdio: "ignore" }).unref();
+            }
+          }
+
+          const repoNames = paths.map((p) => basename(p).replace(`.worktrees/${activeWorktree}`, basename(resolve(p, "../.."))));
+          ctx.ui.notify(`Opened shell in: ${[...activeWorktreePaths.keys()].slice(0, paths.length).join(", ")}`, "info");
           break;
         }
 


### PR DESCRIPTION
## Summary

Adds `/worktree shell` command that opens a terminal pane already `cd`'d into the active worktree directory.

## Usage

- `/worktree shell` — opens a pane in the first repo of the active worktree
- `/worktree shell --all` — opens a pane for each repo in the active worktree

## Supported terminals

- **tmux** — opens a horizontal split (`split-window -h`)
- **Warp** — opens a new tab via `warp://` URI

Other terminals are not supported. The command will show an error if neither tmux nor Warp is detected.

## Why

Navigating into `.worktrees/<tree-name>/` manually is tedious, especially with multiple repos. This gives instant shell access to the worktree.

- Bump to 1.5.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `shell` command to open worktree paths in tmux or Warp Terminal environments with optional `--all` flag for multiple paths.

* **Chores**
  * Bumped package version to 1.5.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->