### PR TITLE
fix(worktree): truncate widget to prevent crash on small terminals

### DIFF
--- a/packages/worktree/package.json
+++ b/packages/worktree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-worktree",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "PI extension to manage git worktrees across multi-repo workspaces with tree-themed names",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/worktree/src/index.ts
+++ b/packages/worktree/src/index.ts
@@ -265,9 +265,10 @@ export default function worktreeExtension(pi: ExtensionAPI): void {
     ctx.ui.setWidget("pi-worktree", (tui: any, theme: any) => ({
       render(width: number): string[] {
         const lines: string[] = [];
-        lines.push(theme.bold(` 🌳 Worktree: ${activeWorktree}`));
-        for (const [repo, path] of activeWorktreePaths) {
-          lines.push(theme.fg("dim", `   ${repo} → ${path}`));
+        const trunc = (s: string) => s.length > width ? s.slice(0, width - 1) + "…" : s;
+        lines.push(trunc(` 🌳 Worktree: ${activeWorktree}`));
+        for (const [repo] of activeWorktreePaths) {
+          lines.push(trunc(`   ${repo}`));
         }
         return lines;
       },


### PR DESCRIPTION
## Summary

Fixes Pi crash (`Rendered line exceeds terminal width`) when the worktree widget is active in a small terminal/split pane.

## Changes

- Truncates all widget lines to the available `width` with `…`
- Shows only repo names (not full paths) to keep lines short
- Bump to 1.5.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text truncation in the worktree widget to better fit content on narrow displays
  * Simplified repository list display to show repository names only with cleaner visual formatting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->