### PR TITLE
feat(smart-context): context-window-aware compression profiles

### DIFF
--- a/packages/smart-context/README.md
+++ b/packages/smart-context/README.md
@@ -44,9 +44,14 @@ Two protections:
 
 #### Aggressive quality gate
 
-- Last **4 turns** never compressed (active working set)
-- Compression only applied if it saves **>15%**
-- Haiku summary only used if it beats the original by >15%; otherwise falls back to a recoverable stub
+The pipeline runs with one of two aggression profiles, chosen per turn:
+
+| Profile | Trigger | Protected turns | Min savings | Summarize ≥ | BM25 drop | Tool trim ≥ | Compress under cache |
+|---|---|---|---|---|---|---|---|
+| **Balanced** | Large-context model, low usage | 4 | 15% | 400 chars | 0.25 | 4000 chars | no |
+| **Aggressive** | Small context window (<200K) **or** usage ≥60% of the window | 2 | 10% | 250 chars | 0.35 | 2000 chars | yes |
+
+Detection uses `ctx.getModel().contextWindow` and `ctx.getContextUsage().tokens`. On a smaller-context model (or when the window is filling up) the extension protects fewer turns, summarizes shorter messages, drops more low-relevance content, trims tool output sooner, and — only in this mode — keeps compressing the prefix even when the provider is caching (the cost of a cache rebuild beats overflowing the window).
 
 ### Commands
 

--- a/packages/smart-context/package.json
+++ b/packages/smart-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-smart-context",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Intelligent model routing and prompt compression for Pi/Kiro",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/smart-context/src/compression/pipeline.ts
+++ b/packages/smart-context/src/compression/pipeline.ts
@@ -20,12 +20,56 @@ interface ContentBlock {
   [key: string]: any;
 }
 
-const PROTECTED_TURNS = 4;
-const MIN_SAVINGS_RATIO = 0.15;
-const SUMMARIZE_MIN_CHARS = 400;
-const BM25_DROP_THRESHOLD = 0.25;
-const LARGE_TOOL_OUTPUT_CHARS = 4000;
-const TOOL_STUB_HEAD_CHARS = 600;
+interface AggressionProfile {
+  protectedTurns: number;
+  minSavingsRatio: number;
+  summarizeMinChars: number;
+  bm25DropThreshold: number;
+  largeToolOutputChars: number;
+  toolStubHeadChars: number;
+  compressDespiteCache: boolean;
+}
+
+const BALANCED_PROFILE: AggressionProfile = {
+  protectedTurns: 4,
+  minSavingsRatio: 0.15,
+  summarizeMinChars: 400,
+  bm25DropThreshold: 0.25,
+  largeToolOutputChars: 4000,
+  toolStubHeadChars: 600,
+  compressDespiteCache: false,
+};
+
+const AGGRESSIVE_PROFILE: AggressionProfile = {
+  protectedTurns: 2,
+  minSavingsRatio: 0.1,
+  summarizeMinChars: 250,
+  bm25DropThreshold: 0.35,
+  largeToolOutputChars: 2000,
+  toolStubHeadChars: 400,
+  compressDespiteCache: true,
+};
+
+const SMALL_CONTEXT_WINDOW = 200_000;
+const HIGH_USAGE_RATIO = 0.6;
+
+function resolveProfile(ctx: any): AggressionProfile {
+  const model = ctx.getModel?.();
+  const contextWindow: number | undefined = model?.contextWindow;
+  const usage = ctx.getContextUsage?.();
+  const usedTokens: number | undefined = usage?.tokens;
+
+  const smallWindow =
+    typeof contextWindow === "number" && contextWindow > 0 && contextWindow < SMALL_CONTEXT_WINDOW;
+
+  const highUsage =
+    typeof usedTokens === "number" &&
+    typeof contextWindow === "number" &&
+    contextWindow > 0 &&
+    usedTokens / contextWindow >= HIGH_USAGE_RATIO;
+
+  return smallWindow || highUsage ? AGGRESSIVE_PROFILE : BALANCED_PROFILE;
+}
 
 interface CompressorDeps {
   store: ContentStore;
@@ -50,9 +94,10 @@ export function createCompressor(deps: CompressorDeps) {
     const lastUserIdx = findLastUserMessage(messages);
     if (lastUserIdx === -1) return messages;
 
+    const profile = resolveProfile(ctx);
     const cacheActive = detectActiveCache(ctx);
     const query = extractText(messages[lastUserIdx]);
-    const protectedBoundary = findProtectedBoundary(messages, PROTECTED_TURNS);
+    const protectedBoundary = findProtectedBoundary(messages, profile.protectedTurns);
 
     const scored = scoreMessages(messages, query, protectedBoundary);
     const result: Message[] = [];
@@ -66,13 +111,13 @@ export function createCompressor(deps: CompressorDeps) {
       }
 
       if (isToolResult(msg)) {
-        if (!cacheActive) {
+        if (!cacheActive || profile.compressDespiteCache) {
           const delta = deltaCompress(msg, state.previousToolHashes);
           if (delta) {
             result.push(delta);
             continue;
           }
-          const trimmed = maybeTrimLargeToolOutput(msg);
+          const trimmed = maybeTrimLargeToolOutput(msg, profile);
           if (trimmed) {
             result.push(trimmed);
             continue;
@@ -83,11 +128,11 @@ export function createCompressor(deps: CompressorDeps) {
       }
 
       if (msg.role === "assistant" || msg.role === "user") {
-        if (cacheActive) {
+        if (cacheActive && !profile.compressDespiteCache) {
           result.push(msg);
           continue;
         }
-        const compressed = await maybeCompressMessage(msg, scored.get(i), ctx);
+        const compressed = await maybeCompressMessage(msg, scored.get(i), ctx, profile);
         result.push(compressed ?? msg);
         continue;
       }
@@ -102,10 +147,11 @@ export function createCompressor(deps: CompressorDeps) {
   async function maybeCompressMessage(
     msg: Message,
     score: number | undefined,
-    ctx: any
+    ctx: any,
+    profile: AggressionProfile
   ): Promise<Message | null> {
     const text = extractText(msg);
-    if (text.length < SUMMARIZE_MIN_CHARS) return null;
+    if (text.length < profile.summarizeMinChars) return null;
 
     const stableKey = store.makeId(text);
     const cachedForm = state.stableCompressions.get(stableKey);
@@ -113,20 +159,20 @@ export function createCompressor(deps: CompressorDeps) {
       return replaceText(msg, cachedForm);
     }
 
-    const relevant = score !== undefined && score >= BM25_DROP_THRESHOLD;
+    const relevant = score !== undefined && score >= profile.bm25DropThreshold;
 
     let replacement: string | null = null;
 
     if (relevant) {
       const summary = await summarizer.summarize(text, ctx);
-      if (summary && summary.length < text.length * (1 - MIN_SAVINGS_RATIO)) {
+      if (summary && summary.length < text.length * (1 - profile.minSavingsRatio)) {
         const id = store.put(text, msg.role, state.turnsProcessed);
         replacement = `${summary}\n[full original: recover_context("${id}")]`;
       }
     } else {
       const summary = await summarizer.summarize(text, ctx);
       const id = store.put(text, msg.role, state.turnsProcessed);
-      if (summary && summary.length < text.length * (1 - MIN_SAVINGS_RATIO)) {
+      if (summary && summary.length < text.length * (1 - profile.minSavingsRatio)) {
         replacement = `[low-relevance, summarized] ${summary}\n[full: recover_context("${id}")]`;
       } else {
         replacement = `[compressed ${msg.role} message — ${text.length} chars — recover_context("${id}")]`;
@@ -139,9 +185,9 @@ export function createCompressor(deps: CompressorDeps) {
     return replaceText(msg, replacement);
   }
 
-  function maybeTrimLargeToolOutput(msg: Message): Message | null {
+  function maybeTrimLargeToolOutput(msg: Message, profile: AggressionProfile): Message | null {
     const text = extractText(msg);
-    if (text.length < LARGE_TOOL_OUTPUT_CHARS) return null;
+    if (text.length < profile.largeToolOutputChars) return null;
 
     const stableKey = store.makeId(text);
     const cachedForm = state.stableCompressions.get(stableKey);
@@ -153,14 +199,14 @@ export function createCompressor(deps: CompressorDeps) {
     structural = foldLogs(structural);
     structural = deduplicateLines(structural);
     structural = compactJson(structural);
-    if (structural.length < text.length * (1 - MIN_SAVINGS_RATIO)) {
+    if (structural.length < text.length * (1 - profile.minSavingsRatio)) {
       state.stableCompressions.set(stableKey, structural);
       return replaceText(msg, structural);
     }
 
     const id = store.put(text, msg.role, state.turnsProcessed);
-    const head = text.slice(0, TOOL_STUB_HEAD_CHARS);
-    const stub = `${head}\n[... ${text.length - TOOL_STUB_HEAD_CHARS} chars trimmed — recover_context("${id}") for full output ...]`;
+    const head = text.slice(0, profile.toolStubHeadChars);
+    const stub = `${head}\n[... ${text.length - profile.toolStubHeadChars} chars trimmed — recover_context("${id}") for full output ...]`;
 
     if (stub.length >= text.length) return null;
 


### PR DESCRIPTION
## Summary

Detecta a janela de contexto do modelo ativo (`ctx.getModel().contextWindow`) e o uso atual (`ctx.getContextUsage().tokens`) para escolher um **perfil de agressividade** de compressão por turn.

| Perfil | Trigger | Protected turns | Min savings | Summarize ≥ | BM25 drop | Tool trim ≥ | Comprime sob cache |
|---|---|---|---|---|---|---|---|
| **Balanced** | Modelo de contexto grande, uso baixo | 4 | 15% | 400 chars | 0.25 | 4000 chars | não |
| **Aggressive** | Janela < 200K **ou** uso ≥ 60% da janela | 2 | 10% | 250 chars | 0.35 | 2000 chars | sim |

## Motivação

Em modelos com janela menor (ou quando o contexto já está enchendo), o comportamento balanceado anterior não comprimia o suficiente e estourava o limite (`context_length_exceeded`). O perfil agressivo protege menos turns, sumariza mensagens mais curtas, dropa mais conteúdo de baixa relevância, corta tool output antes e — só nesse modo — segue comprimindo o prefixo mesmo com cache ativo (o custo de rebuild do cache compensa não estourar a janela).

## O que mudou

- `resolveProfile(ctx)` escolhe Balanced/Aggressive por turn.
- Constantes de compressão viraram campos do profile.
- **Lógica de cache Anthropic preservada**: o bypass cache-safe continua intacto no perfil Balanced; só o perfil agressivo o ignora deliberadamente.
- README atualizado.
- Bump `0.2.0 → 0.3.0`.

## Teste
- `pnpm build` (tsc) limpo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Smart compression now supports two adaptive profiles ("Balanced" and "Aggressive") automatically selected per-turn based on context window usage and available space.

* **Documentation**
  * Updated compression quality gate documentation with detailed profile specifications, including minimum savings thresholds, summarization minimum lengths, and tool-output trimming behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->