### PR TITLE
feat(prs-tracker): color-code PR status and link in widget

### DIFF
--- a/packages/prs-tracker/README.md
+++ b/packages/prs-tracker/README.md
@@ -20,8 +20,8 @@ Or in `.pi/settings.json`:
 
 - Listens to `bash` tool executions. When a command contains `gh pr create` or its output prints a `github.com/<owner>/<repo>/pull/<n>` URL, the PR is captured automatically.
 - For each tracked PR it runs `gh pr view <n> --json ...` to read title and state.
-- A widget pinned above the editor lists every tracked PR with a status icon:
-  - 🟢 open · ⚪ draft · 🟣 merged · 🔴 closed
+- A widget pinned above the editor lists every tracked PR with its state and URL:
+  - `[open]` / `[draft]` / `[merged]` / `[closed]`
 - Background polling (every 60s) refreshes statuses. Merged PRs stay for 24h, closed PRs drop off immediately.
 
 ## Commands

--- a/packages/prs-tracker/README.md
+++ b/packages/prs-tracker/README.md
@@ -1,0 +1,36 @@
+# @arvoretech/pi-prs-tracker
+
+Keeps your open and recently-merged PRs pinned in the chat as a persistent widget. PRs are auto-detected from `gh pr create` calls (and any GitHub PR URL) the agent runs during the session, and their status is refreshed in the background.
+
+## Install
+
+```bash
+pi install npm:@arvoretech/pi-prs-tracker
+```
+
+Or in `.pi/settings.json`:
+
+```json
+{
+  "packages": ["npm:@arvoretech/pi-prs-tracker"]
+}
+```
+
+## How it works
+
+- Listens to `bash` tool executions. When a command contains `gh pr create` or its output prints a `github.com/<owner>/<repo>/pull/<n>` URL, the PR is captured automatically.
+- For each tracked PR it runs `gh pr view <n> --json ...` to read title and state.
+- A widget pinned above the editor lists every tracked PR with a status icon:
+  - 🟢 open · ⚪ draft · 🟣 merged · 🔴 closed
+- Background polling (every 60s) refreshes statuses. Merged PRs stay for 24h, closed PRs drop off immediately.
+
+## Commands
+
+- `/prs` — show usage
+- `/prs hide` — hide the widget
+- `/prs show` — re-show the widget
+- `/prs refresh` — force an immediate status refresh
+
+## Requirements
+
+- GitHub CLI (`gh`) authenticated in the working directory.

--- a/packages/prs-tracker/package.json
+++ b/packages/prs-tracker/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@arvoretech/pi-prs-tracker",
+  "version": "1.0.0",
+  "description": "PI extension that keeps open/recently-merged PRs pinned in the chat as a persistent widget",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "lint": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": ">=0.74.0"
+  },
+  "devDependencies": {
+    "@earendil-works/pi-coding-agent": "latest",
+    "@earendil-works/pi-ai": "latest",
+    "@types/node": "^20.10.0",
+    "typescript": "^5.3.0"
+  },
+  "pi": {
+    "extensions": [
+      "./dist/index.js"
+    ]
+  },
+  "keywords": [
+    "pi-package",
+    "pi",
+    "extension",
+    "pull-request",
+    "github",
+    "widget"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/arvoreeducacao/arvore-pi-extensions.git",
+    "directory": "packages/prs-tracker"
+  },
+  "author": "Arvore",
+  "license": "MIT"
+}

--- a/packages/prs-tracker/src/index.ts
+++ b/packages/prs-tracker/src/index.ts
@@ -1,5 +1,7 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { execSync } from "node:child_process";
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { join, dirname, basename } from "node:path";
 
 interface TrackedPr {
   number: number;
@@ -14,12 +16,62 @@ interface TrackedPr {
 const POLL_INTERVAL_MS = 60_000;
 const MERGED_RETENTION_MS = 24 * 60 * 60 * 1000;
 const PR_URL_RE = /https?:\/\/github\.com\/[^/\s]+\/[^/\s]+\/pull\/(\d+)/g;
+const STATE_DIR = ".pi/prs-tracker-sessions";
 
 const tracked = new Map<string, TrackedPr>();
 let hidden = false;
 let widgetVisible = false;
 let pollTimer: ReturnType<typeof setInterval> | null = null;
 let uiCtx: any = null;
+let sessionId = `mem-${Date.now()}`;
+
+function getSessionId(ctx: any): string {
+  const file = ctx?.sessionManager?.getSessionFile?.() || "";
+  return file ? basename(file, ".json") : sessionId;
+}
+
+function findHubRoot(cwd: string): string | null {
+  let dir = cwd;
+  for (let i = 0; i < 12; i++) {
+    if (existsSync(join(dir, ".pi")) || existsSync(join(dir, ".git"))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+function getStatePath(cwd: string): string | null {
+  const root = findHubRoot(cwd);
+  return root ? join(root, STATE_DIR, `${sessionId}.json`) : null;
+}
+
+function saveState(cwd: string): void {
+  const path = getStatePath(cwd);
+  if (!path) return;
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, JSON.stringify({ hidden, prs: [...tracked.values()] }, null, 2));
+  } catch {}
+}
+
+function loadState(cwd: string): void {
+  const path = getStatePath(cwd);
+  if (!path || !existsSync(path)) return;
+  try {
+    const state = JSON.parse(readFileSync(path, "utf-8")) as {
+      hidden?: boolean;
+      prs?: TrackedPr[];
+    };
+    hidden = Boolean(state.hidden);
+    tracked.clear();
+    for (const pr of state.prs ?? []) {
+      if (pr && typeof pr.number === "number" && pr.repoDir) {
+        tracked.set(keyOf(pr.repoDir, pr.number), pr);
+      }
+    }
+  } catch {}
+}
 
 function keyOf(repoDir: string, number: number): string {
   return `${repoDir}#${number}`;
@@ -129,29 +181,31 @@ function sortedPrs(): TrackedPr[] {
   });
 }
 
-function iconFor(pr: TrackedPr): string {
-  if (pr.state === "MERGED") return "🟣";
-  if (pr.state === "CLOSED") return "🔴";
-  if (pr.isDraft) return "⚪";
-  return "🟢";
+function labelFor(pr: TrackedPr): string {
+  if (pr.state === "MERGED") return "merged";
+  if (pr.state === "CLOSED") return "closed";
+  if (pr.isDraft) return "draft";
+  return "open";
 }
 
 function renderWidget(width: number, theme: any): string[] {
   const prs = sortedPrs();
   const lines: string[] = [];
   const trunc = (s: string): string => (s.length > width ? `${s.slice(0, width - 1)}…` : s);
+  const dim = (s: string): string => (theme?.dim ? theme.dim(s) : s);
 
   const open = prs.filter((p) => p.state === "OPEN").length;
   const merged = prs.filter((p) => p.state === "MERGED").length;
-  const header = ` 🔀 PRs · ${open} aberto(s)${merged ? ` · ${merged} mergeado(s)` : ""}`;
+  const header = ` PRs - ${open} open${merged ? `, ${merged} merged` : ""}`;
   lines.push(theme?.bold ? theme.bold(trunc(header)) : trunc(header));
 
   const max = 12;
   for (const pr of prs.slice(0, max)) {
-    const label = `   ${iconFor(pr)} #${pr.number} ${pr.title}`;
-    lines.push(trunc(label));
+    const title = `   [${labelFor(pr)}] #${pr.number} ${pr.title}`;
+    lines.push(trunc(title));
+    lines.push(dim(trunc(`      ${pr.url}`)));
   }
-  if (prs.length > max) lines.push(trunc(`   +${prs.length - max} mais`));
+  if (prs.length > max) lines.push(trunc(`   +${prs.length - max} more`));
   return lines;
 }
 
@@ -187,7 +241,10 @@ function startPolling(ctx: any): void {
   pollTimer = setInterval(() => {
     if (tracked.size === 0) return;
     const changed = refreshAll();
-    if (changed) updateWidget(ctx);
+    if (changed) {
+      saveState(ctx?.cwd ?? uiCtx?.cwd ?? process.cwd());
+      updateWidget(ctx);
+    }
   }, POLL_INTERVAL_MS);
   if (typeof pollTimer.unref === "function") pollTimer.unref();
 }
@@ -201,6 +258,9 @@ function stopPolling(): void {
 
 export default function prsTrackerExtension(pi: ExtensionAPI): void {
   pi.on("session_start", async (_event, ctx) => {
+    sessionId = getSessionId(ctx);
+    loadState(ctx?.cwd ?? process.cwd());
+    if (tracked.size > 0) refreshAll();
     startPolling(ctx);
     updateWidget(ctx);
   });
@@ -216,12 +276,12 @@ export default function prsTrackerExtension(pi: ExtensionAPI): void {
     const before = tracked.size;
     const beforeSnapshot = JSON.stringify([...tracked.values()]);
     const cwd = ctx?.cwd ?? process.cwd();
-
     const command: string = event?.args?.command ?? "";
     const resultText = resultToText(event?.result);
     extractPrs(`${command}\n${resultText}`, cwd);
 
     if (tracked.size !== before || JSON.stringify([...tracked.values()]) !== beforeSnapshot) {
+      saveState(cwd);
       updateWidget(ctx);
     }
   });
@@ -234,12 +294,14 @@ export default function prsTrackerExtension(pi: ExtensionAPI): void {
       switch (sub) {
         case "hide":
           hidden = true;
+          saveState(ctx?.cwd ?? process.cwd());
           updateWidget(ctx);
           ctx.ui.notify("PRs widget oculto. Use /prs show para reexibir.", "info");
           break;
 
         case "show":
           hidden = false;
+          saveState(ctx?.cwd ?? process.cwd());
           updateWidget(ctx);
           ctx.ui.notify(
             tracked.size === 0
@@ -253,6 +315,7 @@ export default function prsTrackerExtension(pi: ExtensionAPI): void {
         case "": {
           if (sub === "refresh") {
             refreshAll();
+            saveState(ctx?.cwd ?? process.cwd());
             updateWidget(ctx);
             ctx.ui.notify(`PRs atualizados (${tracked.size} rastreado(s)).`, "info");
           } else {

--- a/packages/prs-tracker/src/index.ts
+++ b/packages/prs-tracker/src/index.ts
@@ -5,7 +5,7 @@ import { join, dirname, basename } from "node:path";
 
 interface TrackedPr {
   number: number;
-  repoDir: string;
+  repo: string;
   title: string;
   url: string;
   state: "OPEN" | "MERGED" | "CLOSED";
@@ -15,7 +15,7 @@ interface TrackedPr {
 
 const POLL_INTERVAL_MS = 60_000;
 const MERGED_RETENTION_MS = 24 * 60 * 60 * 1000;
-const PR_URL_RE = /https?:\/\/github\.com\/[^/\s]+\/[^/\s]+\/pull\/(\d+)/g;
+const PR_URL_RE = /https?:\/\/github\.com\/([^/\s]+\/[^/\s]+)\/pull\/(\d+)/g;
 const STATE_DIR = ".pi/prs-tracker-sessions";
 
 const tracked = new Map<string, TrackedPr>();
@@ -66,29 +66,28 @@ function loadState(cwd: string): void {
     hidden = Boolean(state.hidden);
     tracked.clear();
     for (const pr of state.prs ?? []) {
-      if (pr && typeof pr.number === "number" && pr.repoDir) {
-        tracked.set(keyOf(pr.repoDir, pr.number), pr);
+      if (pr && typeof pr.number === "number" && pr.repo) {
+        tracked.set(keyOf(pr.repo, pr.number), pr);
       }
     }
   } catch {}
 }
 
-function keyOf(repoDir: string, number: number): string {
-  return `${repoDir}#${number}`;
+function keyOf(repo: string, number: number): string {
+  return `${repo}#${number}`;
 }
 
-function runGh(args: string, cwd: string): string | null {
+function runGh(args: string): string | null {
   try {
-    return execSync(`gh ${args}`, { cwd, encoding: "utf-8", timeout: 30_000 }).trim();
+    return execSync(`gh ${args}`, { encoding: "utf-8", timeout: 30_000 }).trim();
   } catch {
     return null;
   }
 }
 
-function fetchPrDetails(number: number, repoDir: string): TrackedPr | null {
+function fetchPrDetails(number: number, repo: string): TrackedPr | null {
   const out = runGh(
-    `pr view ${number} --json number,title,state,url,isDraft,mergedAt`,
-    repoDir,
+    `pr view ${number} --repo ${repo} --json number,title,state,url,isDraft,mergedAt`,
   );
   if (!out) return null;
   try {
@@ -102,7 +101,7 @@ function fetchPrDetails(number: number, repoDir: string): TrackedPr | null {
     };
     return {
       number: data.number,
-      repoDir,
+      repo,
       title: data.title,
       url: data.url,
       state: (data.state as TrackedPr["state"]) ?? "OPEN",
@@ -114,10 +113,10 @@ function fetchPrDetails(number: number, repoDir: string): TrackedPr | null {
   }
 }
 
-function trackPr(number: number, repoDir: string): boolean {
-  const details = fetchPrDetails(number, repoDir);
+function trackPr(number: number, repo: string): boolean {
+  const details = fetchPrDetails(number, repo);
   if (!details) return false;
-  tracked.set(keyOf(repoDir, number), details);
+  tracked.set(keyOf(repo, number), details);
   return true;
 }
 
@@ -137,7 +136,7 @@ function pruneStale(): void {
 function refreshAll(): boolean {
   let changed = false;
   for (const [key, pr] of tracked) {
-    const updated = fetchPrDetails(pr.number, pr.repoDir);
+    const updated = fetchPrDetails(pr.number, pr.repo);
     if (updated && JSON.stringify(updated) !== JSON.stringify(pr)) {
       tracked.set(key, updated);
       changed = true;
@@ -147,12 +146,13 @@ function refreshAll(): boolean {
   return changed;
 }
 
-function extractPrs(text: string, cwd: string): void {
+function extractPrs(text: string): void {
   PR_URL_RE.lastIndex = 0;
   let match: RegExpExecArray | null;
   while ((match = PR_URL_RE.exec(text)) !== null) {
-    const number = Number(match[1]);
-    if (Number.isFinite(number)) trackPr(number, cwd);
+    const repo = match[1];
+    const number = Number(match[2]);
+    if (repo && Number.isFinite(number)) trackPr(number, repo);
   }
 }
 
@@ -188,24 +188,34 @@ function labelFor(pr: TrackedPr): string {
   return "open";
 }
 
+function colorFor(pr: TrackedPr): string {
+  if (pr.state === "MERGED") return "accent";
+  if (pr.state === "CLOSED") return "error";
+  if (pr.isDraft) return "warning";
+  return "success";
+}
+
 function renderWidget(width: number, theme: any): string[] {
   const prs = sortedPrs();
   const lines: string[] = [];
   const trunc = (s: string): string => (s.length > width ? `${s.slice(0, width - 1)}…` : s);
-  const dim = (s: string): string => (theme?.dim ? theme.dim(s) : s);
+  const fg = (color: string, s: string): string => (theme?.fg ? theme.fg(color, s) : s);
+  const bold = (s: string): string => (theme?.bold ? theme.bold(s) : s);
 
   const open = prs.filter((p) => p.state === "OPEN").length;
   const merged = prs.filter((p) => p.state === "MERGED").length;
-  const header = ` PRs - ${open} open${merged ? `, ${merged} merged` : ""}`;
-  lines.push(theme?.bold ? theme.bold(trunc(header)) : trunc(header));
+  const header = ` PRs — ${open} open${merged ? `, ${merged} merged` : ""}`;
+  lines.push(bold(fg("accent", trunc(header))));
 
   const max = 12;
   for (const pr of prs.slice(0, max)) {
-    const title = `   [${labelFor(pr)}] #${pr.number} ${pr.title}`;
-    lines.push(trunc(title));
-    lines.push(dim(trunc(`      ${pr.url}`)));
+    const color = colorFor(pr);
+    const tag = fg(color, bold(labelFor(pr).toUpperCase()));
+    const head = trunc(`#${pr.number} ${pr.title}`);
+    lines.push(`   ${tag} ${fg("text", head)}`);
+    lines.push(`      ${fg("mdLinkUrl", trunc(pr.url))}`);
   }
-  if (prs.length > max) lines.push(trunc(`   +${prs.length - max} more`));
+  if (prs.length > max) lines.push(fg("dim", `   +${prs.length - max} more`));
   return lines;
 }
 
@@ -278,7 +288,7 @@ export default function prsTrackerExtension(pi: ExtensionAPI): void {
     const cwd = ctx?.cwd ?? process.cwd();
     const command: string = event?.args?.command ?? "";
     const resultText = resultToText(event?.result);
-    extractPrs(`${command}\n${resultText}`, cwd);
+    extractPrs(`${command}\n${resultText}`);
 
     if (tracked.size !== before || JSON.stringify([...tracked.values()]) !== beforeSnapshot) {
       saveState(cwd);

--- a/packages/prs-tracker/src/index.ts
+++ b/packages/prs-tracker/src/index.ts
@@ -1,0 +1,269 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { execSync } from "node:child_process";
+
+interface TrackedPr {
+  number: number;
+  repoDir: string;
+  title: string;
+  url: string;
+  state: "OPEN" | "MERGED" | "CLOSED";
+  isDraft: boolean;
+  mergedAt: number | null;
+}
+
+const POLL_INTERVAL_MS = 60_000;
+const MERGED_RETENTION_MS = 24 * 60 * 60 * 1000;
+const PR_URL_RE = /https?:\/\/github\.com\/[^/\s]+\/[^/\s]+\/pull\/(\d+)/g;
+
+const tracked = new Map<string, TrackedPr>();
+let hidden = false;
+let widgetVisible = false;
+let pollTimer: ReturnType<typeof setInterval> | null = null;
+let uiCtx: any = null;
+
+function keyOf(repoDir: string, number: number): string {
+  return `${repoDir}#${number}`;
+}
+
+function runGh(args: string, cwd: string): string | null {
+  try {
+    return execSync(`gh ${args}`, { cwd, encoding: "utf-8", timeout: 30_000 }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function fetchPrDetails(number: number, repoDir: string): TrackedPr | null {
+  const out = runGh(
+    `pr view ${number} --json number,title,state,url,isDraft,mergedAt`,
+    repoDir,
+  );
+  if (!out) return null;
+  try {
+    const data = JSON.parse(out) as {
+      number: number;
+      title: string;
+      state: string;
+      url: string;
+      isDraft: boolean;
+      mergedAt: string | null;
+    };
+    return {
+      number: data.number,
+      repoDir,
+      title: data.title,
+      url: data.url,
+      state: (data.state as TrackedPr["state"]) ?? "OPEN",
+      isDraft: Boolean(data.isDraft),
+      mergedAt: data.mergedAt ? new Date(data.mergedAt).getTime() : null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function trackPr(number: number, repoDir: string): boolean {
+  const details = fetchPrDetails(number, repoDir);
+  if (!details) return false;
+  tracked.set(keyOf(repoDir, number), details);
+  return true;
+}
+
+function pruneStale(): void {
+  const now = Date.now();
+  for (const [key, pr] of tracked) {
+    if (pr.state === "CLOSED") {
+      tracked.delete(key);
+      continue;
+    }
+    if (pr.state === "MERGED" && pr.mergedAt && now - pr.mergedAt > MERGED_RETENTION_MS) {
+      tracked.delete(key);
+    }
+  }
+}
+
+function refreshAll(): boolean {
+  let changed = false;
+  for (const [key, pr] of tracked) {
+    const updated = fetchPrDetails(pr.number, pr.repoDir);
+    if (updated && JSON.stringify(updated) !== JSON.stringify(pr)) {
+      tracked.set(key, updated);
+      changed = true;
+    }
+  }
+  pruneStale();
+  return changed;
+}
+
+function extractPrs(text: string, cwd: string): void {
+  PR_URL_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = PR_URL_RE.exec(text)) !== null) {
+    const number = Number(match[1]);
+    if (Number.isFinite(number)) trackPr(number, cwd);
+  }
+}
+
+function resultToText(result: any): string {
+  if (!result) return "";
+  if (typeof result === "string") return result;
+  const parts: string[] = [];
+  const content = result.content ?? result.output ?? result;
+  if (Array.isArray(content)) {
+    for (const item of content) {
+      if (typeof item === "string") parts.push(item);
+      else if (item?.text) parts.push(String(item.text));
+    }
+  } else if (typeof content === "string") {
+    parts.push(content);
+  }
+  return parts.join("\n");
+}
+
+function sortedPrs(): TrackedPr[] {
+  const order = (pr: TrackedPr): number => (pr.state === "OPEN" ? 0 : 1);
+  return [...tracked.values()].sort((a, b) => {
+    const byState = order(a) - order(b);
+    if (byState !== 0) return byState;
+    return b.number - a.number;
+  });
+}
+
+function iconFor(pr: TrackedPr): string {
+  if (pr.state === "MERGED") return "🟣";
+  if (pr.state === "CLOSED") return "🔴";
+  if (pr.isDraft) return "⚪";
+  return "🟢";
+}
+
+function renderWidget(width: number, theme: any): string[] {
+  const prs = sortedPrs();
+  const lines: string[] = [];
+  const trunc = (s: string): string => (s.length > width ? `${s.slice(0, width - 1)}…` : s);
+
+  const open = prs.filter((p) => p.state === "OPEN").length;
+  const merged = prs.filter((p) => p.state === "MERGED").length;
+  const header = ` 🔀 PRs · ${open} aberto(s)${merged ? ` · ${merged} mergeado(s)` : ""}`;
+  lines.push(theme?.bold ? theme.bold(trunc(header)) : trunc(header));
+
+  const max = 12;
+  for (const pr of prs.slice(0, max)) {
+    const label = `   ${iconFor(pr)} #${pr.number} ${pr.title}`;
+    lines.push(trunc(label));
+  }
+  if (prs.length > max) lines.push(trunc(`   +${prs.length - max} mais`));
+  return lines;
+}
+
+function updateWidget(ctx: any): void {
+  uiCtx = ctx;
+  if (!ctx?.ui?.setWidget) return;
+
+  if (hidden || tracked.size === 0) {
+    if (widgetVisible) {
+      ctx.ui.setWidget("pi-prs-tracker", undefined);
+      widgetVisible = false;
+    }
+    return;
+  }
+
+  ctx.ui.setWidget(
+    "pi-prs-tracker",
+    (_tui: any, theme: any) => ({
+      render(width: number): string[] {
+        return renderWidget(width, theme);
+      },
+      invalidate(): void {
+        widgetVisible = false;
+      },
+    }),
+    { placement: "aboveEditor" },
+  );
+  widgetVisible = true;
+}
+
+function startPolling(ctx: any): void {
+  if (pollTimer) return;
+  pollTimer = setInterval(() => {
+    if (tracked.size === 0) return;
+    const changed = refreshAll();
+    if (changed) updateWidget(ctx);
+  }, POLL_INTERVAL_MS);
+  if (typeof pollTimer.unref === "function") pollTimer.unref();
+}
+
+function stopPolling(): void {
+  if (pollTimer) {
+    clearInterval(pollTimer);
+    pollTimer = null;
+  }
+}
+
+export default function prsTrackerExtension(pi: ExtensionAPI): void {
+  pi.on("session_start", async (_event, ctx) => {
+    startPolling(ctx);
+    updateWidget(ctx);
+  });
+
+  pi.on("session_shutdown", async () => {
+    stopPolling();
+  });
+
+  pi.on("tool_execution_end", async (event: any, ctx: any) => {
+    const name = event?.toolName;
+    if (name !== "bash" || event?.isError) return;
+
+    const before = tracked.size;
+    const beforeSnapshot = JSON.stringify([...tracked.values()]);
+    const cwd = ctx?.cwd ?? process.cwd();
+
+    const command: string = event?.args?.command ?? "";
+    const resultText = resultToText(event?.result);
+    extractPrs(`${command}\n${resultText}`, cwd);
+
+    if (tracked.size !== before || JSON.stringify([...tracked.values()]) !== beforeSnapshot) {
+      updateWidget(ctx);
+    }
+  });
+
+  pi.registerCommand("prs", {
+    description: "Manage the pinned PRs widget. Usage: /prs [show|hide|refresh]",
+    handler: async (args, ctx) => {
+      const sub = (args ?? "").trim().toLowerCase();
+
+      switch (sub) {
+        case "hide":
+          hidden = true;
+          updateWidget(ctx);
+          ctx.ui.notify("PRs widget oculto. Use /prs show para reexibir.", "info");
+          break;
+
+        case "show":
+          hidden = false;
+          updateWidget(ctx);
+          ctx.ui.notify(
+            tracked.size === 0
+              ? "Nenhum PR rastreado ainda nesta sessão."
+              : "PRs widget visível.",
+            "info",
+          );
+          break;
+
+        case "refresh":
+        case "": {
+          if (sub === "refresh") {
+            refreshAll();
+            updateWidget(ctx);
+            ctx.ui.notify(`PRs atualizados (${tracked.size} rastreado(s)).`, "info");
+          } else {
+            ctx.ui.notify("Usage: /prs [show|hide|refresh]", "info");
+          }
+          break;
+        }
+
+        default:
+          ctx.ui.notify("Usage: /prs [show|hide|refresh]", "warning");
+      }
+    },
+  });
+}

--- a/packages/prs-tracker/tsconfig.json
+++ b/packages/prs-tracker/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,10 +23,10 @@ importers:
     devDependencies:
       '@earendil-works/pi-ai':
         specifier: latest
-        version: 0.79.5(ws@8.20.0)(zod@4.4.3)
+        version: 0.79.6(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-coding-agent':
         specifier: latest
-        version: 0.79.5(ws@8.20.0)(zod@4.4.3)
+        version: 0.79.6(ws@8.20.0)(zod@4.4.3)
       '@types/node':
         specifier: ^20.10.0
         version: 20.19.39
@@ -38,7 +38,7 @@ importers:
     devDependencies:
       '@earendil-works/pi-coding-agent':
         specifier: latest
-        version: 0.79.5(ws@8.20.0)(zod@4.4.3)
+        version: 0.79.6(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-tui':
         specifier: 0.79.5
         version: 0.79.5
@@ -53,10 +53,10 @@ importers:
     devDependencies:
       '@earendil-works/pi-ai':
         specifier: latest
-        version: 0.79.5(ws@8.20.0)(zod@4.4.3)
+        version: 0.79.6(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-coding-agent':
         specifier: latest
-        version: 0.79.5(ws@8.20.0)(zod@4.4.3)
+        version: 0.79.6(ws@8.20.0)(zod@4.4.3)
       '@types/node':
         specifier: ^20.10.0
         version: 20.19.39
@@ -72,10 +72,10 @@ importers:
     devDependencies:
       '@earendil-works/pi-ai':
         specifier: latest
-        version: 0.79.5(ws@8.20.0)(zod@4.4.3)
+        version: 0.79.6(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-coding-agent':
         specifier: latest
-        version: 0.79.5(ws@8.20.0)(zod@4.4.3)
+        version: 0.79.6(ws@8.20.0)(zod@4.4.3)
       '@types/node':
         specifier: ^20.10.0
         version: 20.19.39
@@ -132,10 +132,10 @@ importers:
     devDependencies:
       '@earendil-works/pi-ai':
         specifier: latest
-        version: 0.79.5(ws@8.20.0)(zod@4.4.3)
+        version: 0.79.6(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-coding-agent':
         specifier: latest
-        version: 0.79.5(ws@8.20.0)(zod@4.4.3)
+        version: 0.79.6(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-tui':
         specifier: 0.79.5
         version: 0.79.5
@@ -150,16 +150,31 @@ importers:
     devDependencies:
       '@earendil-works/pi-agent-core':
         specifier: latest
-        version: 0.79.5(ws@8.20.0)(zod@4.4.3)
+        version: 0.79.6(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-ai':
         specifier: latest
-        version: 0.79.5(ws@8.20.0)(zod@4.4.3)
+        version: 0.79.6(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-coding-agent':
         specifier: latest
-        version: 0.79.5(ws@8.20.0)(zod@4.4.3)
+        version: 0.79.6(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-tui':
         specifier: 0.79.5
         version: 0.79.5
+      '@types/node':
+        specifier: ^20.10.0
+        version: 20.19.39
+      typescript:
+        specifier: ^5.3.0
+        version: 5.9.3
+
+  packages/prs-tracker:
+    devDependencies:
+      '@earendil-works/pi-ai':
+        specifier: latest
+        version: 0.79.6(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-coding-agent':
+        specifier: latest
+        version: 0.79.6(ws@8.20.0)(zod@4.4.3)
       '@types/node':
         specifier: ^20.10.0
         version: 20.19.39
@@ -238,7 +253,7 @@ importers:
     devDependencies:
       '@earendil-works/pi-coding-agent':
         specifier: latest
-        version: 0.79.5(ws@8.20.0)(zod@4.4.3)
+        version: 0.79.6(ws@8.20.0)(zod@4.4.3)
       '@types/node':
         specifier: ^20.10.0
         version: 20.19.39
@@ -2820,9 +2835,9 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-agent-core@0.79.5(ws@8.20.0)(zod@4.4.3)':
+  '@earendil-works/pi-agent-core@0.79.5':
     dependencies:
-      '@earendil-works/pi-ai': 0.79.5(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.79.6(ws@8.20.0)(zod@4.4.3)
       ignore: 7.0.5
       typebox: 1.1.38
       yaml: 2.9.0
@@ -3045,7 +3060,7 @@ snapshots:
   '@earendil-works/pi-coding-agent@0.79.0':
     dependencies:
       '@earendil-works/pi-agent-core': 0.79.0
-      '@earendil-works/pi-ai': 0.79.5(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.79.6(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-tui': 0.79.5
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
@@ -3073,8 +3088,8 @@ snapshots:
 
   '@earendil-works/pi-coding-agent@0.79.1':
     dependencies:
-      '@earendil-works/pi-agent-core': 0.79.5(ws@8.20.0)(zod@4.4.3)
-      '@earendil-works/pi-ai': 0.79.5(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-agent-core': 0.79.5
+      '@earendil-works/pi-ai': 0.79.6(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-tui': 0.79.5
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
@@ -3102,8 +3117,8 @@ snapshots:
 
   '@earendil-works/pi-coding-agent@0.79.5(ws@8.20.0)(zod@4.4.3)':
     dependencies:
-      '@earendil-works/pi-agent-core': 0.79.5(ws@8.20.0)(zod@4.4.3)
-      '@earendil-works/pi-ai': 0.79.5(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-agent-core': 0.79.6(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.79.6(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-tui': 0.79.5
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
@@ -3980,7 +3995,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 8.59.3
       debug: 4.4.3
       minimatch: 10.2.5
-      semver: 7.7.4
+      semver: 7.8.0
       tinyglobby: 0.2.16
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3


### PR DESCRIPTION
## Resumo

Segundo PR de demonstração do widget de PRs. Adiciona cores semânticas ao widget:

- Status colorido por estado: open (verde/success), draft (amarelo/warning), merged (roxo/accent), closed (vermelho/error)
- Link do PR destacado com cor de link do tema (mdLinkUrl)
- Sem emojis, label de status em texto maiúsculo

Identificação do PR agora é por `owner/repo` extraído da URL + `gh pr view --repo`, eliminando dependência do cwd. Estado persiste por sessão em `.pi/prs-tracker-sessions/`.