### PR TITLE
feat(worktree): per-repo setup scripts (sync/background)

### DIFF
--- a/packages/worktree/package.json
+++ b/packages/worktree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-worktree",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "description": "PI extension to manage git worktrees across multi-repo workspaces with tree-themed names",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/worktree/src/index.ts
+++ b/packages/worktree/src/index.ts
@@ -1,7 +1,7 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "@earendil-works/pi-ai";
 import { execSync, spawnSync, spawn } from "node:child_process";
-import { existsSync, readFileSync, appendFileSync, readdirSync, statSync, symlinkSync, writeFileSync, mkdirSync } from "node:fs";
+import { existsSync, readFileSync, appendFileSync, readdirSync, statSync, symlinkSync, writeFileSync, mkdirSync, openSync } from "node:fs";
 import { join, resolve, basename } from "node:path";
 
 let activeWorktree: string | null = null;
@@ -22,6 +22,29 @@ const TREE_NAMES = [
 ];
 
 const WORKTREES_DIR = ".worktrees";
+const SETUP_DIR = ".pi/worktree-setup";
+
+interface SetupConfig {
+  defaultSymlink?: string[];
+  background?: boolean;
+  repos?: Record<string, { symlink?: string[]; background?: boolean }>;
+}
+
+function getSetupDir(repoPath: string): string {
+  const root = findHubRoot(repoPath) || repoPath;
+  return join(root, SETUP_DIR);
+}
+
+function loadSetupConfig(repoPath: string): SetupConfig | null {
+  const path = join(getSetupDir(repoPath), "setup.json");
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, "utf-8")) as SetupConfig;
+  } catch (e) {
+    process.stderr.write(`[pi-worktree] Invalid setup.json: ${(e as Error).message}\n`);
+    return null;
+  }
+}
 
 function pickAvailableName(repoPath: string): string | null {
   const dir = join(repoPath, WORKTREES_DIR);
@@ -100,21 +123,103 @@ function getExistingWorktrees(repoPath: string): Array<{ name: string; branch: s
   return entries;
 }
 
-function symlinkEnvFiles(repoPath: string, targetDir: string): void {
+function matchesPattern(entry: string, pattern: string): boolean {
+  if (pattern.endsWith("*")) return entry.startsWith(pattern.slice(0, -1));
+  return entry === pattern.replace(/\/$/, "");
+}
+
+function symlinkMatching(repoPath: string, targetDir: string, patterns: string[]): string[] {
+  const linked: string[] = [];
   for (const entry of readdirSync(repoPath)) {
-    if (!entry.startsWith(".env")) continue;
+    if (!patterns.some((p) => matchesPattern(entry, p))) continue;
     const src = join(repoPath, entry);
     const dest = join(targetDir, entry);
-    if (statSync(src).isFile() && !existsSync(dest)) {
-      try { symlinkSync(src, dest); } catch (e) {
-        process.stderr.write(`[pi-worktree] Failed to symlink ${entry}: ${(e as Error).message}\n`);
-      }
+    if (existsSync(dest)) continue;
+    try {
+      symlinkSync(src, dest);
+      linked.push(entry);
+    } catch (e) {
+      process.stderr.write(`[pi-worktree] Failed to symlink ${entry}: ${(e as Error).message}\n`);
     }
   }
+  return linked;
+}
+
+function autoInstall(repoPath: string, targetDir: string): void {
   if (existsSync(join(repoPath, "package.json")) && !existsSync(join(targetDir, "node_modules"))) {
     const pm = existsSync(join(repoPath, "pnpm-lock.yaml")) ? "pnpm" : existsSync(join(repoPath, "yarn.lock")) ? "yarn" : "npm";
     spawn(pm, ["install"], { cwd: targetDir, stdio: "ignore", detached: true }).unref();
   }
+}
+
+function runSetupScript(scriptPath: string, repoPath: string, targetDir: string): { ok: boolean; output: string } {
+  const result = spawnSync("bash", [scriptPath], {
+    cwd: targetDir,
+    encoding: "utf-8",
+    env: {
+      ...process.env,
+      WT_REPO: targetDir,
+      WT_MAIN: repoPath,
+      WT_NAME: basename(targetDir),
+      WT_REPO_NAME: basename(repoPath),
+    },
+  });
+  if (result.error) return { ok: false, output: result.error.message };
+  const output = [result.stdout, result.stderr].filter(Boolean).join("").trim();
+  return { ok: result.status === 0, output };
+}
+
+function setupLogPath(targetDir: string): string {
+  const gitFile = join(targetDir, ".git");
+  try {
+    const content = readFileSync(gitFile, "utf-8").trim();
+    const match = content.match(/^gitdir:\s*(.+)$/);
+    if (match) return join(match[1].trim(), "pi-worktree-setup.log");
+  } catch {}
+  return join(targetDir, ".pi-worktree-setup.log");
+}
+
+function runSetupScriptBackground(scriptPath: string, repoPath: string, targetDir: string): string {
+  const logPath = setupLogPath(targetDir);
+  const fd = openSync(logPath, "w");
+  const child = spawn("bash", [scriptPath], {
+    cwd: targetDir,
+    stdio: ["ignore", fd, fd],
+    detached: true,
+    env: {
+      ...process.env,
+      WT_REPO: targetDir,
+      WT_MAIN: repoPath,
+      WT_NAME: basename(targetDir),
+      WT_REPO_NAME: basename(repoPath),
+    },
+  });
+  child.unref();
+  return logPath;
+}
+
+function runRepoSetup(repoPath: string, targetDir: string): string {
+  const repoName = basename(repoPath);
+  const config = loadSetupConfig(repoPath);
+  const symlinkPatterns = config?.repos?.[repoName]?.symlink ?? config?.defaultSymlink ?? [".env*"];
+  const linked = symlinkMatching(repoPath, targetDir, symlinkPatterns);
+  const linkedNote = linked.length ? ` (linked ${linked.join(", ")})` : "";
+  const background = config?.repos?.[repoName]?.background ?? config?.background ?? false;
+
+  const scriptPath = join(getSetupDir(repoPath), `${repoName}.sh`);
+  if (existsSync(scriptPath)) {
+    if (background) {
+      const logPath = runSetupScriptBackground(scriptPath, repoPath, targetDir);
+      return `setup: ${repoName}.sh ⧖ background${linkedNote}\n  log: ${logPath}`;
+    }
+    const { ok, output } = runSetupScript(scriptPath, repoPath, targetDir);
+    if (ok) return `setup: ${repoName}.sh ✓${linkedNote}`;
+    const tail = output ? `\n${output.split("\n").slice(-6).join("\n")}` : "";
+    return `setup: ${repoName}.sh ✗${tail}`;
+  }
+
+  autoInstall(repoPath, targetDir);
+  return `setup: default${linkedNote}`;
 }
 
 function createWorktree(repoPath: string, name: string, branch?: string): { ok: boolean; message: string } {
@@ -137,14 +242,14 @@ function createWorktree(repoPath: string, name: string, branch?: string): { ok: 
         encoding: "utf-8",
       });
       if (result2.status !== 0) return { ok: false, message: `Failed: ${result2.stderr?.trim()}` };
-      symlinkEnvFiles(repoPath, targetDir);
-      return { ok: true, message: `Created worktree '${name}' in ${basename(repoPath)} (existing branch)` };
+      const setup2 = runRepoSetup(repoPath, targetDir);
+      return { ok: true, message: `Created worktree '${name}' in ${basename(repoPath)} (existing branch)\n  ${setup2}` };
     }
     return { ok: false, message: `Failed: ${err}` };
   }
 
-  symlinkEnvFiles(repoPath, targetDir);
-  return { ok: true, message: `Created worktree '${name}' in ${basename(repoPath)} → branch wt/${name}` };
+  const setup = runRepoSetup(repoPath, targetDir);
+  return { ok: true, message: `Created worktree '${name}' in ${basename(repoPath)} → branch wt/${name}\n  ${setup}` };
 }
 
 function removeWorktree(repoPath: string, name: string): { ok: boolean; message: string } {
@@ -176,6 +281,10 @@ function formatHelp(): string {
     "",
     "If --repos is omitted, shows interactive picker.",
     "If --name is omitted on create, picks a random tree name.",
+    "",
+    "Setup on create: runs .pi/worktree-setup/<repo>.sh if present (cwd=worktree,",
+    "  env: $WT_REPO $WT_MAIN $WT_NAME $WT_REPO_NAME). Otherwise symlinks .env* and",
+    "  auto-installs node deps. Symlink globs + background flag in .pi/worktree-setup/setup.json.",
   ].join("\n");
 }
 

--- a/packages/worktree/src/index.ts
+++ b/packages/worktree/src/index.ts
@@ -1,7 +1,7 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "@earendil-works/pi-ai";
 import { execSync, spawnSync, spawn } from "node:child_process";
-import { existsSync, readFileSync, appendFileSync, readdirSync, statSync, symlinkSync, writeFileSync, mkdirSync, openSync } from "node:fs";
+import { existsSync, readFileSync, appendFileSync, readdirSync, statSync, symlinkSync, writeFileSync, mkdirSync, openSync, closeSync } from "node:fs";
 import { join, resolve, basename } from "node:path";
 
 let activeWorktree: string | null = null;
@@ -195,6 +195,7 @@ function runSetupScriptBackground(scriptPath: string, repoPath: string, targetDi
     },
   });
   child.unref();
+  closeSync(fd);
   return logPath;
 }
 


### PR DESCRIPTION
## Summary

Adds per-repo setup hooks to the `worktree` extension so each repo can fully
prepare a freshly created worktree, with a fallback to the previous behavior.

On `create_worktree` / `/worktree create`, for each repo:

1. Symlink globs run first — from `.pi/worktree-setup/setup.json`
   (`defaultSymlink` or per-repo `repos.<name>.symlink`), defaulting to `.env*`.
2. If `.pi/worktree-setup/<repo>.sh` exists, it runs inside the new worktree
   with `$WT_REPO`, `$WT_MAIN`, `$WT_NAME`, `$WT_REPO_NAME` available.
3. Otherwise it falls back to the original behavior: symlink `.env*` +
   background auto-install of node deps.

The setup dir resolves to the hub root's `.pi` when in a hub, or the repo's own
`.pi` for standalone projects, so it works in both modes.

### Sync vs. background

Scripts run synchronously by default (creation waits, non-zero exit reported as
a failure but the worktree is still created). Setting `background: true` in
`setup.json` (global or per-repo) detaches the script and streams its output to
`pi-worktree-setup.log` in the worktree's git metadata dir
(`.git/worktrees/<name>/`), keeping it out of the working tree.

## Changes

- Refactored the old hardcoded `symlinkEnvFiles` into composable helpers
  (`symlinkMatching`, `autoInstall`, `runSetupScript`, `runSetupScriptBackground`,
  `runRepoSetup`).
- `createWorktree` now reports the setup result inline.
- Updated `/worktree help`.
- Bumped to `1.6.0`.

## Tested

Verified end-to-end against `api-arvore`: `mise trust` (no GUI prompt),
`pnpm install`, and `pnpm prisma:generate` all ran via a background setup script,
with `create_worktree` returning instantly and output captured in the gitdir log.
The fallback path was verified in isolation for repos without a script.

> Hub-local config (`.pi/worktree-setup/`) lives in the arvore-hub repo, not here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable “setup on create” for worktrees, including automated symlinking of environment files using configurable name patterns (defaulting to `.env*`).
  * Automatically installs Node.js dependencies when a `package.json` is present and `node_modules` is missing.
  * Runs optional per-repository setup scripts during creation, supporting both synchronous execution (with output capture) and background execution (with log output).
  * Setup runs for both newly created and already-existing worktree paths, and reports the setup result.

* **Documentation**
  * Updated `/worktree` help text to describe the setup behavior and environment variables passed to setup scripts.

* **Chores**
  * Bumped package version to 1.6.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->