### PR TITLE
fix(pi-memory): injecao menos agressiva no retrieval (v0.5.0)

### DIFF
--- a/packages/pi-memory/package.json
+++ b/packages/pi-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-memory",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "PI extension for cloud-based memory with RAG (Qdrant + GitHub OAuth)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/pi-memory/src/api.ts
+++ b/packages/pi-memory/src/api.ts
@@ -62,7 +62,7 @@ export function ingest(sessionId: string, messages: IngestMessage[], final: bool
 
 export async function search(
   query: string,
-  options: { tier?: string; category?: string; limit?: number } = {},
+  options: { tier?: string; category?: string; limit?: number; threshold?: number } = {},
 ): Promise<SearchResult[]> {
   const data = await request<{ results: SearchResult[] }>("/search", "POST", { query, ...options });
   return data.results;

--- a/packages/pi-memory/src/index.ts
+++ b/packages/pi-memory/src/index.ts
@@ -26,6 +26,8 @@ import {
 const LOGIN_TIMEOUT_MS = 60_000;
 const MIN_TEXT_LENGTH = 10;
 const FLUSH_DEBOUNCE_MS = 4000;
+const SEARCH_LIMIT = 4;
+const SEARCH_THRESHOLD = 0.6;
 
 let incognito = false;
 let sessionId = "";
@@ -86,8 +88,8 @@ function collectMessages(entries: unknown[]): IngestMessage[] {
 
 function buildSearchQuery(entries: unknown[], prompt: string): string {
   const messages = collectMessages(entries);
-  const recent = messages.slice(-3).map((m) => m.text);
-  const combined = [...recent, prompt].join("\n").trim();
+  const previous = messages.slice(-1).map((m) => m.text);
+  const combined = [prompt, prompt, ...previous].join("\n").trim();
   return combined.slice(0, 800);
 }
 
@@ -203,7 +205,7 @@ export default function piMemoryExtension(pi: ExtensionAPI): void {
       }
 
       const query = buildSearchQuery(ctx.sessionManager.getEntries(), prompt);
-      const results = await search(query, { limit: 10 });
+      const results = await search(query, { limit: SEARCH_LIMIT, threshold: SEARCH_THRESHOLD });
       lastSearchResults = results;
       if (results.length === 0) {
         return;
@@ -212,11 +214,13 @@ export default function piMemoryExtension(pi: ExtensionAPI): void {
       const memoryBlock = [
         "## Team Memory (cloud)",
         "",
-        "This workspace uses a shared cloud team memory. Use the `memory_search` tool to recover",
-        "relevant decisions, conventions, incidents, domain knowledge and gotchas before non-trivial",
-        "tasks, and `memory_save` to persist durable knowledge the team should not rediscover.",
+        "The team keeps a shared cloud memory. The items below were retrieved by semantic",
+        "similarity to the current request and MAY be irrelevant. Treat them as optional hints,",
+        "not facts: if an item does not clearly relate to what the user is asking now, ignore it",
+        "entirely and do not let it steer the conversation. Use `memory_search` to look deeper only",
+        "when an item is clearly on-topic, and `memory_save` for durable knowledge worth keeping.",
         "",
-        "### Relevant context for the current request",
+        "### Possibly relevant context (verify before using)",
         ...results.map((r) => `- ${r.title ? `**${r.title}**: ` : ""}${r.content}`),
       ].join("\n");
 


### PR DESCRIPTION
## Contexto

Na thread de feedback do pi-memory, vários devs reportaram que o agente injeta memórias irrelevantes no contexto e elas "cagam" a conversa (OMS→Biblion, Metabase→Datadog/SigNoz). Do lado do cliente, três problemas amplificavam isso.

## O que muda (v0.5.0)

- **Injeção menos agressiva**: `limit 10 → 4` e `threshold: 0.6` explícito na busca (antes usava o default permissivo da API e injetava até 10 itens sem olhar score).
- **Query focada no prompt atual**: `buildSearchQuery` agora prioriza o prompt da vez (peso duplo) e usa só a última mensagem como contexto, em vez de misturar as 3 últimas. Resolve o caso de arrastar o assunto anterior quando o tópico muda no meio da conversa.
- **Wording do bloco injetado**: deixa explícito que os itens **podem ser irrelevantes** e devem ser ignorados se não casarem com a pergunta, em vez de afirmar "Relevant context for the current request".

## Par

Acompanha o PR da API (`api-arvore`) que sobe o threshold e adiciona piso de score por tier (raw 0.6 / curated 0.5).

## Verificação

- `tsc --noEmit` ✅
- Bump de versão `0.4.0 → 0.5.0` (precisa republicar no npm após merge)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional threshold parameter to search API for enhanced filtering control and granular result refinement.

* **Improvements**
  * Optimized search query processing for more relevant memory retrieval.
  * Enhanced guidance and instructions for handling retrieved contextual information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->