### PR TITLE
feat(worktree): add list_worktrees tool

### DIFF
--- a/packages/worktree/package.json
+++ b/packages/worktree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-worktree",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "PI extension to manage git worktrees across multi-repo workspaces with tree-themed names",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/worktree/src/index.ts
+++ b/packages/worktree/src/index.ts
@@ -407,6 +407,36 @@ export default function worktreeExtension(pi: ExtensionAPI): void {
   });
 
   pi.registerTool({
+    name: "list_worktrees",
+    label: "List Worktrees",
+    description: "Lists all existing worktrees on disk across repos, grouped by repo, with each worktree's branch and whether it is the currently active one. Use to discover available worktrees before activating, attaching, or deleting one.",
+    promptSnippet: "List all existing git worktrees across repos",
+    parameters: Type.Object({}),
+    async execute(_toolCallId, _params, _signal, _onUpdate, ctx) {
+      const repos = discoverRepos(ctx.cwd);
+      const lines: string[] = [];
+      const details: Array<{ repo: string; name: string; branch: string; path: string; active: boolean }> = [];
+
+      for (const repo of repos) {
+        const worktrees = getExistingWorktrees(repo);
+        if (worktrees.length === 0) continue;
+        lines.push(`${basename(repo)}:`);
+        for (const wt of worktrees) {
+          const isActive = activeWorktree === wt.name;
+          lines.push(`  ${wt.name} → ${wt.branch}${isActive ? " (active)" : ""}`);
+          details.push({ repo: basename(repo), name: wt.name, branch: wt.branch, path: wt.path, active: isActive });
+        }
+      }
+
+      const text = lines.length > 0 ? lines.join("\n") : "No worktrees found.";
+      return {
+        content: [{ type: "text", text }],
+        details: { worktrees: details },
+      };
+    },
+  });
+
+  pi.registerTool({
     name: "create_worktree",
     label: "Create Worktree",
     description: "Creates a new worktree for the specified repos and activates it. The worktree gets a random tree-themed name (from a fixed pool) and a new branch. All .env* files are symlinked into it. Do NOT pass a custom name — the name is always auto-generated.",


### PR DESCRIPTION
## Descrição

Adiciona a tool `list_worktrees` para a IA, que antes não tinha como listar os worktrees existentes — só conseguia ver o worktree ativo via `get_worktree_paths`.

A lógica de listagem (`getExistingWorktrees`) já existia, mas só era exposta no comando `/worktree list` (TUI). Agora a IA também consegue descobrir os worktrees em disco.

## Mudanças

- Nova tool `list_worktrees` (sem parâmetros).
- Lista todos os worktrees em disco agrupados por repo, com branch e flag `(active)` no worktree ativo.
- Retorna também `details.worktrees` estruturado (`repo`, `name`, `branch`, `path`, `active`) para uso programático.
- Bump de versão `1.7.0` → `1.8.0`.

## Testes

- `pnpm build` (tsc) passando.