### PR TITLE
feat: pi-cloud-sessions — sync pi sessions to git/iCloud

### DIFF
--- a/packages/cloud-sessions/README.md
+++ b/packages/cloud-sessions/README.md
@@ -1,0 +1,98 @@
+# @arvoretech/pi-cloud-sessions
+
+Sync your pi sessions to a cloud backend so you can start a conversation on one
+machine and resume it on another. The full session is synced — messages, tree,
+labels, and the session name — by mirroring the JSONL files pi stores under
+`~/.pi/agent/sessions/`.
+
+Two backends are supported:
+
+- **git** — a private Git repo you own (versioned history, free, works anywhere).
+- **icloud** — a folder inside iCloud Drive (zero infra, Macs on the same Apple ID).
+
+## How it works
+
+pi stores each session as a JSONL file under
+`<agent-dir>/sessions/--<project-path>--/<timestamp>_<uuid>.jsonl`. This
+extension mirrors that tree to the chosen backend:
+
+- On startup it **pulls** newer sessions from the backend into your local store.
+- After each turn it **pushes** the current state (debounced).
+- On shutdown it flushes a final sync.
+
+Conflict resolution is **last-write-wins per file** by modification time. File
+mtimes are preserved across machines so the newest edit wins regardless of which
+machine synced last. Sessions are append-only/branching, so concurrent edits to
+the same file are rare.
+
+## Setup
+
+Run the setup command inside pi:
+
+```
+/cloud-sessions-setup
+```
+
+It asks for the backend and writes `~/.config/pi/cloud-sessions.json`.
+
+### Git backend
+
+Create an **empty private repo** (e.g. `git@github.com:you/pi-sessions.git`) and
+make sure your local `git` can push to it (SSH key or `gh auth`). Then:
+
+```jsonc
+// ~/.config/pi/cloud-sessions.json
+{
+  "provider": "git",
+  "git": { "repo": "git@github.com:you/pi-sessions.git", "branch": "main" }
+}
+```
+
+The repo is cloned to `~/.config/pi/cloud-sessions/repo` and kept in sync.
+
+### iCloud backend
+
+```jsonc
+{
+  "provider": "icloud",
+  "icloud": {
+    "dir": "~/Library/Mobile Documents/com~apple~CloudDocs/pi-sessions"
+  }
+}
+```
+
+## Commands
+
+- `/cloud-sessions-sync` — pull + push now.
+- `/cloud-sessions-status` — show config and current state.
+- `/cloud-sessions-setup` — configure the backend interactively.
+
+## Configuration
+
+All options can be set in `~/.config/pi/cloud-sessions.json` or via env vars:
+
+| Setting        | JSON key         | Env var                            | Default                |
+| -------------- | ---------------- | ---------------------------------- | ---------------------- |
+| Backend        | `provider`       | `PI_CLOUD_SESSIONS_PROVIDER`       | `git`                  |
+| Auto push      | `autoPush`       | `PI_CLOUD_SESSIONS_AUTO_PUSH`      | `true`                 |
+| Pull on start  | `pullOnStart`    | `PI_CLOUD_SESSIONS_PULL_ON_START`  | `true`                 |
+| Push debounce  | `pushDebounceMs` | `PI_CLOUD_SESSIONS_DEBOUNCE_MS`    | `4000`                 |
+| Machine label  | `machineId`      | `PI_CLOUD_SESSIONS_MACHINE_ID`     | hostname               |
+| Git repo       | `git.repo`       | `PI_CLOUD_SESSIONS_GIT_REPO`       | —                      |
+| Git branch     | `git.branch`     | `PI_CLOUD_SESSIONS_GIT_BRANCH`     | `main`                 |
+| iCloud folder  | `icloud.dir`     | `PI_CLOUD_SESSIONS_ICLOUD_DIR`     | iCloud Drive/pi-sessions |
+
+## Privacy
+
+Sessions can contain anything you typed or any file content the agent read.
+Use a **private** repo and treat the backend as sensitive. There is no
+encryption layer — the JSONL is stored as-is.
+
+## Install
+
+Place the built extension under a trusted pi extensions directory, or load it
+directly:
+
+```
+pi -e ./packages/cloud-sessions/dist/index.js
+```

--- a/packages/cloud-sessions/README.md
+++ b/packages/cloud-sessions/README.md
@@ -17,6 +17,8 @@ pi stores each session as a JSONL file under
 extension mirrors that tree to the chosen backend:
 
 - On startup it **pulls** newer sessions from the backend into your local store.
+- Every `pollIntervalMs` (default 60s) it **pulls in the background**, so sessions created on another machine show up in `/resume` even while pi is open.
+- Before resuming/switching to a session it **pulls** so the loaded session is the freshest version.
 - After each turn it **pushes** the current state (debounced).
 - On shutdown it flushes a final sync.
 
@@ -61,9 +63,26 @@ The repo is cloned to `~/.config/pi/cloud-sessions/repo` and kept in sync.
 }
 ```
 
+## Resuming on another machine
+
+Everything is automatic — you never have to run a sync command:
+
+1. Use pi on machine A. Sessions push after each turn.
+2. Open pi on machine B (same project path). Startup pull brings A's sessions; background polling keeps them coming even if B was already open.
+3. Run `/resume` — A's session is listed. Pick it and continue.
+
+**Caveat — session must share the same `cwd`.** Sessions are stored per working
+directory (`--<project-path>--`). For a session to appear in `/resume` on machine
+B, B must be in the same absolute project path as A. If your username/home path
+differs between machines, the paths won't match.
+
+**Caveat — no live two-way editing.** The sync is serial: finish on one machine,
+continue on the other. A session already loaded in memory is not hot-reloaded
+when a newer version is pulled.
+
 ## Commands
 
-- `/cloud-sessions-sync` — pull + push now.
+- `/cloud-sessions-sync` — pull + push now (optional; sync is automatic).
 - `/cloud-sessions-status` — show config and current state.
 - `/cloud-sessions-setup` — configure the backend interactively.
 
@@ -77,6 +96,7 @@ All options can be set in `~/.config/pi/cloud-sessions.json` or via env vars:
 | Auto push      | `autoPush`       | `PI_CLOUD_SESSIONS_AUTO_PUSH`      | `true`                 |
 | Pull on start  | `pullOnStart`    | `PI_CLOUD_SESSIONS_PULL_ON_START`  | `true`                 |
 | Push debounce  | `pushDebounceMs` | `PI_CLOUD_SESSIONS_DEBOUNCE_MS`    | `4000`                 |
+| Poll interval  | `pollIntervalMs` | `PI_CLOUD_SESSIONS_POLL_MS`        | `60000` (0 disables)   |
 | Machine label  | `machineId`      | `PI_CLOUD_SESSIONS_MACHINE_ID`     | hostname               |
 | Git repo       | `git.repo`       | `PI_CLOUD_SESSIONS_GIT_REPO`       | —                      |
 | Git branch     | `git.branch`     | `PI_CLOUD_SESSIONS_GIT_BRANCH`     | `main`                 |

--- a/packages/cloud-sessions/README.md
+++ b/packages/cloud-sessions/README.md
@@ -31,7 +31,7 @@ the same file are rare.
 
 Run the setup command inside pi:
 
-```
+```bash
 /cloud-sessions-setup
 ```
 
@@ -113,6 +113,6 @@ encryption layer — the JSONL is stored as-is.
 Place the built extension under a trusted pi extensions directory, or load it
 directly:
 
-```
+```bash
 pi -e ./packages/cloud-sessions/dist/index.js
 ```

--- a/packages/cloud-sessions/package.json
+++ b/packages/cloud-sessions/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@arvoretech/pi-cloud-sessions",
+  "version": "0.1.0",
+  "description": "PI extension that syncs your pi sessions to a cloud backend (private Git repo or iCloud Drive) so you can resume them from any machine",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "lint": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": ">=0.74.0"
+  },
+  "devDependencies": {
+    "@earendil-works/pi-coding-agent": "latest",
+    "@earendil-works/pi-ai": "latest",
+    "@earendil-works/pi-tui": "latest",
+    "@types/node": "^20.10.0",
+    "typescript": "^5.3.0"
+  },
+  "pi": {
+    "extensions": [
+      "./dist/index.js"
+    ]
+  },
+  "keywords": [
+    "pi",
+    "extension",
+    "sessions",
+    "sync",
+    "cloud",
+    "git",
+    "icloud"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/arvoreeducacao/arvore-pi-extensions.git",
+    "directory": "packages/cloud-sessions"
+  },
+  "author": "Arvore",
+  "license": "MIT"
+}

--- a/packages/cloud-sessions/package.json
+++ b/packages/cloud-sessions/package.json
@@ -17,9 +17,9 @@
     "@earendil-works/pi-coding-agent": ">=0.74.0"
   },
   "devDependencies": {
-    "@earendil-works/pi-coding-agent": "latest",
-    "@earendil-works/pi-ai": "latest",
-    "@earendil-works/pi-tui": "latest",
+    "@earendil-works/pi-coding-agent": "^0.79.4",
+    "@earendil-works/pi-ai": "^0.79.4",
+    "@earendil-works/pi-tui": "^0.79.4",
     "@types/node": "^20.10.0",
     "typescript": "^5.3.0"
   },

--- a/packages/cloud-sessions/pnpm-lock.yaml
+++ b/packages/cloud-sessions/pnpm-lock.yaml
@@ -1,0 +1,1341 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      '@earendil-works/pi-ai':
+        specifier: latest
+        version: 0.79.8(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-coding-agent':
+        specifier: latest
+        version: 0.79.8(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-tui':
+        specifier: latest
+        version: 0.79.8
+      '@types/node':
+        specifier: ^20.10.0
+        version: 20.19.43
+      typescript:
+        specifier: ^5.3.0
+        version: 5.9.3
+
+packages:
+
+  '@anthropic-ai/sdk@0.91.1':
+    resolution: {integrity: sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  '@aws-crypto/crc32@5.2.0':
+    resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
+
+  '@aws-crypto/sha256-js@5.2.0':
+    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
+
+  '@aws-crypto/util@5.2.0':
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/client-bedrock-runtime@3.1048.0':
+    resolution: {integrity: sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.974.22':
+    resolution: {integrity: sha512-YofH63shc6YRdXjz80BJkpJW+Bkn0Cuu2dn4Rv7s9G2Idt58tgtzQEWxrR2xVljlVfIBeUjPuULnSVYLke3sUQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.48':
+    resolution: {integrity: sha512-h6FEC95fbexUd6zxm4PdgS82bTcI2PRtUb2ZwMipb/Xr8bPwtf0G8rBo2jp7NA24Mbx2JA8/WingiYpA9RCCyw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.50':
+    resolution: {integrity: sha512-lJO3OLpjvz5m/RSBQmsG/CEUGsvCy5ruxKwPQaOCqxqCMuyYT2BZwQUTDZVVwqQ9LrZKuK24JSa6r31hL/tvkg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.972.55':
+    resolution: {integrity: sha512-TBoF4buBGYhXjdZAryayY2TrkQj2B2KfE/msG4V53XCt+w0EhEwM2JRjx8p2grJ2C6gtH5++SAwEvGMRdi0yyw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.54':
+    resolution: {integrity: sha512-hBWI3wZTdTGiuMfmPts6AWbAjFfRniOQnqx68tc2cQvRKWawFbN9wkLOVPWM1FAOyowZU73mC6Fi+rHSHNyLFw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.57':
+    resolution: {integrity: sha512-u6dClpzNdWf1HGWz4wwhdXi1wiOofCLniM9S4BQQGlLAN9TW7VB+ld5V533GdKrYMaFeBGFqKnj0JCYvynLqwQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.48':
+    resolution: {integrity: sha512-w6VZwojPt12WnEkAUy6Nu4K6sWCbBmR7QX390b0nE6vRvkXbrYr9Lq9VySGkfjiMjpUA87op+J4EgvRmtWIDoQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.972.54':
+    resolution: {integrity: sha512-23uZpIpF2SIFDCa1fcWa202tK4gGeyvX6GIIAjiB8WBsvsVRBMnJ/7dCxHzxf7eZT7GToJg837LDIBnZsl/VUg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.54':
+    resolution: {integrity: sha512-0Iv5QttS6wcATlodYKgvQj6B9Db51rx7NU9fqu0PoLeS4BIgdYMc/QK4smwLwpm5RFrs02V/eLyEFp3FklvlNQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/eventstream-handler-node@3.972.22':
+    resolution: {integrity: sha512-tqPJv0dz4+O0hWGm1a6YekcMZyPhDFs/zH73Von7icaVT5n0Jqvm86typ3jRrG+qoUdPhALOnboRLTmnWQTlYQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-eventstream@3.972.18':
+    resolution: {integrity: sha512-OHpk8YoZi3yexPq8aFt1vN1IxA2zLKvsIR5GpWYylX/ve6kQmY7wxHNSFy/D3t2apMZ16rs76Co4dJWcDyIk3A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-websocket@3.972.30':
+    resolution: {integrity: sha512-kH6N4f/Fzi9r/dYap8EQ+Zk4NOz8pl4AtWKhzAoG2C1/4YkIHok9APp/e+75woreWQq264n+LkrJsJVZ0Q+M1Q==}
+    engines: {node: '>= 14.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.22':
+    resolution: {integrity: sha512-4IwtcYSxEIVw5hcp8ogq0CMbFNZFw7jJUetpfFUhFFeqsa1K8j2Ihg2hnxLyOp3stMZnXda6VzOmPi1AFZQXcg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.35':
+    resolution: {integrity: sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1048.0':
+    resolution: {integrity: sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1071.0':
+    resolution: {integrity: sha512-4LDW2Qob6LoLFuqYSYZq2AyTE9koSE9+i+n5UZcm10GpmQOK0zRD9L4uYlzItiTKksIWgC/qMFChAi3RvKYtMg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.13':
+    resolution: {integrity: sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-locate-window@3.965.8':
+    resolution: {integrity: sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.30':
+    resolution: {integrity: sha512-StElZPEoBquWwNqw1AcfpzEyZqJvFxouG+mpDNYlcH6ZOrqd2CuIryv+8LV8gNHZUOyKyJF3Dq9vxaXEmDR9TQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.2.4':
+    resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
+
+  '@earendil-works/pi-agent-core@0.79.8':
+    resolution: {integrity: sha512-8m5fcqRpoGpq3QY0I/tFXROSTmPwBb1dAuzYZO3XYgjsdCokkRMAGRjA9P8s/UD6Jy9yy69lyE4H6sz/5A1TmQ==}
+    engines: {node: '>=22.19.0'}
+
+  '@earendil-works/pi-ai@0.79.8':
+    resolution: {integrity: sha512-ZpSwaD7oNpsjn9vtEatZQNT9PSdDJXi6rFeY5Qv+OHQGFDKlmcrfJE4ypm4SAc/fBECPs4Rdi3l+YjVtXYrkKw==}
+    engines: {node: '>=22.19.0'}
+    hasBin: true
+
+  '@earendil-works/pi-coding-agent@0.79.8':
+    resolution: {integrity: sha512-wr9oTS/yrwURDXnYrONQgFgV7QDlwslXL/rvKU5X7TRtrGxIhippsRApXqYlRwSeMjb2YzgHMfZ/kAhOqrzoFQ==}
+    engines: {node: '>=22.19.0'}
+    hasBin: true
+
+  '@earendil-works/pi-tui@0.79.8':
+    resolution: {integrity: sha512-QerB+0wUc6eEO8MwvzOQGtzcsbwo6y8VvdxYU6vGcakz6ofJZWhrmwrknp1dCGx3bEtCf+siUIxEzkqvFCzIsg==}
+    engines: {node: '>=22.19.0'}
+
+  '@google/genai@1.52.0':
+    resolution: {integrity: sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.25.2
+    peerDependenciesMeta:
+      '@modelcontextprotocol/sdk':
+        optional: true
+
+  '@mariozechner/clipboard-darwin-arm64@0.3.9':
+    resolution: {integrity: sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@mariozechner/clipboard-darwin-universal@0.3.9':
+    resolution: {integrity: sha512-BGGR4iA9Z2shAjI65eI5xtyb3LYNlDW9X3gxKxDbqtbnREohsrqznov6zpKoIrsRWpzlYVEdKphS7ksJ0/ndSQ==}
+    engines: {node: '>= 10'}
+    os: [darwin]
+
+  '@mariozechner/clipboard-darwin-x64@0.3.9':
+    resolution: {integrity: sha512-4kURmCbS6nt8uYhtmWpUcJWyPHfmAr5dTpXD1nO3pIfa+TSQ9DbrGOYCKH+aEFW47XhQ4Vp8ZTszie+wfFvDKg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@mariozechner/clipboard-linux-arm64-gnu@0.3.9':
+    resolution: {integrity: sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@mariozechner/clipboard-linux-arm64-musl@0.3.9':
+    resolution: {integrity: sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@mariozechner/clipboard-linux-riscv64-gnu@0.3.9':
+    resolution: {integrity: sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@mariozechner/clipboard-linux-x64-gnu@0.3.9':
+    resolution: {integrity: sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@mariozechner/clipboard-linux-x64-musl@0.3.9':
+    resolution: {integrity: sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@mariozechner/clipboard-win32-arm64-msvc@0.3.9':
+    resolution: {integrity: sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@mariozechner/clipboard-win32-x64-msvc@0.3.9':
+    resolution: {integrity: sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@mariozechner/clipboard@0.3.9':
+    resolution: {integrity: sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA==}
+    engines: {node: '>= 10'}
+
+  '@mistralai/mistralai@2.2.6':
+    resolution: {integrity: sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+
+  '@nodable/entities@2.2.0':
+    resolution: {integrity: sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==}
+
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/semantic-conventions@1.41.1':
+    resolution: {integrity: sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==}
+    engines: {node: '>=14'}
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
+
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.1':
+    resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
+
+  '@silvia-odwyer/photon-node@0.3.4':
+    resolution: {integrity: sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==}
+
+  '@smithy/core@3.25.1':
+    resolution: {integrity: sha512-zpDbpXBCBsxfLtG2GEUyfgvHvSFrw5CwDZSNzL0v52gx/c3oPlPbm+7W7num8xs6vyiUBn+bvYPHcQDOXZynCQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.4.1':
+    resolution: {integrity: sha512-TSAF5NHgxEsllbErYWbK8aLnl5L601NGc5VYJlSPsKnf3YlkhdoBN+geGcaU00oiw2OK3QO5LA3QNXiiWhCidQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.5.1':
+    resolution: {integrity: sha512-96JrD1q71anokymx9Iblb+zKmNQYNstlV/25A9ZYIJ2A0rp1r7/GZAIm0bDWSmVvz3DpNOCZuabzsiL+w0UHhw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/is-array-buffer@2.2.0':
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/node-http-handler@4.7.3':
+    resolution: {integrity: sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.8.1':
+    resolution: {integrity: sha512-emtXvoky671puri18ETf64AFIQUGIEA093F2drXpBgB0OGnBLjcwNR3CA2mYu62IAqNsS56xa5lnTxAgPq7cjw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.5.1':
+    resolution: {integrity: sha512-X9rVls3En0z3NtrmguTmpRM0/NqtWUxBjal6fcAkwtsub+gOdLZ6kD+V7xhUgFMGdG14bHbZ7M5QjaRI1+DatQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.15.0':
+    resolution: {integrity: sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-buffer-from@2.2.0':
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@2.3.0':
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
+    engines: {node: '>=14.0.0'}
+
+  '@types/node@20.19.43':
+    resolution: {integrity: sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==}
+
+  '@types/retry@0.12.0':
+    resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
+
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
+  anynum@1.0.1:
+    resolution: {integrity: sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==}
+
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
+
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+    engines: {node: 18 || 20 || >=22}
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
+
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  diff@8.0.4:
+    resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
+    engines: {node: '>=0.3.1'}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
+  fast-xml-builder@1.2.0:
+    resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
+
+  fast-xml-parser@5.7.3:
+    resolution: {integrity: sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==}
+    hasBin: true
+
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+
+  gaxios@7.1.5:
+    resolution: {integrity: sha512-5FZy72Rh8LhtjmvDrKkI+lVhrsQrVKVsItxMoDm5mNQE+xR0WVIIs+jzPSJgBvKVsLi24fZhXJIsNI0bihDzFg==}
+    engines: {node: '>=18'}
+
+  gcp-metadata@8.1.2:
+    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
+    engines: {node: '>=18'}
+
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
+    engines: {node: '>=18'}
+
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
+
+  google-auth-library@10.7.0:
+    resolution: {integrity: sha512-QpTAbNJ36TliZLx3TTtahR8HG0hN9RllL1e3FymOvQSIKK8JmgV58H924ub2wa2DsS3ANjjP1Aw1N+Ramc8hqQ==}
+    engines: {node: '>=18'}
+
+  google-logging-utils@1.1.3:
+    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
+    engines: {node: '>=14'}
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  highlight.js@10.7.3:
+    resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
+
+  hosted-git-info@9.0.3:
+    resolution: {integrity: sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
+  ignore@7.0.5:
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
+    engines: {node: '>= 4'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  jiti@2.7.0:
+    resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
+    hasBin: true
+
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
+
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
+  lru-cache@11.5.1:
+    resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
+    engines: {node: 20 || >=22}
+
+  marked@18.0.5:
+    resolution: {integrity: sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==}
+    engines: {node: '>= 20'}
+    hasBin: true
+
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  openai@6.26.0:
+    resolution: {integrity: sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
+
+  p-retry@4.6.2:
+    resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
+    engines: {node: '>=8'}
+
+  partial-json@0.1.7:
+    resolution: {integrity: sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==}
+
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
+    engines: {node: '>=14.0.0'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
+
+  proper-lockfile@4.1.2:
+    resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
+
+  protobufjs@7.6.4:
+    resolution: {integrity: sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==}
+    engines: {node: '>=12.0.0'}
+
+  retry@0.12.0:
+    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
+    engines: {node: '>= 4'}
+
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  semver@7.8.0:
+    resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
+  strnum@2.4.1:
+    resolution: {integrity: sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==}
+
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  typebox@1.1.38:
+    resolution: {integrity: sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@8.5.0:
+    resolution: {integrity: sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==}
+    engines: {node: '>=22.19.0'}
+
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xml-naming@0.1.0:
+    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
+    engines: {node: '>=16.0.0'}
+
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
+snapshots:
+
+  '@anthropic-ai/sdk@0.91.1(zod@4.4.3)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 4.4.3
+
+  '@aws-crypto/crc32@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.13
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.13
+      '@aws-sdk/util-locate-window': 3.965.8
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-js@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.13
+      tslib: 2.8.1
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-crypto/util@5.2.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.13
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-bedrock-runtime@3.1048.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/credential-provider-node': 3.972.57
+      '@aws-sdk/eventstream-handler-node': 3.972.22
+      '@aws-sdk/middleware-eventstream': 3.972.18
+      '@aws-sdk/middleware-websocket': 3.972.30
+      '@aws-sdk/token-providers': 3.1048.0
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/fetch-http-handler': 5.5.1
+      '@smithy/node-http-handler': 4.7.3
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.974.22':
+    dependencies:
+      '@aws-sdk/types': 3.973.13
+      '@aws-sdk/xml-builder': 3.972.30
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/core': 3.25.1
+      '@smithy/signature-v4': 5.5.1
+      '@smithy/types': 4.15.0
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.48':
+    dependencies:
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.50':
+    dependencies:
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/fetch-http-handler': 5.5.1
+      '@smithy/node-http-handler': 4.8.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.972.55':
+    dependencies:
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/credential-provider-env': 3.972.48
+      '@aws-sdk/credential-provider-http': 3.972.50
+      '@aws-sdk/credential-provider-login': 3.972.54
+      '@aws-sdk/credential-provider-process': 3.972.48
+      '@aws-sdk/credential-provider-sso': 3.972.54
+      '@aws-sdk/credential-provider-web-identity': 3.972.54
+      '@aws-sdk/nested-clients': 3.997.22
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/credential-provider-imds': 4.4.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.54':
+    dependencies:
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/nested-clients': 3.997.22
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.57':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.48
+      '@aws-sdk/credential-provider-http': 3.972.50
+      '@aws-sdk/credential-provider-ini': 3.972.55
+      '@aws-sdk/credential-provider-process': 3.972.48
+      '@aws-sdk/credential-provider-sso': 3.972.54
+      '@aws-sdk/credential-provider-web-identity': 3.972.54
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/credential-provider-imds': 4.4.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.48':
+    dependencies:
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.972.54':
+    dependencies:
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/nested-clients': 3.997.22
+      '@aws-sdk/token-providers': 3.1071.0
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.54':
+    dependencies:
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/nested-clients': 3.997.22
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/eventstream-handler-node@3.972.22':
+    dependencies:
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-eventstream@3.972.18':
+    dependencies:
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-websocket@3.972.30':
+    dependencies:
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/fetch-http-handler': 5.5.1
+      '@smithy/signature-v4': 5.5.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.22':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/signature-v4-multi-region': 3.996.35
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/fetch-http-handler': 5.5.1
+      '@smithy/node-http-handler': 4.8.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.35':
+    dependencies:
+      '@aws-sdk/types': 3.973.13
+      '@smithy/signature-v4': 5.5.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1048.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/nested-clients': 3.997.22
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1071.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/nested-clients': 3.997.22
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.973.13':
+    dependencies:
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/util-locate-window@3.965.8':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.30':
+    dependencies:
+      '@smithy/types': 4.15.0
+      fast-xml-parser: 5.7.3
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.2.4': {}
+
+  '@babel/runtime@7.29.7': {}
+
+  '@earendil-works/pi-agent-core@0.79.8(ws@8.21.0)(zod@4.4.3)':
+    dependencies:
+      '@earendil-works/pi-ai': 0.79.8(ws@8.21.0)(zod@4.4.3)
+      ignore: 7.0.5
+      typebox: 1.1.38
+      yaml: 2.9.0
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-ai@0.79.8(ws@8.21.0)(zod@4.4.3)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
+      '@aws-sdk/client-bedrock-runtime': 3.1048.0
+      '@google/genai': 1.52.0
+      '@mistralai/mistralai': 2.2.6(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.0
+      '@smithy/node-http-handler': 4.7.3
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      openai: 6.26.0(ws@8.21.0)(zod@4.4.3)
+      partial-json: 0.1.7
+      typebox: 1.1.38
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-coding-agent@0.79.8(ws@8.21.0)(zod@4.4.3)':
+    dependencies:
+      '@earendil-works/pi-agent-core': 0.79.8(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.79.8(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-tui': 0.79.8
+      '@silvia-odwyer/photon-node': 0.3.4
+      chalk: 5.6.2
+      cross-spawn: 7.0.6
+      diff: 8.0.4
+      glob: 13.0.6
+      highlight.js: 10.7.3
+      hosted-git-info: 9.0.3
+      ignore: 7.0.5
+      jiti: 2.7.0
+      minimatch: 10.2.5
+      proper-lockfile: 4.1.2
+      semver: 7.8.0
+      typebox: 1.1.38
+      undici: 8.5.0
+      yaml: 2.9.0
+    optionalDependencies:
+      '@mariozechner/clipboard': 0.3.9
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-tui@0.79.8':
+    dependencies:
+      get-east-asian-width: 1.6.0
+      marked: 18.0.5
+
+  '@google/genai@1.52.0':
+    dependencies:
+      google-auth-library: 10.7.0
+      p-retry: 4.6.2
+      protobufjs: 7.6.4
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@mariozechner/clipboard-darwin-arm64@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-darwin-universal@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-darwin-x64@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-linux-arm64-gnu@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-linux-arm64-musl@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-linux-riscv64-gnu@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-linux-x64-gnu@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-linux-x64-musl@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-win32-arm64-msvc@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-win32-x64-msvc@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard@0.3.9':
+    optionalDependencies:
+      '@mariozechner/clipboard-darwin-arm64': 0.3.9
+      '@mariozechner/clipboard-darwin-universal': 0.3.9
+      '@mariozechner/clipboard-darwin-x64': 0.3.9
+      '@mariozechner/clipboard-linux-arm64-gnu': 0.3.9
+      '@mariozechner/clipboard-linux-arm64-musl': 0.3.9
+      '@mariozechner/clipboard-linux-riscv64-gnu': 0.3.9
+      '@mariozechner/clipboard-linux-x64-gnu': 0.3.9
+      '@mariozechner/clipboard-linux-x64-musl': 0.3.9
+      '@mariozechner/clipboard-win32-arm64-msvc': 0.3.9
+      '@mariozechner/clipboard-win32-x64-msvc': 0.3.9
+    optional: true
+
+  '@mistralai/mistralai@2.2.6(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/semantic-conventions': 1.41.1
+      ws: 8.21.0
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@nodable/entities@2.2.0': {}
+
+  '@opentelemetry/api@1.9.0': {}
+
+  '@opentelemetry/semantic-conventions@1.41.1': {}
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.1': {}
+
+  '@protobufjs/fetch@1.1.1':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.1': {}
+
+  '@silvia-odwyer/photon-node@0.3.4': {}
+
+  '@smithy/core@3.25.1':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.4.1':
+    dependencies:
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.5.1':
+    dependencies:
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.7.3':
+    dependencies:
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.8.1':
+    dependencies:
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.5.1':
+    dependencies:
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@smithy/types@4.15.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@2.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@2.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
+
+  '@types/node@20.19.43':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@types/retry@0.12.0': {}
+
+  agent-base@7.1.4: {}
+
+  anynum@1.0.1: {}
+
+  balanced-match@4.0.4: {}
+
+  base64-js@1.5.1: {}
+
+  bignumber.js@9.3.1: {}
+
+  bowser@2.14.1: {}
+
+  brace-expansion@5.0.6:
+    dependencies:
+      balanced-match: 4.0.4
+
+  buffer-equal-constant-time@1.0.1: {}
+
+  chalk@5.6.2: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  data-uri-to-buffer@4.0.1: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  diff@8.0.4: {}
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  extend@3.0.2: {}
+
+  fast-xml-builder@1.2.0:
+    dependencies:
+      path-expression-matcher: 1.5.0
+      xml-naming: 0.1.0
+
+  fast-xml-parser@5.7.3:
+    dependencies:
+      '@nodable/entities': 2.2.0
+      fast-xml-builder: 1.2.0
+      path-expression-matcher: 1.5.0
+      strnum: 2.4.1
+
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
+
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
+
+  gaxios@7.1.5:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@8.1.2:
+    dependencies:
+      gaxios: 7.1.5
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  get-east-asian-width@1.6.0: {}
+
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      path-scurry: 2.0.2
+
+  google-auth-library@10.7.0:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.1.5
+      gcp-metadata: 8.1.2
+      google-logging-utils: 1.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  google-logging-utils@1.1.3: {}
+
+  graceful-fs@4.2.11: {}
+
+  highlight.js@10.7.3: {}
+
+  hosted-git-info@9.0.3:
+    dependencies:
+      lru-cache: 11.5.1
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  ignore@7.0.5: {}
+
+  isexe@2.0.0: {}
+
+  jiti@2.7.0: {}
+
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
+
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.7
+      ts-algebra: 2.0.0
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
+
+  long@5.3.2: {}
+
+  lru-cache@11.5.1: {}
+
+  marked@18.0.5: {}
+
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.6
+
+  minipass@7.1.3: {}
+
+  ms@2.1.3: {}
+
+  node-domexception@1.0.0: {}
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
+
+  openai@6.26.0(ws@8.21.0)(zod@4.4.3):
+    optionalDependencies:
+      ws: 8.21.0
+      zod: 4.4.3
+
+  p-retry@4.6.2:
+    dependencies:
+      '@types/retry': 0.12.0
+      retry: 0.13.1
+
+  partial-json@0.1.7: {}
+
+  path-expression-matcher@1.5.0: {}
+
+  path-key@3.1.1: {}
+
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.5.1
+      minipass: 7.1.3
+
+  proper-lockfile@4.1.2:
+    dependencies:
+      graceful-fs: 4.2.11
+      retry: 0.12.0
+      signal-exit: 3.0.7
+
+  protobufjs@7.6.4:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.1
+      '@types/node': 20.19.43
+      long: 5.3.2
+
+  retry@0.12.0: {}
+
+  retry@0.13.1: {}
+
+  safe-buffer@5.2.1: {}
+
+  semver@7.8.0: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  signal-exit@3.0.7: {}
+
+  strnum@2.4.1:
+    dependencies:
+      anynum: 1.0.1
+
+  ts-algebra@2.0.0: {}
+
+  tslib@2.8.1: {}
+
+  typebox@1.1.38: {}
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}
+
+  undici@8.5.0: {}
+
+  web-streams-polyfill@3.3.3: {}
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  ws@8.21.0: {}
+
+  xml-naming@0.1.0: {}
+
+  yaml@2.9.0: {}
+
+  zod-to-json-schema@3.25.2(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
+
+  zod@4.4.3: {}

--- a/packages/cloud-sessions/src/config.ts
+++ b/packages/cloud-sessions/src/config.ts
@@ -79,6 +79,15 @@ function asBool(value: string | undefined, fallback: boolean): boolean {
   return value !== "0" && value.toLowerCase() !== "false";
 }
 
+function numberFrom(value: string | undefined, fileValue: number | undefined, fallback: number): number {
+  if (value !== undefined && value.trim() !== "") {
+    const n = Number(value);
+    if (Number.isFinite(n)) return n;
+  }
+  if (typeof fileValue === "number" && Number.isFinite(fileValue)) return fileValue;
+  return fallback;
+}
+
 export async function loadConfig(): Promise<CloudSessionsConfig> {
   const raw = await readRawConfig();
 
@@ -86,11 +95,10 @@ export async function loadConfig(): Promise<CloudSessionsConfig> {
     provider: resolveProvider(raw),
     autoPush: asBool(process.env.PI_CLOUD_SESSIONS_AUTO_PUSH, raw.autoPush ?? true),
     pullOnStart: asBool(process.env.PI_CLOUD_SESSIONS_PULL_ON_START, raw.pullOnStart ?? true),
-    pushDebounceMs: Number(process.env.PI_CLOUD_SESSIONS_DEBOUNCE_MS) || raw.pushDebounceMs || 4000,
-    pollIntervalMs:
-      Number(process.env.PI_CLOUD_SESSIONS_POLL_MS) ||
-      (raw.pollIntervalMs === undefined ? 60000 : raw.pollIntervalMs),
-    machineId: raw.machineId || defaultMachineId(),
+    pushDebounceMs: numberFrom(process.env.PI_CLOUD_SESSIONS_DEBOUNCE_MS, raw.pushDebounceMs, 4000),
+    pollIntervalMs: numberFrom(process.env.PI_CLOUD_SESSIONS_POLL_MS, raw.pollIntervalMs, 60000),
+    machineId:
+      process.env.PI_CLOUD_SESSIONS_MACHINE_ID || raw.machineId || defaultMachineId(),
     git: {
       repo: process.env.PI_CLOUD_SESSIONS_GIT_REPO || raw.git?.repo || "",
       branch: process.env.PI_CLOUD_SESSIONS_GIT_BRANCH || raw.git?.branch || "main",
@@ -100,6 +108,10 @@ export async function loadConfig(): Promise<CloudSessionsConfig> {
       dir: process.env.PI_CLOUD_SESSIONS_ICLOUD_DIR || raw.icloud?.dir || defaultIcloudDir(),
     },
   };
+}
+
+export async function readRawConfigFile(): Promise<Record<string, unknown>> {
+  return readRawConfig() as Promise<Record<string, unknown>>;
 }
 
 export function isProviderConfigured(config: CloudSessionsConfig): boolean {

--- a/packages/cloud-sessions/src/config.ts
+++ b/packages/cloud-sessions/src/config.ts
@@ -21,6 +21,7 @@ export interface CloudSessionsConfig {
   autoPush: boolean;
   pullOnStart: boolean;
   pushDebounceMs: number;
+  pollIntervalMs: number;
   machineId: string;
   git: GitProviderConfig;
   icloud: IcloudProviderConfig;
@@ -53,6 +54,7 @@ interface RawConfig {
   autoPush?: boolean;
   pullOnStart?: boolean;
   pushDebounceMs?: number;
+  pollIntervalMs?: number;
   machineId?: string;
   git?: Partial<GitProviderConfig>;
   icloud?: Partial<IcloudProviderConfig>;
@@ -85,6 +87,9 @@ export async function loadConfig(): Promise<CloudSessionsConfig> {
     autoPush: asBool(process.env.PI_CLOUD_SESSIONS_AUTO_PUSH, raw.autoPush ?? true),
     pullOnStart: asBool(process.env.PI_CLOUD_SESSIONS_PULL_ON_START, raw.pullOnStart ?? true),
     pushDebounceMs: Number(process.env.PI_CLOUD_SESSIONS_DEBOUNCE_MS) || raw.pushDebounceMs || 4000,
+    pollIntervalMs:
+      Number(process.env.PI_CLOUD_SESSIONS_POLL_MS) ||
+      (raw.pollIntervalMs === undefined ? 60000 : raw.pollIntervalMs),
     machineId: raw.machineId || defaultMachineId(),
     git: {
       repo: process.env.PI_CLOUD_SESSIONS_GIT_REPO || raw.git?.repo || "",

--- a/packages/cloud-sessions/src/config.ts
+++ b/packages/cloud-sessions/src/config.ts
@@ -1,0 +1,111 @@
+import { execSync } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export type ProviderKind = "git" | "icloud";
+
+export interface GitProviderConfig {
+  repo: string;
+  branch: string;
+  remoteName: string;
+}
+
+export interface IcloudProviderConfig {
+  dir: string;
+}
+
+export interface CloudSessionsConfig {
+  provider: ProviderKind;
+  autoPush: boolean;
+  pullOnStart: boolean;
+  pushDebounceMs: number;
+  machineId: string;
+  git: GitProviderConfig;
+  icloud: IcloudProviderConfig;
+}
+
+const CONFIG_DIR = join(homedir(), ".config", "pi");
+const CONFIG_FILE = join(CONFIG_DIR, "cloud-sessions.json");
+
+function defaultIcloudDir(): string {
+  return join(
+    homedir(),
+    "Library",
+    "Mobile Documents",
+    "com~apple~CloudDocs",
+    "pi-sessions",
+  );
+}
+
+function defaultMachineId(): string {
+  if (process.env.PI_CLOUD_SESSIONS_MACHINE_ID) return process.env.PI_CLOUD_SESSIONS_MACHINE_ID;
+  if (process.env.HOSTNAME) return process.env.HOSTNAME;
+  if (process.env.HOST) return process.env.HOST;
+  try { return execSync("hostname -s", { encoding: "utf-8" }).trim(); } catch { /* continue */ }
+  try { return execSync("scutil --get ComputerName", { encoding: "utf-8" }).trim().replace(/\s+/g, "-"); } catch { /* continue */ }
+  return "unknown-machine";
+}
+
+interface RawConfig {
+  provider?: string;
+  autoPush?: boolean;
+  pullOnStart?: boolean;
+  pushDebounceMs?: number;
+  machineId?: string;
+  git?: Partial<GitProviderConfig>;
+  icloud?: Partial<IcloudProviderConfig>;
+}
+
+async function readRawConfig(): Promise<RawConfig> {
+  if (!existsSync(CONFIG_FILE)) return {};
+  try {
+    return JSON.parse(await readFile(CONFIG_FILE, "utf-8")) as RawConfig;
+  } catch {
+    return {};
+  }
+}
+
+function resolveProvider(raw: RawConfig): ProviderKind {
+  const value = process.env.PI_CLOUD_SESSIONS_PROVIDER || raw.provider;
+  return value === "icloud" ? "icloud" : "git";
+}
+
+function asBool(value: string | undefined, fallback: boolean): boolean {
+  if (value === undefined) return fallback;
+  return value !== "0" && value.toLowerCase() !== "false";
+}
+
+export async function loadConfig(): Promise<CloudSessionsConfig> {
+  const raw = await readRawConfig();
+
+  return {
+    provider: resolveProvider(raw),
+    autoPush: asBool(process.env.PI_CLOUD_SESSIONS_AUTO_PUSH, raw.autoPush ?? true),
+    pullOnStart: asBool(process.env.PI_CLOUD_SESSIONS_PULL_ON_START, raw.pullOnStart ?? true),
+    pushDebounceMs: Number(process.env.PI_CLOUD_SESSIONS_DEBOUNCE_MS) || raw.pushDebounceMs || 4000,
+    machineId: raw.machineId || defaultMachineId(),
+    git: {
+      repo: process.env.PI_CLOUD_SESSIONS_GIT_REPO || raw.git?.repo || "",
+      branch: process.env.PI_CLOUD_SESSIONS_GIT_BRANCH || raw.git?.branch || "main",
+      remoteName: raw.git?.remoteName || "origin",
+    },
+    icloud: {
+      dir: process.env.PI_CLOUD_SESSIONS_ICLOUD_DIR || raw.icloud?.dir || defaultIcloudDir(),
+    },
+  };
+}
+
+export function isProviderConfigured(config: CloudSessionsConfig): boolean {
+  if (config.provider === "git") return config.git.repo.length > 0;
+  return config.icloud.dir.length > 0;
+}
+
+export function configFilePath(): string {
+  return CONFIG_FILE;
+}
+
+export function configDir(): string {
+  return CONFIG_DIR;
+}

--- a/packages/cloud-sessions/src/index.ts
+++ b/packages/cloud-sessions/src/index.ts
@@ -1,0 +1,182 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import {
+  configFilePath,
+  isProviderConfigured,
+  loadConfig,
+  type CloudSessionsConfig,
+} from "./config.js";
+import { Sync, type SyncResult } from "./sync.js";
+
+const STATUS_KEY = "cloud-sessions";
+
+let syncing = false;
+let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+type Notify = (key: string, text: string | undefined) => void;
+
+function summarize(result: SyncResult): string {
+  const parts: string[] = [];
+  if (result.pushed.length) parts.push(`↑${result.pushed.length}`);
+  if (result.pulled.length) parts.push(`↓${result.pulled.length}`);
+  if (parts.length === 0) return "up to date";
+  return parts.join(" ");
+}
+
+async function runSync(setStatus: Notify): Promise<SyncResult | null> {
+  if (syncing) return null;
+  syncing = true;
+  try {
+    const config = await loadConfig();
+    if (!isProviderConfigured(config)) {
+      setStatus(STATUS_KEY, "sessions: not configured");
+      return null;
+    }
+    setStatus(STATUS_KEY, `sessions: syncing (${config.provider})`);
+    const sync = new Sync(config);
+    const result = await sync.run();
+    setStatus(STATUS_KEY, `sessions: ${config.provider} ${summarize(result)}`);
+    return result;
+  } catch (error) {
+    setStatus(STATUS_KEY, "sessions: sync error");
+    throw error;
+  } finally {
+    syncing = false;
+  }
+}
+
+function scheduleSync(config: CloudSessionsConfig, setStatus: Notify): void {
+  if (debounceTimer) clearTimeout(debounceTimer);
+  debounceTimer = setTimeout(() => {
+    debounceTimer = null;
+    void runSync(setStatus).catch(() => {});
+  }, config.pushDebounceMs);
+}
+
+async function writeConfig(partial: Record<string, unknown>): Promise<void> {
+  await mkdir(dirname(configFilePath()), { recursive: true });
+  await writeFile(configFilePath(), JSON.stringify(partial, null, 2));
+}
+
+export default function cloudSessions(pi: ExtensionAPI): void {
+  pi.on("session_start", async (event, ctx) => {
+    const config = await loadConfig();
+    const setStatus: Notify = (k, t) => ctx.ui.setStatus(k, t);
+
+    if (!isProviderConfigured(config)) {
+      setStatus(STATUS_KEY, "sessions: not configured");
+      return;
+    }
+    setStatus(STATUS_KEY, `sessions: ${config.provider}`);
+
+    if (config.pullOnStart && event.reason === "startup") {
+      await runSync(setStatus).catch((error) => {
+        ctx.ui.notify(
+          `cloud-sessions sync failed: ${error instanceof Error ? error.message : String(error)}`,
+          "warning",
+        );
+      });
+    }
+  });
+
+  pi.on("turn_end", async (_event, ctx) => {
+    const config = await loadConfig();
+    if (!config.autoPush || !isProviderConfigured(config)) return;
+    scheduleSync(config, (k, t) => ctx.ui.setStatus(k, t));
+  });
+
+  pi.on("session_shutdown", async (_event, ctx) => {
+    if (debounceTimer) {
+      clearTimeout(debounceTimer);
+      debounceTimer = null;
+    }
+    const config = await loadConfig();
+    if (!config.autoPush || !isProviderConfigured(config)) return;
+    await runSync((k, t) => ctx.ui.setStatus(k, t)).catch(() => {});
+  });
+
+  pi.registerCommand("cloud-sessions-sync", {
+    description: "Sync pi sessions with the cloud backend now (pull + push)",
+    handler: async (_args, ctx) => {
+      try {
+        const result = await runSync((k, t) => ctx.ui.setStatus(k, t));
+        if (!result) {
+          ctx.ui.notify(
+            "cloud-sessions is not configured. Run /cloud-sessions-setup.",
+            "warning",
+          );
+          return;
+        }
+        ctx.ui.notify(
+          `Synced: ${result.pushed.length} pushed, ${result.pulled.length} pulled, ${result.unchanged} unchanged.`,
+          "info",
+        );
+      } catch (error) {
+        ctx.ui.notify(
+          `Sync failed: ${error instanceof Error ? error.message : String(error)}`,
+          "error",
+        );
+      }
+    },
+  });
+
+  pi.registerCommand("cloud-sessions-status", {
+    description: "Show cloud-sessions configuration and status",
+    handler: async (_args, ctx) => {
+      const config = await loadConfig();
+      const lines = [
+        `provider: ${config.provider}`,
+        `configured: ${isProviderConfigured(config) ? "yes" : "no"}`,
+        `autoPush: ${config.autoPush}`,
+        `pullOnStart: ${config.pullOnStart}`,
+        `machineId: ${config.machineId}`,
+        config.provider === "git"
+          ? `git repo: ${config.git.repo || "(unset)"} [${config.git.branch}]`
+          : `icloud dir: ${config.icloud.dir}`,
+        `config file: ${configFilePath()}`,
+      ];
+      ctx.ui.notify(lines.join("\n"), "info");
+    },
+  });
+
+  pi.registerCommand("cloud-sessions-setup", {
+    description: "Configure the cloud-sessions backend (git repo or iCloud folder)",
+    handler: async (_args, ctx) => {
+      const provider = await ctx.ui.select(
+        "Cloud sessions backend",
+        ["git", "icloud"],
+      );
+      if (!provider) return;
+
+      if (provider === "git") {
+        const repo = await ctx.ui.input(
+          "Private git repo URL",
+          "git@github.com:you/pi-sessions.git",
+        );
+        if (!repo) {
+          ctx.ui.notify("Setup cancelled: repo is required.", "warning");
+          return;
+        }
+        const branch = (await ctx.ui.input("Branch", "main")) || "main";
+        await writeConfig({ provider: "git", git: { repo, branch } });
+        ctx.ui.notify(
+          `Saved git backend to ${configFilePath()}. Run /cloud-sessions-sync.`,
+          "info",
+        );
+      } else {
+        const config = await loadConfig();
+        const dir =
+          (await ctx.ui.input("iCloud sessions folder", config.icloud.dir)) ||
+          config.icloud.dir;
+        await writeConfig({ provider: "icloud", icloud: { dir } });
+        ctx.ui.notify(
+          `Saved iCloud backend to ${configFilePath()}. Run /cloud-sessions-sync.`,
+          "info",
+        );
+      }
+
+      ctx.ui.setStatus(STATUS_KEY, `sessions: ${provider}`);
+    },
+  });
+}

--- a/packages/cloud-sessions/src/index.ts
+++ b/packages/cloud-sessions/src/index.ts
@@ -5,13 +5,14 @@ import {
   configFilePath,
   isProviderConfigured,
   loadConfig,
+  readRawConfigFile,
   type CloudSessionsConfig,
 } from "./config.js";
 import { Sync, type SyncResult } from "./sync.js";
 
 const STATUS_KEY = "cloud-sessions";
 
-let syncing = false;
+let activeSync: Promise<SyncResult | null> | null = null;
 let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 let pollTimer: ReturnType<typeof setInterval> | null = null;
 
@@ -26,25 +27,27 @@ function summarize(result: SyncResult): string {
 }
 
 async function runSync(setStatus: Notify): Promise<SyncResult | null> {
-  if (syncing) return null;
-  syncing = true;
-  try {
-    const config = await loadConfig();
-    if (!isProviderConfigured(config)) {
-      setStatus(STATUS_KEY, "sessions: not configured");
-      return null;
+  if (activeSync) return activeSync;
+  activeSync = (async () => {
+    try {
+      const config = await loadConfig();
+      if (!isProviderConfigured(config)) {
+        setStatus(STATUS_KEY, "sessions: not configured");
+        return null;
+      }
+      setStatus(STATUS_KEY, `sessions: syncing (${config.provider})`);
+      const sync = new Sync(config);
+      const result = await sync.run();
+      setStatus(STATUS_KEY, `sessions: ${config.provider} ${summarize(result)}`);
+      return result;
+    } catch (error) {
+      setStatus(STATUS_KEY, "sessions: sync error");
+      throw error;
+    } finally {
+      activeSync = null;
     }
-    setStatus(STATUS_KEY, `sessions: syncing (${config.provider})`);
-    const sync = new Sync(config);
-    const result = await sync.run();
-    setStatus(STATUS_KEY, `sessions: ${config.provider} ${summarize(result)}`);
-    return result;
-  } catch (error) {
-    setStatus(STATUS_KEY, "sessions: sync error");
-    throw error;
-  } finally {
-    syncing = false;
-  }
+  })();
+  return activeSync;
 }
 
 function scheduleSync(config: CloudSessionsConfig, setStatus: Notify): void {
@@ -76,8 +79,16 @@ function stopTimers(): void {
 }
 
 async function writeConfig(partial: Record<string, unknown>): Promise<void> {
+  const current = await readRawConfigFile();
+  const merged: Record<string, unknown> = { ...current, ...partial };
+  if (partial.git || current.git) {
+    merged.git = { ...(current.git as object), ...(partial.git as object) };
+  }
+  if (partial.icloud || current.icloud) {
+    merged.icloud = { ...(current.icloud as object), ...(partial.icloud as object) };
+  }
   await mkdir(dirname(configFilePath()), { recursive: true });
-  await writeFile(configFilePath(), JSON.stringify(partial, null, 2));
+  await writeFile(configFilePath(), JSON.stringify(merged, null, 2));
 }
 
 export default function cloudSessions(pi: ExtensionAPI): void {

--- a/packages/cloud-sessions/src/index.ts
+++ b/packages/cloud-sessions/src/index.ts
@@ -13,6 +13,7 @@ const STATUS_KEY = "cloud-sessions";
 
 let syncing = false;
 let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+let pollTimer: ReturnType<typeof setInterval> | null = null;
 
 type Notify = (key: string, text: string | undefined) => void;
 
@@ -54,6 +55,26 @@ function scheduleSync(config: CloudSessionsConfig, setStatus: Notify): void {
   }, config.pushDebounceMs);
 }
 
+function startPolling(config: CloudSessionsConfig, setStatus: Notify): void {
+  if (pollTimer) clearInterval(pollTimer);
+  if (config.pollIntervalMs <= 0) return;
+  pollTimer = setInterval(() => {
+    void runSync(setStatus).catch(() => {});
+  }, config.pollIntervalMs);
+  if (typeof pollTimer.unref === "function") pollTimer.unref();
+}
+
+function stopTimers(): void {
+  if (debounceTimer) {
+    clearTimeout(debounceTimer);
+    debounceTimer = null;
+  }
+  if (pollTimer) {
+    clearInterval(pollTimer);
+    pollTimer = null;
+  }
+}
+
 async function writeConfig(partial: Record<string, unknown>): Promise<void> {
   await mkdir(dirname(configFilePath()), { recursive: true });
   await writeFile(configFilePath(), JSON.stringify(partial, null, 2));
@@ -78,6 +99,14 @@ export default function cloudSessions(pi: ExtensionAPI): void {
         );
       });
     }
+
+    startPolling(config, setStatus);
+  });
+
+  pi.on("session_before_switch", async (_event, ctx) => {
+    const config = await loadConfig();
+    if (!isProviderConfigured(config)) return;
+    await runSync((k, t) => ctx.ui.setStatus(k, t)).catch(() => {});
   });
 
   pi.on("turn_end", async (_event, ctx) => {
@@ -87,10 +116,7 @@ export default function cloudSessions(pi: ExtensionAPI): void {
   });
 
   pi.on("session_shutdown", async (_event, ctx) => {
-    if (debounceTimer) {
-      clearTimeout(debounceTimer);
-      debounceTimer = null;
-    }
+    stopTimers();
     const config = await loadConfig();
     if (!config.autoPush || !isProviderConfigured(config)) return;
     await runSync((k, t) => ctx.ui.setStatus(k, t)).catch(() => {});
@@ -130,6 +156,7 @@ export default function cloudSessions(pi: ExtensionAPI): void {
         `configured: ${isProviderConfigured(config) ? "yes" : "no"}`,
         `autoPush: ${config.autoPush}`,
         `pullOnStart: ${config.pullOnStart}`,
+        `pollIntervalMs: ${config.pollIntervalMs}`,
         `machineId: ${config.machineId}`,
         config.provider === "git"
           ? `git repo: ${config.git.repo || "(unset)"} [${config.git.branch}]`
@@ -161,7 +188,7 @@ export default function cloudSessions(pi: ExtensionAPI): void {
         const branch = (await ctx.ui.input("Branch", "main")) || "main";
         await writeConfig({ provider: "git", git: { repo, branch } });
         ctx.ui.notify(
-          `Saved git backend to ${configFilePath()}. Run /cloud-sessions-sync.`,
+          `Saved git backend to ${configFilePath()}. Syncing automatically from now on.`,
           "info",
         );
       } else {
@@ -171,7 +198,7 @@ export default function cloudSessions(pi: ExtensionAPI): void {
           config.icloud.dir;
         await writeConfig({ provider: "icloud", icloud: { dir } });
         ctx.ui.notify(
-          `Saved iCloud backend to ${configFilePath()}. Run /cloud-sessions-sync.`,
+          `Saved iCloud backend to ${configFilePath()}. Syncing automatically from now on.`,
           "info",
         );
       }

--- a/packages/cloud-sessions/src/providers/git.ts
+++ b/packages/cloud-sessions/src/providers/git.ts
@@ -1,0 +1,80 @@
+import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import type { GitProviderConfig } from "../config.js";
+import { configDir } from "../config.js";
+import { copyInto, listJsonlIn } from "./mirror.js";
+import type { RemoteFile, SyncProvider } from "./types.js";
+
+const exec = promisify(execFile);
+
+export class GitProvider implements SyncProvider {
+  readonly kind = "git";
+  private readonly repo: string;
+  private readonly branch: string;
+  private readonly remoteName: string;
+  private readonly clonePath: string;
+
+  constructor(config: GitProviderConfig) {
+    this.repo = config.repo;
+    this.branch = config.branch;
+    this.remoteName = config.remoteName;
+    this.clonePath = join(configDir(), "cloud-sessions", "repo");
+  }
+
+  private async git(args: string[]): Promise<string> {
+    const { stdout } = await exec("git", ["-C", this.clonePath, ...args], {
+      maxBuffer: 32 * 1024 * 1024,
+    });
+    return stdout.trim();
+  }
+
+  private isCloned(): boolean {
+    return existsSync(join(this.clonePath, ".git"));
+  }
+
+  async ensureReady(): Promise<void> {
+    if (this.isCloned()) return;
+    await mkdir(join(configDir(), "cloud-sessions"), { recursive: true });
+    await exec("git", ["clone", "--branch", this.branch, this.repo, this.clonePath]).catch(
+      async () => {
+        await exec("git", ["clone", this.repo, this.clonePath]);
+        await this.git(["checkout", "-B", this.branch]);
+      },
+    );
+    await this.configureIdentity();
+  }
+
+  private async configureIdentity(): Promise<void> {
+    await this.git(["config", "user.name", "pi-cloud-sessions"]).catch(() => "");
+    await this.git(["config", "user.email", "pi-cloud-sessions@local"]).catch(() => "");
+  }
+
+  async pull(): Promise<void> {
+    await this.ensureReady();
+    await this.git(["fetch", this.remoteName, this.branch]).catch(() => "");
+    await this.git(["reset", "--hard", `${this.remoteName}/${this.branch}`]).catch(() => "");
+  }
+
+  async listRemote(): Promise<RemoteFile[]> {
+    return listJsonlIn(this.clonePath);
+  }
+
+  mirrorPath(relativePath: string): string {
+    return join(this.clonePath, relativePath);
+  }
+
+  async stageFromLocal(relativePath: string, localAbsolutePath: string): Promise<void> {
+    await copyInto(this.clonePath, relativePath, localAbsolutePath);
+  }
+
+  async push(message: string): Promise<void> {
+    await this.git(["add", "-A"]);
+    const status = await this.git(["status", "--porcelain"]);
+    if (status.length === 0) return;
+    await this.git(["commit", "-m", message]);
+    await this.git(["push", this.remoteName, `HEAD:${this.branch}`]);
+  }
+}

--- a/packages/cloud-sessions/src/providers/git.ts
+++ b/packages/cloud-sessions/src/providers/git.ts
@@ -36,7 +36,18 @@ export class GitProvider implements SyncProvider {
   }
 
   async ensureReady(): Promise<void> {
-    if (this.isCloned()) return;
+    if (this.isCloned()) {
+      const currentRemote = await this.git(["remote", "get-url", this.remoteName]).catch(() => "");
+      if (currentRemote && currentRemote !== this.repo) {
+        throw new Error(
+          `cloud-sessions clone at ${this.clonePath} points to ${currentRemote}, not ${this.repo}. ` +
+            `Remove it to re-clone, or revert the repo setting.`,
+        );
+      }
+      await this.configureIdentity();
+      await this.git(["checkout", "-B", this.branch]).catch(() => "");
+      return;
+    }
     await mkdir(join(configDir(), "cloud-sessions"), { recursive: true });
     await exec("git", ["clone", "--branch", this.branch, this.repo, this.clonePath]).catch(
       async () => {
@@ -54,8 +65,8 @@ export class GitProvider implements SyncProvider {
 
   async pull(): Promise<void> {
     await this.ensureReady();
-    await this.git(["fetch", this.remoteName, this.branch]).catch(() => "");
-    await this.git(["reset", "--hard", `${this.remoteName}/${this.branch}`]).catch(() => "");
+    await this.git(["fetch", this.remoteName, this.branch]);
+    await this.git(["reset", "--hard", `${this.remoteName}/${this.branch}`]);
   }
 
   async listRemote(): Promise<RemoteFile[]> {

--- a/packages/cloud-sessions/src/providers/icloud.ts
+++ b/packages/cloud-sessions/src/providers/icloud.ts
@@ -1,0 +1,36 @@
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import type { IcloudProviderConfig } from "../config.js";
+import { copyInto, listJsonlIn } from "./mirror.js";
+import type { RemoteFile, SyncProvider } from "./types.js";
+
+export class IcloudProvider implements SyncProvider {
+  readonly kind = "icloud";
+  private readonly dir: string;
+
+  constructor(config: IcloudProviderConfig) {
+    this.dir = config.dir;
+  }
+
+  async ensureReady(): Promise<void> {
+    await mkdir(this.dir, { recursive: true });
+  }
+
+  async pull(): Promise<void> {
+    await mkdir(this.dir, { recursive: true });
+  }
+
+  async listRemote(): Promise<RemoteFile[]> {
+    return listJsonlIn(this.dir);
+  }
+
+  mirrorPath(relativePath: string): string {
+    return join(this.dir, relativePath);
+  }
+
+  async stageFromLocal(relativePath: string, localAbsolutePath: string): Promise<void> {
+    await copyInto(this.dir, relativePath, localAbsolutePath);
+  }
+
+  async push(): Promise<void> {}
+}

--- a/packages/cloud-sessions/src/providers/index.ts
+++ b/packages/cloud-sessions/src/providers/index.ts
@@ -1,0 +1,13 @@
+import type { CloudSessionsConfig } from "../config.js";
+import { GitProvider } from "./git.js";
+import { IcloudProvider } from "./icloud.js";
+import type { SyncProvider } from "./types.js";
+
+export function createProvider(config: CloudSessionsConfig): SyncProvider {
+  if (config.provider === "icloud") {
+    return new IcloudProvider(config.icloud);
+  }
+  return new GitProvider(config.git);
+}
+
+export type { SyncProvider, RemoteFile } from "./types.js";

--- a/packages/cloud-sessions/src/providers/mirror.ts
+++ b/packages/cloud-sessions/src/providers/mirror.ts
@@ -13,8 +13,9 @@ async function walk(dir: string, root: string, out: RemoteFile[]): Promise<void>
   let entries: Dirent[];
   try {
     entries = await readdir(dir, { withFileTypes: true });
-  } catch {
-    return;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+    throw new Error(`Failed to read mirror directory: ${dir}`, { cause: error });
   }
   for (const entry of entries) {
     if (entry.name === ".git") continue;

--- a/packages/cloud-sessions/src/providers/mirror.ts
+++ b/packages/cloud-sessions/src/providers/mirror.ts
@@ -1,0 +1,54 @@
+import { readdir, stat, mkdir, copyFile, utimes } from "node:fs/promises";
+import type { Dirent } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { dirname, join, relative } from "node:path";
+import type { RemoteFile } from "./types.js";
+
+export function hashFileSync(absolutePath: string): string {
+  return createHash("sha256").update(readFileSync(absolutePath)).digest("hex");
+}
+
+async function walk(dir: string, root: string, out: RemoteFile[]): Promise<void> {
+  let entries: Dirent[];
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (entry.name === ".git") continue;
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      await walk(full, root, out);
+      continue;
+    }
+    if (!entry.isFile() || !entry.name.endsWith(".jsonl")) continue;
+    const info = await stat(full);
+    out.push({
+      relativePath: relative(root, full),
+      mtimeMs: info.mtimeMs,
+      size: info.size,
+      hash: hashFileSync(full),
+    });
+  }
+}
+
+export async function listJsonlIn(root: string): Promise<RemoteFile[]> {
+  if (!existsSync(root)) return [];
+  const out: RemoteFile[] = [];
+  await walk(root, root, out);
+  return out;
+}
+
+export async function copyInto(
+  root: string,
+  relativePath: string,
+  sourceAbsolutePath: string,
+): Promise<void> {
+  const dest = join(root, relativePath);
+  await mkdir(dirname(dest), { recursive: true });
+  await copyFile(sourceAbsolutePath, dest);
+  const info = await stat(sourceAbsolutePath);
+  await utimes(dest, info.atime, info.mtime);
+}

--- a/packages/cloud-sessions/src/providers/types.ts
+++ b/packages/cloud-sessions/src/providers/types.ts
@@ -1,0 +1,22 @@
+export interface RemoteFile {
+  relativePath: string;
+  mtimeMs: number;
+  size: number;
+  hash: string;
+}
+
+export interface SyncProvider {
+  readonly kind: string;
+
+  ensureReady(): Promise<void>;
+
+  pull(): Promise<void>;
+
+  listRemote(): Promise<RemoteFile[]>;
+
+  mirrorPath(relativePath: string): string;
+
+  stageFromLocal(relativePath: string, localAbsolutePath: string): Promise<void>;
+
+  push(message: string): Promise<void>;
+}

--- a/packages/cloud-sessions/src/sessions.ts
+++ b/packages/cloud-sessions/src/sessions.ts
@@ -27,8 +27,9 @@ async function walkJsonl(dir: string, root: string, out: LocalSession[]): Promis
   let entries: Dirent[];
   try {
     entries = await readdir(dir, { withFileTypes: true });
-  } catch {
-    return;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+    throw new Error(`Failed to read sessions directory: ${dir}`, { cause: error });
   }
 
   for (const entry of entries) {

--- a/packages/cloud-sessions/src/sessions.ts
+++ b/packages/cloud-sessions/src/sessions.ts
@@ -1,0 +1,69 @@
+import { readdir, stat, mkdir } from "node:fs/promises";
+import type { Dirent } from "node:fs";
+import { existsSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
+
+export interface LocalSession {
+  relativePath: string;
+  absolutePath: string;
+  mtimeMs: number;
+  size: number;
+  hash: string;
+}
+
+export function sessionsRoot(): string {
+  return join(getAgentDir(), "sessions");
+}
+
+function hashFile(absolutePath: string): string {
+  const content = readFileSync(absolutePath);
+  return createHash("sha256").update(content).digest("hex");
+}
+
+async function walkJsonl(dir: string, root: string, out: LocalSession[]): Promise<void> {
+  let entries: Dirent[];
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      await walkJsonl(full, root, out);
+      continue;
+    }
+    if (!entry.isFile() || !entry.name.endsWith(".jsonl")) {
+      continue;
+    }
+    const info = await stat(full);
+    out.push({
+      relativePath: relative(root, full),
+      absolutePath: full,
+      mtimeMs: info.mtimeMs,
+      size: info.size,
+      hash: hashFile(full),
+    });
+  }
+}
+
+export async function listLocalSessions(): Promise<LocalSession[]> {
+  const root = sessionsRoot();
+  if (!existsSync(root)) {
+    await mkdir(root, { recursive: true });
+    return [];
+  }
+  const out: LocalSession[] = [];
+  await walkJsonl(root, root, out);
+  return out;
+}
+
+export async function ensureSessionsRoot(): Promise<string> {
+  const root = sessionsRoot();
+  await mkdir(root, { recursive: true });
+  return root;
+}

--- a/packages/cloud-sessions/src/sync.ts
+++ b/packages/cloud-sessions/src/sync.ts
@@ -78,7 +78,14 @@ export class Sync {
           result.unchanged += 1;
           continue;
         }
-        if (l.mtimeMs > r.mtimeMs + MTIME_TOLERANCE_MS) {
+        const delta = l.mtimeMs - r.mtimeMs;
+        if (delta > MTIME_TOLERANCE_MS) {
+          await this.provider.stageFromLocal(path, l.absolutePath);
+          result.pushed.push(path);
+        } else if (delta < -MTIME_TOLERANCE_MS) {
+          await copyRemoteToLocal(this.provider.mirrorPath(path), path);
+          result.pulled.push(path);
+        } else if (l.mtimeMs >= r.mtimeMs) {
           await this.provider.stageFromLocal(path, l.absolutePath);
           result.pushed.push(path);
         } else {

--- a/packages/cloud-sessions/src/sync.ts
+++ b/packages/cloud-sessions/src/sync.ts
@@ -1,0 +1,98 @@
+import { copyFile, mkdir, stat, utimes } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import type { CloudSessionsConfig } from "./config.js";
+import { createProvider, type SyncProvider } from "./providers/index.js";
+import { listLocalSessions, sessionsRoot } from "./sessions.js";
+
+const MTIME_TOLERANCE_MS = 1500;
+
+export interface SyncResult {
+  pulled: string[];
+  pushed: string[];
+  unchanged: number;
+}
+
+interface FileState {
+  hash: string;
+  mtimeMs: number;
+}
+
+async function copyRemoteToLocal(remoteAbsolutePath: string, localRelativePath: string): Promise<void> {
+  const dest = join(sessionsRoot(), localRelativePath);
+  await mkdir(dirname(dest), { recursive: true });
+  await copyFile(remoteAbsolutePath, dest);
+  const info = await stat(remoteAbsolutePath);
+  await utimes(dest, info.atime, info.mtime);
+}
+
+export class Sync {
+  private readonly provider: SyncProvider;
+  private readonly machineId: string;
+
+  constructor(config: CloudSessionsConfig) {
+    this.provider = createProvider(config);
+    this.machineId = config.machineId;
+  }
+
+  get providerKind(): string {
+    return this.provider.kind;
+  }
+
+  async run(): Promise<SyncResult> {
+    await this.provider.ensureReady();
+    await this.provider.pull();
+
+    const local = await listLocalSessions();
+    const remote = await this.provider.listRemote();
+
+    const localByPath = new Map<string, FileState & { absolutePath: string }>();
+    for (const f of local) {
+      localByPath.set(f.relativePath, { hash: f.hash, mtimeMs: f.mtimeMs, absolutePath: f.absolutePath });
+    }
+    const remoteByPath = new Map<string, FileState>();
+    for (const f of remote) {
+      remoteByPath.set(f.relativePath, { hash: f.hash, mtimeMs: f.mtimeMs });
+    }
+
+    const allPaths = new Set<string>([...localByPath.keys(), ...remoteByPath.keys()]);
+    const result: SyncResult = { pulled: [], pushed: [], unchanged: 0 };
+
+    for (const path of allPaths) {
+      const l = localByPath.get(path);
+      const r = remoteByPath.get(path);
+
+      if (l && !r) {
+        await this.provider.stageFromLocal(path, l.absolutePath);
+        result.pushed.push(path);
+        continue;
+      }
+
+      if (!l && r) {
+        await copyRemoteToLocal(this.provider.mirrorPath(path), path);
+        result.pulled.push(path);
+        continue;
+      }
+
+      if (l && r) {
+        if (l.hash === r.hash) {
+          result.unchanged += 1;
+          continue;
+        }
+        if (l.mtimeMs > r.mtimeMs + MTIME_TOLERANCE_MS) {
+          await this.provider.stageFromLocal(path, l.absolutePath);
+          result.pushed.push(path);
+        } else {
+          await copyRemoteToLocal(this.provider.mirrorPath(path), path);
+          result.pulled.push(path);
+        }
+      }
+    }
+
+    if (result.pushed.length > 0) {
+      const message = `sync from ${this.machineId}: ${result.pushed.length} session(s) @ ${new Date().toISOString()}`;
+      await this.provider.push(message);
+    }
+
+    return result;
+  }
+}

--- a/packages/cloud-sessions/tsconfig.json
+++ b/packages/cloud-sessions/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "lib": ["ES2022"],
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,6 +64,24 @@ importers:
         specifier: ^5.3.0
         version: 5.9.3
 
+  packages/cloud-sessions:
+    devDependencies:
+      '@earendil-works/pi-ai':
+        specifier: latest
+        version: 0.79.8(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-coding-agent':
+        specifier: latest
+        version: 0.79.8(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-tui':
+        specifier: 0.79.5
+        version: 0.79.5
+      '@types/node':
+        specifier: ^20.10.0
+        version: 20.19.39
+      typescript:
+        specifier: ^5.3.0
+        version: 5.9.3
+
   packages/element-inspector:
     dependencies:
       ws:
@@ -481,6 +499,10 @@ packages:
     resolution: {integrity: sha512-SXZc4rQI+3zgUmAJDbU0GzFEHCPHbhItjN7QLsahj3TKfQAon4guwCqsrwZBLH5lPcub2+evTojPNrPItL62tA==}
     engines: {node: '>=22.19.0'}
 
+  '@earendil-works/pi-agent-core@0.79.8':
+    resolution: {integrity: sha512-8m5fcqRpoGpq3QY0I/tFXROSTmPwBb1dAuzYZO3XYgjsdCokkRMAGRjA9P8s/UD6Jy9yy69lyE4H6sz/5A1TmQ==}
+    engines: {node: '>=22.19.0'}
+
   '@earendil-works/pi-ai@0.74.0':
     resolution: {integrity: sha512-7M7qcrZY/KEkH4wFkX3eqzvmKru4O88wezNKoN0KD2m4aAOmp9tdW2xCmUgSTSWlKB7b2Xw9QtAgrzHtg6t6iw==}
     engines: {node: '>=20.0.0'}
@@ -503,6 +525,11 @@ packages:
 
   '@earendil-works/pi-ai@0.79.6':
     resolution: {integrity: sha512-KGepEdgEeWDs7Imwlp96tBsO8TjSIpcDBvazsCDtHRa81+uwJI/YGetTegI52pMlKhVpJFLIGajRi4PCGC5MUg==}
+    engines: {node: '>=22.19.0'}
+    hasBin: true
+
+  '@earendil-works/pi-ai@0.79.8':
+    resolution: {integrity: sha512-ZpSwaD7oNpsjn9vtEatZQNT9PSdDJXi6rFeY5Qv+OHQGFDKlmcrfJE4ypm4SAc/fBECPs4Rdi3l+YjVtXYrkKw==}
     engines: {node: '>=22.19.0'}
     hasBin: true
 
@@ -538,6 +565,11 @@ packages:
 
   '@earendil-works/pi-coding-agent@0.79.6':
     resolution: {integrity: sha512-xPQDoA3+4Q8UsInST8OGFHPHyi7JQIbx51ku5kf2VuhXrrTv/npjVTXYD3A3D5xs6QRebV0B2mQqHfXaxQAplw==}
+    engines: {node: '>=22.19.0'}
+    hasBin: true
+
+  '@earendil-works/pi-coding-agent@0.79.8':
+    resolution: {integrity: sha512-wr9oTS/yrwURDXnYrONQgFgV7QDlwslXL/rvKU5X7TRtrGxIhippsRApXqYlRwSeMjb2YzgHMfZ/kAhOqrzoFQ==}
     engines: {node: '>=22.19.0'}
     hasBin: true
 
@@ -945,8 +977,24 @@ packages:
   '@mistralai/mistralai@2.2.1':
     resolution: {integrity: sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==}
 
+  '@mistralai/mistralai@2.2.6':
+    resolution: {integrity: sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+
   '@nodable/entities@2.1.0':
     resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
+
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/semantic-conventions@1.41.1':
+    resolution: {integrity: sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==}
+    engines: {node: '>=14'}
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -2335,6 +2383,10 @@ packages:
     resolution: {integrity: sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==}
     engines: {node: '>=22.19.0'}
 
+  undici@8.5.0:
+    resolution: {integrity: sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==}
+    engines: {node: '>=22.19.0'}
+
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
@@ -2823,7 +2875,7 @@ snapshots:
 
   '@earendil-works/pi-agent-core@0.79.0':
     dependencies:
-      '@earendil-works/pi-ai': 0.79.6(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.79.8(ws@8.20.0)(zod@4.4.3)
       ignore: 7.0.5
       typebox: 1.1.38
       yaml: 2.9.0
@@ -2837,7 +2889,7 @@ snapshots:
 
   '@earendil-works/pi-agent-core@0.79.5':
     dependencies:
-      '@earendil-works/pi-ai': 0.79.6(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.79.8(ws@8.20.0)(zod@4.4.3)
       ignore: 7.0.5
       typebox: 1.1.38
       yaml: 2.9.0
@@ -2851,7 +2903,21 @@ snapshots:
 
   '@earendil-works/pi-agent-core@0.79.6(ws@8.20.0)(zod@4.4.3)':
     dependencies:
-      '@earendil-works/pi-ai': 0.79.6(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.79.8(ws@8.20.0)(zod@4.4.3)
+      ignore: 7.0.5
+      typebox: 1.1.38
+      yaml: 2.9.0
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-agent-core@0.79.8(ws@8.20.0)(zod@4.4.3)':
+    dependencies:
+      '@earendil-works/pi-ai': 0.79.8(ws@8.20.0)(zod@4.4.3)
       ignore: 7.0.5
       typebox: 1.1.38
       yaml: 2.9.0
@@ -2965,6 +3031,27 @@ snapshots:
       - ws
       - zod
 
+  '@earendil-works/pi-ai@0.79.8(ws@8.20.0)(zod@4.4.3)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
+      '@aws-sdk/client-bedrock-runtime': 3.1048.0
+      '@google/genai': 1.52.0
+      '@mistralai/mistralai': 2.2.6(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.0
+      '@smithy/node-http-handler': 4.7.3
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      openai: 6.26.0(ws@8.20.0)(zod@4.4.3)
+      partial-json: 0.1.7
+      typebox: 1.1.38
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
   '@earendil-works/pi-coding-agent@0.74.0(ws@8.20.0)(zod@4.4.3)':
     dependencies:
       '@earendil-works/pi-agent-core': 0.74.0(ws@8.20.0)(zod@4.4.3)
@@ -3060,7 +3147,7 @@ snapshots:
   '@earendil-works/pi-coding-agent@0.79.0':
     dependencies:
       '@earendil-works/pi-agent-core': 0.79.0
-      '@earendil-works/pi-ai': 0.79.6(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.79.8(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-tui': 0.79.5
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
@@ -3089,7 +3176,7 @@ snapshots:
   '@earendil-works/pi-coding-agent@0.79.1':
     dependencies:
       '@earendil-works/pi-agent-core': 0.79.5
-      '@earendil-works/pi-ai': 0.79.6(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.79.8(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-tui': 0.79.5
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
@@ -3118,7 +3205,7 @@ snapshots:
   '@earendil-works/pi-coding-agent@0.79.5(ws@8.20.0)(zod@4.4.3)':
     dependencies:
       '@earendil-works/pi-agent-core': 0.79.6(ws@8.20.0)(zod@4.4.3)
-      '@earendil-works/pi-ai': 0.79.6(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.79.8(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-tui': 0.79.5
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
@@ -3164,6 +3251,36 @@ snapshots:
       semver: 7.8.0
       typebox: 1.1.38
       undici: 8.3.0
+      yaml: 2.9.0
+    optionalDependencies:
+      '@mariozechner/clipboard': 0.3.9
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-coding-agent@0.79.8(ws@8.20.0)(zod@4.4.3)':
+    dependencies:
+      '@earendil-works/pi-agent-core': 0.79.8(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.79.8(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-tui': 0.79.5
+      '@silvia-odwyer/photon-node': 0.3.4
+      chalk: 5.6.2
+      cross-spawn: 7.0.6
+      diff: 8.0.4
+      glob: 13.0.6
+      highlight.js: 10.7.3
+      hosted-git-info: 9.0.3
+      ignore: 7.0.5
+      jiti: 2.7.0
+      minimatch: 10.2.5
+      proper-lockfile: 4.1.2
+      semver: 7.8.0
+      typebox: 1.1.38
+      undici: 8.5.0
       yaml: 2.9.0
     optionalDependencies:
       '@mariozechner/clipboard': 0.3.9
@@ -3483,7 +3600,23 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  '@mistralai/mistralai@2.2.6(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/semantic-conventions': 1.41.1
+      ws: 8.20.0
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@nodable/entities@2.1.0': {}
+
+  '@opentelemetry/api@1.9.0': {}
+
+  '@opentelemetry/semantic-conventions@1.41.1': {}
 
   '@protobufjs/aspromise@1.1.2': {}
 
@@ -5111,6 +5244,8 @@ snapshots:
   undici@7.25.0: {}
 
   undici@8.3.0: {}
+
+  undici@8.5.0: {}
 
   unpipe@1.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,10 +67,10 @@ importers:
   packages/cloud-sessions:
     devDependencies:
       '@earendil-works/pi-ai':
-        specifier: latest
+        specifier: ^0.79.4
         version: 0.79.8(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-coding-agent':
-        specifier: latest
+        specifier: ^0.79.4
         version: 0.79.8(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-tui':
         specifier: 0.79.5


### PR DESCRIPTION
## Summary

Adds the `@arvoretech/pi-cloud-sessions` extension. Syncs all pi session JSONL files to a cloud backend so sessions can be resumed from any machine.

## Backends

- **git** (default) — private git repo dedicado. O provider clona em `~/.config/pi/cloud-sessions/repo` e commita/push a cada sync.
- **icloud** — pasta no iCloud Drive (macOS). Cópia de arquivo direta, zero infra.

## Sync model

- **startup**: pull de sessões mais novas do backend → local (last-write-wins por mtime).
- **turn_end**: push automático com debounce de 4s.
- **session_shutdown**: flush final.
- **LWW**: mtime preservado ao copiar → a edição mais recente vence independente de qual máquina sincronizou por último.

## Commands

- `/cloud-sessions-setup` — configura backend interativamente, salva em `~/.config/pi/cloud-sessions.json`.
- `/cloud-sessions-sync` — força pull+push agora.
- `/cloud-sessions-status` — mostra config e estado atual.

## Tested

- Verified end-to-end with iCloud and git (local bare repo):
  - Push new session → mirror ✓
  - Pull on fresh machine → identical content ✓
  - Edit on machine B (newer mtime) → push wins ✓
  - Machine A pulls B's edit ✓
  - No changes → unchanged count ✓
- Tested locally in a running pi instance: 17 sessions synced to `Joao208/pi-sessions` on first startup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Cloud session synchronization extension supporting private Git repositories and iCloud Drive
  * Automatic synchronization at startup, per-turn (debounced), and shutdown
  * Conflict resolution using last-write-wins strategy per file
  * Interactive CLI commands for setup, sync status, and synchronization
  * Configuration via JSON files and environment variables

* **Documentation**
  * Complete README with interactive setup instructions and backend-specific configuration examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->