### PR TITLE
chore: add .npmignore so cloud-sessions dist is published

### DIFF
--- a/packages/cloud-sessions/.npmignore
+++ b/packages/cloud-sessions/.npmignore
@@ -1,0 +1,3 @@
+src
+tsconfig.json
+*.tsbuildinfo


### PR DESCRIPTION
## Summary

Fixes the npm publish problem where the tarball only contained `README.md` + `package.json` and was missing the compiled `dist/`.

## Root cause

`packages/cloud-sessions/` had no `.npmignore`, so npm fell back to the root `.gitignore` which contains `dist/` — excluding the build from the published tarball even though `files: ["dist"]` is set.

## Fix

Added `packages/cloud-sessions/.npmignore` (ignores `src`, `tsconfig.json`, `*.tsbuildinfo`), which overrides the `.gitignore` fallback. With `files: ["dist"]` as the whitelist, the package now publishes the compiled code.

## Testing

`npm publish --access public --dry-run` now lists 38 files (14.4 kB) including the full `dist/` tree.