### PR TITLE
feat(warp-tab-title): sync warp event integration + tab title optional

### DIFF
--- a/packages/warp-tab-title/src/index.ts
+++ b/packages/warp-tab-title/src/index.ts
@@ -1,150 +1,214 @@
+import { randomUUID } from "node:crypto";
+import { closeSync, openSync, writeSync } from "node:fs";
 import path from "node:path";
 import type {
-  ExtensionAPI,
-  ExtensionContext,
+	ExtensionAPI,
+	ExtensionContext,
 } from "@earendil-works/pi-coding-agent";
-import { Type } from "@earendil-works/pi-ai";
 import { Text } from "@earendil-works/pi-tui";
+import { Type } from "@earendil-works/pi-ai";
 
 interface TabTitleState {
-  emoji: string;
-  summary: string;
+	emoji: string;
+	summary: string;
 }
 
 const STATE_TYPE = "warp-tab-title";
 const DEFAULT_EMOJI = "🤖";
 const MAX_SUMMARY_LEN = 60;
 
-let pi: ExtensionAPI;
-let currentState: TabTitleState | null = null;
-
 function basenameCwd(): string {
-  return path.basename(process.cwd()) || "pi";
+	return path.basename(process.cwd()) || "pi";
 }
 
 function buildTitle(state: TabTitleState | null): string {
-  if (state) {
-    const emoji = state.emoji.trim() || DEFAULT_EMOJI;
-    const summary = state.summary.trim().slice(0, MAX_SUMMARY_LEN);
-    return summary ? `${emoji} ${summary}` : `${emoji} ${basenameCwd()}`;
-  }
-  const sessionName = pi?.getSessionName?.();
-  const cwd = basenameCwd();
-  return sessionName
-    ? `${DEFAULT_EMOJI} ${sessionName} · ${cwd}`
-    : `${DEFAULT_EMOJI} ${cwd}`;
+	if (state) {
+		const emoji = state.emoji.trim() || DEFAULT_EMOJI;
+		const summary = state.summary.trim().slice(0, MAX_SUMMARY_LEN);
+		return summary ? `${emoji} ${summary}` : `${emoji} ${basenameCwd()}`;
+	}
+	const sessionName = pi.getSessionName?.();
+	const cwd = basenameCwd();
+	return sessionName ? `${DEFAULT_EMOJI} ${sessionName} · ${cwd}` : `${DEFAULT_EMOJI} ${cwd}`;
 }
 
-function restoreFromBranch(ctx: ExtensionContext): void {
-  const entries = ctx.sessionManager.getBranch();
-  let last: TabTitleState | null = null;
-  for (const entry of entries) {
-    if (entry.type === "custom" && entry.customType === STATE_TYPE) {
-      const data = entry.data as TabTitleState | undefined;
-      if (data?.summary) last = data;
-    }
-  }
-  currentState = last;
+let pi: ExtensionAPI;
+let currentState: TabTitleState | null = null;
+
+const WARP_AGENT_NAME = "pi";
+const WARP_PROTOCOL_VERSION = 1;
+const warpSessionId = randomUUID();
+let lastQuery = "";
+
+function isWarpTerminal(): boolean {
+	return process.env.TERM_PROGRAM === "WarpTerminal";
 }
 
-function applyTitle(ctx: ExtensionContext): void {
-  ctx.ui.setTitle(buildTitle(currentState));
+function emitWarpSequence(seq: string) {
+	if (!isWarpTerminal()) return;
+	try {
+		const fd = openSync("/dev/tty", "w");
+		try {
+			writeSync(fd, seq);
+		} finally {
+			closeSync(fd);
+		}
+	} catch {
+		try {
+			process.stdout.write(seq);
+		} catch {}
+	}
 }
 
-const SYSTEM_PROMPT_INSTRUCTION = `
-<warp_tab_title>
-You can rename the user's terminal tab to reflect what you are currently working on by calling the \`set_tab_title\` tool.
+function sendWarpEvent(event: string, extra: Record<string, unknown> = {}) {
+	if (!isWarpTerminal()) return;
+	const cwd = process.cwd();
+	const payload = {
+		v: WARP_PROTOCOL_VERSION,
+		agent: WARP_AGENT_NAME,
+		event,
+		session_id: warpSessionId,
+		cwd,
+		project: path.basename(cwd) || "pi",
+		...extra,
+	};
+	const body = JSON.stringify(payload);
+	const seq = `\x1b]777;notify;warp://cli-agent;${body}\x07`;
+	emitWarpSequence(seq);
+}
 
-When to call it:
-- At the start of a new task or thread, once you understand the user's goal
-- Whenever the focus shifts to a meaningfully different task (different repo, different feature, different bug, different phase like refinement → coding → review)
+function truncate(text: string, max = 200): string {
+	if (!text) return "";
+	return text.length > max ? `${text.slice(0, max - 3)}...` : text;
+}
 
-When NOT to call it:
-- For trivial follow-ups inside the same task
-- For each tool call or each message
-- More than once per ~5 turns unless the focus genuinely changed
+function restoreFromBranch(ctx: ExtensionContext) {
+	const entries = ctx.sessionManager.getBranch();
+	let last: TabTitleState | null = null;
+	for (const entry of entries) {
+		if (entry.type === "custom" && entry.customType === STATE_TYPE) {
+			const data = entry.data as TabTitleState | undefined;
+			if (data?.summary) last = data;
+		}
+	}
+	currentState = last;
+}
 
-Style:
-- Pick an emoji that fits the activity (🐛 debug, 📝 refinement, 🚀 deploy, 🔍 investigate, ✨ feature, 🧪 test, 📚 docs, 🔧 fix, 🎨 ui, 🧹 refactor, 🤖 generic)
-- Summary should be short (≤ 6 words), action-oriented, in the user's working language
-- Examples: "Refinement EXP-231", "Debug memory leak api-arvore", "Refactor auth flow", "Deploy criar staging"
-</warp_tab_title>
-`.trim();
+function applyTitle(ctx: ExtensionContext) {
+	ctx.ui.setTitle(buildTitle(currentState));
+}
 
-export default function warpTabTitleExtension(api: ExtensionAPI): void {
-  pi = api;
+export default function (api: ExtensionAPI) {
+	pi = api;
 
-  pi.registerTool({
-    name: "set_tab_title",
-    label: "Tab Title",
-    description:
-      "Rename the user's terminal tab (Warp) to reflect the current task. Call this when starting a new task or when the focus changes meaningfully.",
-    promptSnippet: "Rename the Warp tab to reflect the current task focus.",
-    promptGuidelines: [
-      "Use set_tab_title at the start of a new thread and whenever the focus shifts to a different task, repo, or phase.",
-      "Pick a fitting emoji and a short action-oriented summary (≤ 6 words).",
-      "Do not call it on every turn — only when the context genuinely changed.",
-    ],
-    parameters: Type.Object({
-      emoji: Type.String({
-        description:
-          "A single emoji that represents the activity (e.g., 🐛, 📝, 🚀, 🔍, ✨, 🧪, 🔧, 🎨, 🧹).",
-      }),
-      summary: Type.String({
-        description:
-          "Short action-oriented summary of the current task (≤ 6 words). Use the user's working language.",
-      }),
-    }),
-    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-      const next: TabTitleState = {
-        emoji: params.emoji?.trim() || DEFAULT_EMOJI,
-        summary: params.summary?.trim() || "",
-      };
-      if (!next.summary) {
-        throw new Error("summary cannot be empty");
-      }
-      currentState = next;
-      pi.appendEntry<TabTitleState>(STATE_TYPE, next);
-      applyTitle(ctx);
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Tab renamed to: ${buildTitle(next)}`,
-          },
-        ],
-        details: next,
-      };
-    },
-    renderResult(result, _options, theme, _context) {
-      const data = result.details as TabTitleState | undefined;
-      if (!data) return new Text(theme.fg("dim", "tab title set"), 0, 0);
-      return new Text(
-        theme.fg("dim", "tab → ") +
-          theme.fg("accent", `${data.emoji} ${data.summary}`),
-        0,
-        0,
-      );
-    },
-  });
+	pi.registerTool({
+		name: "set_tab_title",
+		label: "Tab Title",
+		description:
+			"Rename the user's terminal tab (Warp) to reflect the current task. Call this when starting a new task or when the focus changes meaningfully.",
+		promptSnippet: "Rename the Warp tab to reflect the current task focus.",
+		promptGuidelines: [
+			"Use set_tab_title at the start of a new thread and whenever the focus shifts to a different task, repo, or phase.",
+			"Pick a fitting emoji and a short action-oriented summary (≤ 6 words).",
+			"Do not call it on every turn — only when the context genuinely changed.",
+		],
+		parameters: Type.Object({
+			emoji: Type.String({
+				description:
+					"A single emoji that represents the activity (e.g., 🐛, 📝, 🚀, 🔍, ✨, 🧪, 🔧, 🎨, 🧹).",
+			}),
+			summary: Type.String({
+				description:
+					"Short action-oriented summary of the current task (≤ 6 words). Use the user's working language.",
+			}),
+		}),
+		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+			const next: TabTitleState = {
+				emoji: params.emoji?.trim() || DEFAULT_EMOJI,
+				summary: params.summary?.trim() || "",
+			};
+			if (!next.summary) {
+				throw new Error("summary cannot be empty");
+			}
+			currentState = next;
+			pi.appendEntry<TabTitleState>(STATE_TYPE, next);
+			applyTitle(ctx);
+			return {
+				content: [
+					{
+						type: "text",
+						text: `Tab renamed to: ${buildTitle(next)}`,
+					},
+				],
+				details: next,
+			};
+		},
+		renderResult(result, _options, theme, _context) {
+			const data = result.details as TabTitleState | undefined;
+			if (!data) return new Text(theme.fg("dim", "tab title set"), 0, 0);
+			return new Text(
+				theme.fg("dim", "tab → ") +
+					theme.fg("accent", `${data.emoji} ${data.summary}`),
+				0,
+				0,
+			);
+		},
+	});
 
-  pi.on("session_start", async (_event, ctx) => {
-    restoreFromBranch(ctx);
-    applyTitle(ctx);
-  });
+	pi.on("session_start", async (_event, ctx) => {
+		restoreFromBranch(ctx);
+		applyTitle(ctx);
+		sendWarpEvent("session_start");
+	});
 
-  pi.on("session_tree", async (_event, ctx) => {
-    restoreFromBranch(ctx);
-    applyTitle(ctx);
-  });
+	pi.on("input", async (event) => {
+		if (event.source !== "interactive" && event.source !== "rpc") return;
+		const text = (event.text ?? "").trim();
+		if (!text) return;
+		lastQuery = truncate(text);
+		sendWarpEvent("prompt_submit", { query: lastQuery });
+	});
 
-  pi.on("before_agent_start", async (event) => {
-    return {
-      systemPrompt: `${event.systemPrompt}\n\n${SYSTEM_PROMPT_INSTRUCTION}`,
-    };
-  });
+	pi.on("agent_start", async () => {
+		sendWarpEvent("prompt_submit", { query: lastQuery });
+	});
 
-  pi.on("session_shutdown", async (_event, ctx) => {
-    ctx.ui.setTitle(`${DEFAULT_EMOJI} ${basenameCwd()}`);
-  });
+	pi.on("agent_end", async (event) => {
+		let response = "";
+		for (const message of event.messages ?? []) {
+			if (message.role !== "assistant") continue;
+			for (const block of message.content ?? []) {
+				if (block.type === "text" && block.text) {
+					response = block.text;
+				}
+			}
+		}
+		sendWarpEvent("stop", {
+			query: lastQuery,
+			response: truncate(response),
+		});
+	});
+
+	pi.on("tool_execution_end", async (event) => {
+		sendWarpEvent("post_tool_use", {
+			tool_name: event.toolName,
+			is_error: event.isError ?? false,
+		});
+	});
+
+	pi.on("session_tree", async (_event, ctx) => {
+		restoreFromBranch(ctx);
+		applyTitle(ctx);
+	});
+
+	pi.on("before_agent_start", async (event) => {
+		return {
+			systemPrompt: event.systemPrompt,
+		};
+	});
+
+	pi.on("session_shutdown", async (_event, ctx) => {
+		ctx.ui.setTitle(`${DEFAULT_EMOJI} ${basenameCwd()}`);
+		sendWarpEvent("stop", { query: lastQuery, response: "" });
+	});
 }


### PR DESCRIPTION
## Resumo

Sincroniza o `packages/warp-tab-title/src/index.ts` versionado com a versão que já roda localmente (`~/.pi/agent/extensions`), que estava bem mais avançada que o repo.

## Mudanças
- Integração de eventos Warp via OSC sequences (`sendWarpEvent`): `session_start`, `prompt_submit`, `stop`, `post_tool_use` — emitidos só em `WarpTerminal`.
- Hooks adicionais: `agent_start`, `agent_end`, `tool_execution_end`, `session_shutdown`.
- `set_tab_title` agora é **opcional**: removida a injeção forçada de system prompt no `before_agent_start` (não força mais o modelo a chamar a tool). A tool segue disponível e funcional.
- Import de `Type` ajustado de `typebox` para `@earendil-works/pi-ai` (dependência já presente no pacote).

## Testes
- `pnpm build` (tsc) passa sem erros.