### PR TITLE
feat(slack-agent): persiste sessão do Pi por thread do Slack

### DIFF
--- a/packages/slack-agent/src/rpc-client.ts
+++ b/packages/slack-agent/src/rpc-client.ts
@@ -7,6 +7,7 @@ export interface RpcClientOptions {
   bin: string;
   cwd: string;
   model?: string;
+  session?: string;
   onEvent: (event: RpcEvent) => void;
   onExit: (code: number | null) => void;
 }
@@ -28,9 +29,8 @@ export class RpcClient {
   constructor(options: RpcClientOptions) {
     this.options = options;
     const args = ["--mode", "rpc"];
-    if (options.model) {
-      args.push("--model", options.model);
-    }
+    if (options.model) args.push("--model", options.model);
+    if (options.session) args.push("--session-id", options.session);
 
     this.child = spawn(options.bin, args, {
       cwd: options.cwd,

--- a/packages/slack-agent/src/session-manager.ts
+++ b/packages/slack-agent/src/session-manager.ts
@@ -1,5 +1,10 @@
+import { createHash } from "node:crypto";
 import { RpcClient, type RpcEvent, type RpcClientOptions } from "./rpc-client.js";
 import type { AgentConfig } from "./config.js";
+
+function sessionIdFor(threadTs: string): string {
+  return "slack-" + createHash("sha1").update(threadTs).digest("hex").slice(0, 12);
+}
 
 export interface SessionHandlers {
   onEvent: (event: RpcEvent) => void;
@@ -30,6 +35,7 @@ export class Session {
       bin: this.config.piBin,
       cwd: this.config.piCwd,
       model: this.config.piModel,
+      session: sessionIdFor(this.threadTs),
       onEvent: (event) => this.handleEvent(event),
       onExit: () => { this.client = undefined; this.streaming = false; this.handlers.onExit?.(); },
     });


### PR DESCRIPTION
## O que muda

Cada thread do Slack agora mapeia para uma sessão Pi estável e persistente em disco.

- `session-manager.ts`: `sessionIdFor(threadTs)` deriva um ID determinístico (`slack-<sha1(threadTs)[:12]>`). A mesma thread sempre resolve para o mesmo ID.
- `rpc-client.ts`: passa `--session-id <id>` no spawn do Pi. Essa flag **cria a sessão se não existir e resume se já existir** (diferente de `--session`, que só resume e falha quando ausente).

## Por quê

Antes, o `SessionManager` mantinha as sessões só em memória e o Pi era spawnado sem `--session-id`. Restart do container ou o idle-timeout de 15min descartavam todo o contexto da thread — a conversa parecia contínua no Slack mas o Pi começava do zero.

## Como foi testado

- Mensagem no painel Assistant → sessão criada em `~/.pi/agent/sessions/--workspace--/...slack-f78997182737.jsonl`.
- `docker compose restart` → o arquivo de sessão sobrevive; só existe **1** arquivo por thread (ID determinístico, sem duplicação).
- `--session-id` confirmado via `pi --help`: "Use exact project session ID, creating it if missing".

## Notas

- Build (`pnpm build`) passa; `dist/` é gitignored.
- Diagnóstico à parte: o app no Slack tinha entrega de eventos desativada/dessincronizada (Event Subscriptions) — resolvido reativando/reinstalando, fora do escopo deste diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced session management for Slack conversations with unique session identification per thread to improve tracking and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->