### PR TITLE
feat(prs-tracker): track CI checks and production deploy status

### DIFF
--- a/packages/prs-tracker/README.md
+++ b/packages/prs-tracker/README.md
@@ -1,6 +1,6 @@
 # @arvoretech/pi-prs-tracker
 
-Keeps your open and recently-merged PRs pinned in the chat as a persistent widget. PRs are auto-detected from `gh pr create` calls (and any GitHub PR URL) the agent runs during the session, and their status is refreshed in the background.
+Keeps your open and recently-merged PRs pinned in the chat as a persistent widget — now with CI and production deploy status. PRs are auto-detected from `gh pr create` calls (and any GitHub PR URL) the agent runs during the session, and their status is refreshed in the background.
 
 ## Install
 
@@ -19,10 +19,17 @@ Or in `.pi/settings.json`:
 ## How it works
 
 - Listens to `bash` tool executions. When a command contains `gh pr create` or its output prints a `github.com/<owner>/<repo>/pull/<n>` URL, the PR is captured automatically.
-- For each tracked PR it runs `gh pr view <n> --json ...` to read title and state.
-- A widget pinned above the editor lists every tracked PR with its state and URL:
-  - `[open]` / `[draft]` / `[merged]` / `[closed]`
-- Background polling (every 60s) refreshes statuses. Merged PRs stay for 24h, closed PRs drop off immediately.
+- For each tracked PR it runs `gh pr view <n> --json ...` to read title, state, merge commit and the status check rollup (CI).
+- When a tracked PR becomes `MERGED`, it looks up the production deploy workflow run triggered by the push to `main` for that merge commit (`gh run list --commit <sha>`) and tracks it through `queued → in_progress → success/failure`.
+- A widget pinned above the editor lists every tracked PR with:
+  - State: `[open]` / `[draft]` / `[merged]` / `[closed]`
+  - CI: `CI passed` / `CI failed` / `CI running` with check counts
+  - Deploy: `deploy queued` / `deploying to main` / `deployed to main` / `deploy failed`
+- Background polling (every 60s) refreshes CI and deploy statuses. Merged PRs stay for 24h (and are kept longer if a deploy is still in flight); closed PRs drop off immediately.
+
+## Deploy detection
+
+The production deploy run is matched by the `push` event on the merge commit, picking a workflow whose name contains `deploy` but not `staging`. This matches the `Deploy` workflow in `api-arvore`, `frontend-arvore-nextjs`, etc.
 
 ## Commands
 

--- a/packages/prs-tracker/README.md
+++ b/packages/prs-tracker/README.md
@@ -20,7 +20,7 @@ Or in `.pi/settings.json`:
 
 - Listens to `bash` tool executions. When a command contains `gh pr create` or its output prints a `github.com/<owner>/<repo>/pull/<n>` URL, the PR is captured automatically.
 - For each tracked PR it runs `gh pr view <n> --json ...` to read title, state, merge commit and the status check rollup (CI).
-- When a tracked PR becomes `MERGED`, it looks up the production deploy workflow run triggered by the push to `main` for that merge commit (`gh run list --commit <sha>`) and tracks it through `queued → in_progress → success/failure`.
+- When a tracked PR becomes `MERGED`, it looks up the production deploy workflow run triggered by the `push` for that merge commit (`gh run list --commit <sha>`) and tracks it through `queued → in_progress → success/failure`.
 - A widget pinned above the editor lists every tracked PR with:
   - State: `[open]` / `[draft]` / `[merged]` / `[closed]`
   - CI: `CI passed` / `CI failed` / `CI running` with check counts

--- a/packages/prs-tracker/package.json
+++ b/packages/prs-tracker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-prs-tracker",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "PI extension that keeps open/recently-merged PRs pinned in the chat as a persistent widget",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/prs-tracker/src/index.ts
+++ b/packages/prs-tracker/src/index.ts
@@ -3,6 +3,24 @@ import { execSync } from "node:child_process";
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { join, dirname, basename } from "node:path";
 
+type CiState = "PENDING" | "PASS" | "FAIL" | "NONE";
+type DeployState = "QUEUED" | "IN_PROGRESS" | "SUCCESS" | "FAILURE" | "NONE";
+
+interface CiSummary {
+  state: CiState;
+  total: number;
+  passed: number;
+  failed: number;
+  pending: number;
+}
+
+interface DeployInfo {
+  state: DeployState;
+  workflow: string;
+  url: string;
+  databaseId: number;
+}
+
 interface TrackedPr {
   number: number;
   repo: string;
@@ -11,12 +29,17 @@ interface TrackedPr {
   state: "OPEN" | "MERGED" | "CLOSED";
   isDraft: boolean;
   mergedAt: number | null;
+  mergeCommit: string | null;
+  ci: CiSummary | null;
+  deploy: DeployInfo | null;
 }
 
 const POLL_INTERVAL_MS = 60_000;
 const MERGED_RETENTION_MS = 24 * 60 * 60 * 1000;
 const PR_URL_RE = /https?:\/\/github\.com\/([^/\s]+\/[^/\s]+)\/pull\/(\d+)/g;
 const STATE_DIR = ".pi/prs-tracker-sessions";
+const DEPLOY_WORKFLOW_RE = /deploy/i;
+const DEPLOY_STAGING_RE = /staging/i;
 
 const tracked = new Map<string, TrackedPr>();
 let hidden = false;
@@ -85,9 +108,77 @@ function runGh(args: string): string | null {
   }
 }
 
+function summarizeChecks(rollup: any[]): CiSummary | null {
+  if (!Array.isArray(rollup) || rollup.length === 0) return null;
+  let passed = 0;
+  let failed = 0;
+  let pending = 0;
+  for (const c of rollup) {
+    const status: string = (c?.status ?? c?.state ?? "").toUpperCase();
+    const conclusion: string = (c?.conclusion ?? "").toUpperCase();
+    if (status && status !== "COMPLETED") {
+      pending++;
+      continue;
+    }
+    const outcome = conclusion || status;
+    if (["SUCCESS", "NEUTRAL", "SKIPPED"].includes(outcome)) passed++;
+    else if (["FAILURE", "TIMED_OUT", "CANCELLED", "ACTION_REQUIRED", "ERROR", "STALE"].includes(outcome))
+      failed++;
+    else pending++;
+  }
+  const total = rollup.length;
+  let state: CiState = "NONE";
+  if (failed > 0) state = "FAIL";
+  else if (pending > 0) state = "PENDING";
+  else if (passed > 0) state = "PASS";
+  return { state, total, passed, failed, pending };
+}
+
+function fetchDeploy(repo: string, sha: string): DeployInfo | null {
+  const out = runGh(
+    `run list --repo ${repo} --commit ${sha} --json databaseId,name,status,conclusion,url,event --limit 20`,
+  );
+  if (!out) return null;
+  try {
+    const runs = JSON.parse(out) as Array<{
+      databaseId: number;
+      name: string;
+      status: string;
+      conclusion: string | null;
+      url: string;
+      event: string;
+    }>;
+    const deployRun = runs.find(
+      (r) =>
+        r.event === "push" &&
+        DEPLOY_WORKFLOW_RE.test(r.name) &&
+        !DEPLOY_STAGING_RE.test(r.name),
+    );
+    if (!deployRun) return null;
+    let state: DeployState = "QUEUED";
+    const status = (deployRun.status ?? "").toUpperCase();
+    const conclusion = (deployRun.conclusion ?? "").toUpperCase();
+    if (status === "COMPLETED") {
+      state = conclusion === "SUCCESS" ? "SUCCESS" : "FAILURE";
+    } else if (status === "IN_PROGRESS") {
+      state = "IN_PROGRESS";
+    } else {
+      state = "QUEUED";
+    }
+    return {
+      state,
+      workflow: deployRun.name,
+      url: deployRun.url,
+      databaseId: deployRun.databaseId,
+    };
+  } catch {
+    return null;
+  }
+}
+
 function fetchPrDetails(number: number, repo: string): TrackedPr | null {
   const out = runGh(
-    `pr view ${number} --repo ${repo} --json number,title,state,url,isDraft,mergedAt`,
+    `pr view ${number} --repo ${repo} --json number,title,state,url,isDraft,mergedAt,mergeCommit,statusCheckRollup`,
   );
   if (!out) return null;
   try {
@@ -98,7 +189,10 @@ function fetchPrDetails(number: number, repo: string): TrackedPr | null {
       url: string;
       isDraft: boolean;
       mergedAt: string | null;
+      mergeCommit: { oid: string } | null;
+      statusCheckRollup: any[];
     };
+    const prev = tracked.get(keyOf(repo, number));
     return {
       number: data.number,
       repo,
@@ -107,6 +201,9 @@ function fetchPrDetails(number: number, repo: string): TrackedPr | null {
       state: (data.state as TrackedPr["state"]) ?? "OPEN",
       isDraft: Boolean(data.isDraft),
       mergedAt: data.mergedAt ? new Date(data.mergedAt).getTime() : null,
+      mergeCommit: data.mergeCommit?.oid ?? null,
+      ci: summarizeChecks(data.statusCheckRollup),
+      deploy: prev?.deploy ?? null,
     };
   } catch {
     return null;
@@ -116,6 +213,10 @@ function fetchPrDetails(number: number, repo: string): TrackedPr | null {
 function trackPr(number: number, repo: string): boolean {
   const details = fetchPrDetails(number, repo);
   if (!details) return false;
+  if (details.state === "MERGED" && details.mergeCommit && !details.deploy) {
+    const deploy = fetchDeploy(repo, details.mergeCommit);
+    if (deploy) details.deploy = deploy;
+  }
   tracked.set(keyOf(repo, number), details);
   return true;
 }
@@ -128,6 +229,8 @@ function pruneStale(): void {
       continue;
     }
     if (pr.state === "MERGED" && pr.mergedAt && now - pr.mergedAt > MERGED_RETENTION_MS) {
+      if (pr.deploy && (pr.deploy.state === "QUEUED" || pr.deploy.state === "IN_PROGRESS"))
+        continue;
       tracked.delete(key);
     }
   }
@@ -137,8 +240,19 @@ function refreshAll(): boolean {
   let changed = false;
   for (const [key, pr] of tracked) {
     const updated = fetchPrDetails(pr.number, pr.repo);
-    if (updated && JSON.stringify(updated) !== JSON.stringify(pr)) {
-      tracked.set(key, updated);
+    const next = updated ?? pr;
+    if (
+      next.state === "MERGED" &&
+      next.mergeCommit &&
+      (!next.deploy ||
+        next.deploy.state === "QUEUED" ||
+        next.deploy.state === "IN_PROGRESS")
+    ) {
+      const deploy = fetchDeploy(next.repo, next.mergeCommit);
+      if (deploy) next.deploy = deploy;
+    }
+    if (JSON.stringify(next) !== JSON.stringify(pr)) {
+      tracked.set(key, next);
       changed = true;
     }
   }
@@ -173,7 +287,11 @@ function resultToText(result: any): string {
 }
 
 function sortedPrs(): TrackedPr[] {
-  const order = (pr: TrackedPr): number => (pr.state === "OPEN" ? 0 : 1);
+  const order = (pr: TrackedPr): number => {
+    if (pr.state === "OPEN") return 0;
+    if (pr.deploy && (pr.deploy.state === "QUEUED" || pr.deploy.state === "IN_PROGRESS")) return 1;
+    return 2;
+  };
   return [...tracked.values()].sort((a, b) => {
     const byState = order(a) - order(b);
     if (byState !== 0) return byState;
@@ -195,6 +313,34 @@ function colorFor(pr: TrackedPr): string {
   return "success";
 }
 
+function ciLine(pr: TrackedPr, fg: (c: string, s: string) => string): string | null {
+  const ci = pr.ci;
+  if (!ci || ci.state === "NONE") return null;
+  const map: Record<CiState, [string, string]> = {
+    PASS: ["success", "CI passed"],
+    FAIL: ["error", "CI failed"],
+    PENDING: ["warning", "CI running"],
+    NONE: ["dim", "CI"],
+  };
+  const [color, label] = map[ci.state];
+  const detail = `${label} (${ci.passed}/${ci.total}${ci.failed ? `, ${ci.failed} failed` : ""})`;
+  return fg(color, detail);
+}
+
+function deployLine(pr: TrackedPr, fg: (c: string, s: string) => string): string | null {
+  const d = pr.deploy;
+  if (!d || d.state === "NONE") return null;
+  const map: Record<DeployState, [string, string]> = {
+    QUEUED: ["warning", "deploy queued"],
+    IN_PROGRESS: ["warning", "deploying to main"],
+    SUCCESS: ["success", "deployed to main"],
+    FAILURE: ["error", "deploy failed"],
+    NONE: ["dim", "deploy"],
+  };
+  const [color, label] = map[d.state];
+  return fg(color, label);
+}
+
 function renderWidget(width: number, theme: any): string[] {
   const prs = sortedPrs();
   const lines: string[] = [];
@@ -204,7 +350,13 @@ function renderWidget(width: number, theme: any): string[] {
 
   const open = prs.filter((p) => p.state === "OPEN").length;
   const merged = prs.filter((p) => p.state === "MERGED").length;
-  const header = ` PRs — ${open} open${merged ? `, ${merged} merged` : ""}`;
+  const deploying = prs.filter(
+    (p) => p.deploy && (p.deploy.state === "QUEUED" || p.deploy.state === "IN_PROGRESS"),
+  ).length;
+  const headerParts = [`${open} open`];
+  if (merged) headerParts.push(`${merged} merged`);
+  if (deploying) headerParts.push(`${deploying} deploying`);
+  const header = ` PRs — ${headerParts.join(", ")}`;
   lines.push(bold(fg("accent", trunc(header))));
 
   const max = 12;
@@ -213,6 +365,10 @@ function renderWidget(width: number, theme: any): string[] {
     const tag = fg(color, bold(labelFor(pr).toUpperCase()));
     const head = trunc(`#${pr.number} ${pr.title}`);
     lines.push(`   ${tag} ${fg("text", head)}`);
+    const ci = ciLine(pr, fg);
+    const deploy = deployLine(pr, fg);
+    const status = [ci, deploy].filter(Boolean).join(fg("dim", "  ·  "));
+    if (status) lines.push(`      ${trunc(status)}`);
     lines.push(`      ${fg("mdLinkUrl", trunc(pr.url))}`);
   }
   if (prs.length > max) lines.push(fg("dim", `   +${prs.length - max} more`));

--- a/packages/prs-tracker/src/index.ts
+++ b/packages/prs-tracker/src/index.ts
@@ -239,8 +239,9 @@ function pruneStale(): void {
 function refreshAll(): boolean {
   let changed = false;
   for (const [key, pr] of tracked) {
+    const before = JSON.stringify(pr);
     const updated = fetchPrDetails(pr.number, pr.repo);
-    const next = updated ?? pr;
+    const next = updated ?? { ...pr };
     if (
       next.state === "MERGED" &&
       next.mergeCommit &&
@@ -251,7 +252,7 @@ function refreshAll(): boolean {
       const deploy = fetchDeploy(next.repo, next.mergeCommit);
       if (deploy) next.deploy = deploy;
     }
-    if (JSON.stringify(next) !== JSON.stringify(pr)) {
+    if (JSON.stringify(next) !== before) {
       tracked.set(key, next);
       changed = true;
     }


### PR DESCRIPTION
## Resumo

Estende o `@arvoretech/pi-prs-tracker` para acompanhar **CI** e **deploy de produção** dos PRs rastreados, reusando a mecânica existente (auto-detecção por sessão, polling de 60s, persistência de estado).

### O que muda
- **CI dos PRs**: `gh pr view` agora puxa `statusCheckRollup` + `mergeCommit`. `summarizeChecks()` consolida em `PASS / FAIL / PENDING` com contagem de checks.
- **Deploy automático no merge**: quando um PR vira `MERGED`, busca o workflow run de produção daquele merge commit (`gh run list --commit <sha>`), filtrando `event=push`, nome contém `deploy` e não `staging`. Rastreia `QUEUED -> IN_PROGRESS -> SUCCESS/FAILURE`.
- **Widget**: cada PR mostra linha de CI (`CI passed (3/3)`) e de deploy (`deployed to main`), só com cor para diferenciar (sem emojis). Header conta `N deploying`. Ordenação prioriza abertos e PRs com deploy ativo.
- **Retenção**: merged não é removido enquanto o deploy estiver em andamento, mesmo após as 24h.

### Detecção de deploy
O run de produção é casado pelo evento `push` no merge commit, escolhendo um workflow cujo nome contém `deploy` mas não `staging` — bate com o workflow `Deploy` de `api-arvore`, `frontend-arvore-nextjs`, etc.

### Testado
- `tsc --noEmit` e `tsc` (build) passam limpo
- Estado antigo (PRs salvos sem `ci`/`deploy`) carrega normalmente (campos nullable)

### Pontos de atenção
- O match de deploy é por **nome do workflow**. Se algum repo nomear diferente, dá pra trocar por path do arquivo ou allowlist de repos.
- Rastreia apenas **1 deploy** (produção) por PR. Staging em paralelo pode ser adicionado depois.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PR widget now displays CI status rollup alongside PR information.
  * Production deployment status and URLs now tracked and displayed for merged PRs.
  * Automatic detection of deployment workflow runs added.

* **Documentation**
  * Updated documentation describing CI and deploy status tracking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->