### PR TITLE
feat: linear-tracker and slack-tracker pi extensions

### DIFF
--- a/packages/linear-tracker/README.md
+++ b/packages/linear-tracker/README.md
@@ -18,7 +18,7 @@ Or in `.pi/settings.json`:
 
 ## How it works
 
-- Listens to tool executions. When a command or its output contains a Linear issue URL, the latest one is captured automatically and pinned.
+- Listens to tool executions and to your chat messages. When a command, its output, or a message you send contains a Linear issue URL, the latest one is captured automatically and pinned.
 - The widget pinned above the editor shows the issue ID (e.g. `EXP-231`), a title derived from the URL slug when present, and the full URL.
 - State is persisted per session, so the pinned issue survives restarts of the same session.
 

--- a/packages/linear-tracker/README.md
+++ b/packages/linear-tracker/README.md
@@ -1,0 +1,35 @@
+# @arvoretech/pi-linear-tracker
+
+Pins the active Linear issue link in the chat as a compact persistent widget. The issue is auto-detected from any `linear.app/<team>/issue/<ID>` URL that shows up in a tool command or its output during the session, and can also be set manually.
+
+## Install
+
+```bash
+pi install npm:@arvoretech/pi-linear-tracker
+```
+
+Or in `.pi/settings.json`:
+
+```json
+{
+  "packages": ["npm:@arvoretech/pi-linear-tracker"]
+}
+```
+
+## How it works
+
+- Listens to tool executions. When a command or its output contains a Linear issue URL, the latest one is captured automatically and pinned.
+- The widget pinned above the editor shows the issue ID (e.g. `EXP-231`), a title derived from the URL slug when present, and the full URL.
+- State is persisted per session, so the pinned issue survives restarts of the same session.
+
+## Commands
+
+- `/linear` — show the currently pinned issue (or usage)
+- `/linear <url>` — pin a specific Linear issue
+- `/linear hide` — hide the widget
+- `/linear show` — re-show the widget
+- `/linear clear` — unpin the issue
+
+## Keeping the screen clean
+
+The widget is two compact lines (issue + URL) and shares the `aboveEditor` placement. Use `/linear hide` whenever you don't need it on screen; the pinned link is restored with `/linear show`.

--- a/packages/linear-tracker/package.json
+++ b/packages/linear-tracker/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@arvoretech/pi-linear-tracker",
+  "version": "1.0.0",
+  "description": "PI extension that pins the active Linear issue link in the chat as a compact persistent widget",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "lint": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": ">=0.74.0"
+  },
+  "devDependencies": {
+    "@earendil-works/pi-coding-agent": "latest",
+    "@earendil-works/pi-ai": "latest",
+    "@types/node": "^20.10.0",
+    "typescript": "^5.3.0"
+  },
+  "pi": {
+    "extensions": [
+      "./dist/index.js"
+    ]
+  },
+  "keywords": [
+    "pi-package",
+    "pi",
+    "extension",
+    "linear",
+    "widget"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/arvoreeducacao/arvore-pi-extensions.git",
+    "directory": "packages/linear-tracker"
+  },
+  "author": "Arvore",
+  "license": "MIT"
+}

--- a/packages/linear-tracker/src/index.ts
+++ b/packages/linear-tracker/src/index.ts
@@ -1,0 +1,233 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { join, dirname, basename } from "node:path";
+
+interface LinearLink {
+  url: string;
+  team: string;
+  issueId: string;
+  slug: string;
+}
+
+const STATE_DIR = ".pi/linear-tracker-sessions";
+const WIDGET_ID = "pi-linear-tracker";
+const LINEAR_URL_RE =
+  /https?:\/\/linear\.app\/([^/\s]+)\/issue\/([A-Z]{2,}-\d+)(?:\/([^\s)"']*))?/gi;
+
+let current: LinearLink | null = null;
+let hidden = false;
+let widgetVisible = false;
+let sessionId = `mem-${Date.now()}`;
+
+function getSessionId(ctx: any): string {
+  const file = ctx?.sessionManager?.getSessionFile?.() || "";
+  return file ? basename(file, ".json") : sessionId;
+}
+
+function findHubRoot(cwd: string): string | null {
+  let dir = cwd;
+  for (let i = 0; i < 12; i++) {
+    if (existsSync(join(dir, ".pi")) || existsSync(join(dir, ".git"))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+function getStatePath(cwd: string): string | null {
+  const root = findHubRoot(cwd);
+  return root ? join(root, STATE_DIR, `${sessionId}.json`) : null;
+}
+
+function saveState(cwd: string): void {
+  const path = getStatePath(cwd);
+  if (!path) return;
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, JSON.stringify({ hidden, current }, null, 2));
+  } catch {}
+}
+
+function loadState(cwd: string): void {
+  const path = getStatePath(cwd);
+  if (!path || !existsSync(path)) return;
+  try {
+    const state = JSON.parse(readFileSync(path, "utf-8")) as {
+      hidden?: boolean;
+      current?: LinearLink | null;
+    };
+    hidden = Boolean(state.hidden);
+    current = state.current && state.current.url ? state.current : null;
+  } catch {}
+}
+
+function parseLinearUrl(raw: string): LinearLink | null {
+  LINEAR_URL_RE.lastIndex = 0;
+  const m = LINEAR_URL_RE.exec(raw);
+  if (!m) return null;
+  return {
+    url: m[0],
+    team: m[1],
+    issueId: m[2].toUpperCase(),
+    slug: m[3] ?? "",
+  };
+}
+
+function detectFromText(text: string): LinearLink | null {
+  LINEAR_URL_RE.lastIndex = 0;
+  let last: LinearLink | null = null;
+  let m: RegExpExecArray | null;
+  while ((m = LINEAR_URL_RE.exec(text)) !== null) {
+    last = {
+      url: m[0],
+      team: m[1],
+      issueId: m[2].toUpperCase(),
+      slug: m[3] ?? "",
+    };
+  }
+  return last;
+}
+
+function resultToText(result: any): string {
+  if (typeof result === "string") return result;
+  if (Array.isArray(result)) {
+    return result
+      .map((r) => (typeof r === "string" ? r : (r?.text ?? "")))
+      .join("\n");
+  }
+  if (result && typeof result === "object") {
+    return result.text ?? result.output ?? JSON.stringify(result);
+  }
+  return "";
+}
+
+function titleFromSlug(slug: string): string {
+  if (!slug) return "";
+  const noTail = slug.split(/[?#]/)[0].replace(/\/+$/, "");
+  const last = noTail.split("/").pop() ?? "";
+  const words = last.replace(/-/g, " ").trim();
+  if (!words) return "";
+  return words.charAt(0).toUpperCase() + words.slice(1);
+}
+
+function renderWidget(width: number, theme: any): string[] {
+  if (!current) return [];
+  const fg = (color: string, s: string): string =>
+    theme?.fg ? theme.fg(color, s) : s;
+  const bold = (s: string): string => (theme?.bold ? theme.bold(s) : s);
+  const trunc = (s: string, max: number): string =>
+    s.length > max ? `${s.slice(0, Math.max(1, max - 1))}…` : s;
+
+  const tag = bold(fg("accent", current.issueId));
+  const title = titleFromSlug(current.slug);
+  const head = title
+    ? `${tag} ${fg("text", trunc(title, Math.max(8, width - current.issueId.length - 12)))}`
+    : tag;
+  const lines: string[] = [];
+  lines.push(`${fg("accent", " ◆ Linear")}  ${head}`);
+  lines.push(`   ${fg("mdLinkUrl", trunc(current.url, width - 3))}`);
+  return lines;
+}
+
+function updateWidget(ctx: any): void {
+  if (!ctx?.ui?.setWidget) return;
+  if (hidden || !current) {
+    if (widgetVisible) {
+      ctx.ui.setWidget(WIDGET_ID, undefined);
+      widgetVisible = false;
+    }
+    return;
+  }
+  ctx.ui.setWidget(
+    WIDGET_ID,
+    (_tui: any, theme: any) => ({
+      render(width: number): string[] {
+        return renderWidget(width, theme);
+      },
+      invalidate(): void {
+        widgetVisible = false;
+      },
+    }),
+    { placement: "aboveEditor" },
+  );
+  widgetVisible = true;
+}
+
+export default function linearTrackerExtension(pi: ExtensionAPI): void {
+  pi.on("session_start", async (_event, ctx) => {
+    sessionId = getSessionId(ctx);
+    loadState(ctx?.cwd ?? process.cwd());
+    updateWidget(ctx);
+  });
+
+  pi.on("tool_execution_end", async (event: any, ctx: any) => {
+    if (event?.isError) return;
+    const command: string = event?.args?.command ?? "";
+    const resultText = resultToText(event?.result);
+    const detected = detectFromText(`${command}\n${resultText}`);
+    if (!detected) return;
+    if (current?.url === detected.url) return;
+    current = detected;
+    saveState(ctx?.cwd ?? process.cwd());
+    updateWidget(ctx);
+  });
+
+  pi.registerCommand("linear", {
+    description:
+      "Pin the active Linear issue. Usage: /linear [<url> | show | hide | clear]",
+    handler: async (args, ctx) => {
+      const raw = (args ?? "").trim();
+      const sub = raw.toLowerCase();
+      const cwd = ctx?.cwd ?? process.cwd();
+
+      if (sub === "hide") {
+        hidden = true;
+        saveState(cwd);
+        updateWidget(ctx);
+        ctx.ui.notify("Linear widget escondido.", "info");
+        return;
+      }
+      if (sub === "show") {
+        hidden = false;
+        saveState(cwd);
+        updateWidget(ctx);
+        ctx.ui.notify(
+          current ? "Linear widget visível." : "Nenhuma issue do Linear rastreada ainda.",
+          "info",
+        );
+        return;
+      }
+      if (sub === "clear") {
+        current = null;
+        saveState(cwd);
+        updateWidget(ctx);
+        ctx.ui.notify("Linear desafixado.", "info");
+        return;
+      }
+      if (raw) {
+        const parsed = parseLinearUrl(raw);
+        if (!parsed) {
+          ctx.ui.notify(
+            "URL inválida. Use um link linear.app/<team>/issue/<ID>.",
+            "warning",
+          );
+          return;
+        }
+        current = parsed;
+        hidden = false;
+        saveState(cwd);
+        updateWidget(ctx);
+        ctx.ui.notify(`Linear fixado: ${parsed.issueId}`, "info");
+        return;
+      }
+
+      ctx.ui.notify(
+        current
+          ? `Linear atual: ${current.issueId} — ${current.url}`
+          : "Usage: /linear [<url> | show | hide | clear]",
+        "info",
+      );
+    },
+  });
+}

--- a/packages/linear-tracker/src/index.ts
+++ b/packages/linear-tracker/src/index.ts
@@ -161,16 +161,25 @@ export default function linearTrackerExtension(pi: ExtensionAPI): void {
     updateWidget(ctx);
   });
 
+  const ingest = (text: string, ctx: any): void => {
+    const detected = detectFromText(text);
+    if (!detected) return;
+    if (current?.url === detected.url) return;
+    current = detected;
+    hidden = false;
+    saveState(ctx?.cwd ?? process.cwd());
+    updateWidget(ctx);
+  };
+
+  pi.on("before_agent_start", async (event: any, ctx: any) => {
+    ingest(event?.prompt ?? "", ctx);
+  });
+
   pi.on("tool_execution_end", async (event: any, ctx: any) => {
     if (event?.isError) return;
     const command: string = event?.args?.command ?? "";
     const resultText = resultToText(event?.result);
-    const detected = detectFromText(`${command}\n${resultText}`);
-    if (!detected) return;
-    if (current?.url === detected.url) return;
-    current = detected;
-    saveState(ctx?.cwd ?? process.cwd());
-    updateWidget(ctx);
+    ingest(`${command}\n${resultText}`, ctx);
   });
 
   pi.registerCommand("linear", {

--- a/packages/linear-tracker/tsconfig.json
+++ b/packages/linear-tracker/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/packages/slack-tracker/README.md
+++ b/packages/slack-tracker/README.md
@@ -18,7 +18,7 @@ Or in `.pi/settings.json`:
 
 ## How it works
 
-- Listens to tool executions. When a command or its output contains a Slack URL, the latest one is captured automatically and pinned.
+- Listens to tool executions and to your chat messages. When a command, its output, or a message you send contains a Slack URL, the latest one is captured automatically and pinned.
 - The widget pinned above the editor shows the workspace (when present), whether it's a thread or channel, the channel id, and the full URL.
 - State is persisted per session, so the pinned link survives restarts of the same session.
 

--- a/packages/slack-tracker/README.md
+++ b/packages/slack-tracker/README.md
@@ -1,0 +1,35 @@
+# @arvoretech/pi-slack-tracker
+
+Pins the active Slack thread/channel link in the chat as a compact persistent widget. The link is auto-detected from any `slack.com/archives/...` or `app.slack.com/client/...` URL that shows up in a tool command or its output during the session, and can also be set manually.
+
+## Install
+
+```bash
+pi install npm:@arvoretech/pi-slack-tracker
+```
+
+Or in `.pi/settings.json`:
+
+```json
+{
+  "packages": ["npm:@arvoretech/pi-slack-tracker"]
+}
+```
+
+## How it works
+
+- Listens to tool executions. When a command or its output contains a Slack URL, the latest one is captured automatically and pinned.
+- The widget pinned above the editor shows the workspace (when present), whether it's a thread or channel, the channel id, and the full URL.
+- State is persisted per session, so the pinned link survives restarts of the same session.
+
+## Commands
+
+- `/slack` — show the currently pinned link (or usage)
+- `/slack <url>` — pin a specific Slack thread/channel
+- `/slack hide` — hide the widget
+- `/slack show` — re-show the widget
+- `/slack clear` — unpin the link
+
+## Keeping the screen clean
+
+The widget is two compact lines (channel + URL) and shares the `aboveEditor` placement. Use `/slack hide` whenever you don't need it on screen; the pinned link is restored with `/slack show`.

--- a/packages/slack-tracker/package.json
+++ b/packages/slack-tracker/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@arvoretech/pi-slack-tracker",
+  "version": "1.0.0",
+  "description": "PI extension that pins the active Slack thread/channel link in the chat as a compact persistent widget",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "lint": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": ">=0.74.0"
+  },
+  "devDependencies": {
+    "@earendil-works/pi-coding-agent": "latest",
+    "@earendil-works/pi-ai": "latest",
+    "@types/node": "^20.10.0",
+    "typescript": "^5.3.0"
+  },
+  "pi": {
+    "extensions": [
+      "./dist/index.js"
+    ]
+  },
+  "keywords": [
+    "pi-package",
+    "pi",
+    "extension",
+    "slack",
+    "widget"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/arvoreeducacao/arvore-pi-extensions.git",
+    "directory": "packages/slack-tracker"
+  },
+  "author": "Arvore",
+  "license": "MIT"
+}

--- a/packages/slack-tracker/src/index.ts
+++ b/packages/slack-tracker/src/index.ts
@@ -1,0 +1,241 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { join, dirname, basename } from "node:path";
+
+interface SlackLink {
+  url: string;
+  workspace: string;
+  channel: string;
+  kind: "message" | "channel";
+}
+
+const STATE_DIR = ".pi/slack-tracker-sessions";
+const WIDGET_ID = "pi-slack-tracker";
+const SLACK_ARCHIVES_RE =
+  /https?:\/\/(?:([a-z0-9-]+)\.)?slack\.com\/archives\/([A-Z0-9]+)(?:\/p\d+)?/gi;
+const SLACK_CLIENT_RE =
+  /https?:\/\/app\.slack\.com\/client\/([A-Z0-9]+)\/([A-Z0-9]+)/gi;
+
+let current: SlackLink | null = null;
+let hidden = false;
+let widgetVisible = false;
+let sessionId = `mem-${Date.now()}`;
+
+function getSessionId(ctx: any): string {
+  const file = ctx?.sessionManager?.getSessionFile?.() || "";
+  return file ? basename(file, ".json") : sessionId;
+}
+
+function findHubRoot(cwd: string): string | null {
+  let dir = cwd;
+  for (let i = 0; i < 12; i++) {
+    if (existsSync(join(dir, ".pi")) || existsSync(join(dir, ".git"))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+function getStatePath(cwd: string): string | null {
+  const root = findHubRoot(cwd);
+  return root ? join(root, STATE_DIR, `${sessionId}.json`) : null;
+}
+
+function saveState(cwd: string): void {
+  const path = getStatePath(cwd);
+  if (!path) return;
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, JSON.stringify({ hidden, current }, null, 2));
+  } catch {}
+}
+
+function loadState(cwd: string): void {
+  const path = getStatePath(cwd);
+  if (!path || !existsSync(path)) return;
+  try {
+    const state = JSON.parse(readFileSync(path, "utf-8")) as {
+      hidden?: boolean;
+      current?: SlackLink | null;
+    };
+    hidden = Boolean(state.hidden);
+    current = state.current && state.current.url ? state.current : null;
+  } catch {}
+}
+
+function buildFromArchives(m: RegExpExecArray): SlackLink {
+  const isMessage = /\/p\d+/.test(m[0]);
+  return {
+    url: m[0],
+    workspace: m[1] ?? "",
+    channel: m[2],
+    kind: isMessage ? "message" : "channel",
+  };
+}
+
+function buildFromClient(m: RegExpExecArray): SlackLink {
+  return {
+    url: m[0],
+    workspace: "",
+    channel: m[2],
+    kind: "channel",
+  };
+}
+
+function parseSlackUrl(raw: string): SlackLink | null {
+  SLACK_ARCHIVES_RE.lastIndex = 0;
+  const a = SLACK_ARCHIVES_RE.exec(raw);
+  if (a) return buildFromArchives(a);
+  SLACK_CLIENT_RE.lastIndex = 0;
+  const c = SLACK_CLIENT_RE.exec(raw);
+  if (c) return buildFromClient(c);
+  return null;
+}
+
+function detectFromText(text: string): SlackLink | null {
+  let last: SlackLink | null = null;
+  SLACK_ARCHIVES_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = SLACK_ARCHIVES_RE.exec(text)) !== null) {
+    last = buildFromArchives(m);
+  }
+  if (last) return last;
+  SLACK_CLIENT_RE.lastIndex = 0;
+  while ((m = SLACK_CLIENT_RE.exec(text)) !== null) {
+    last = buildFromClient(m);
+  }
+  return last;
+}
+
+function resultToText(result: any): string {
+  if (typeof result === "string") return result;
+  if (Array.isArray(result)) {
+    return result
+      .map((r) => (typeof r === "string" ? r : (r?.text ?? "")))
+      .join("\n");
+  }
+  if (result && typeof result === "object") {
+    return result.text ?? result.output ?? JSON.stringify(result);
+  }
+  return "";
+}
+
+function renderWidget(width: number, theme: any): string[] {
+  if (!current) return [];
+  const fg = (color: string, s: string): string =>
+    theme?.fg ? theme.fg(color, s) : s;
+  const bold = (s: string): string => (theme?.bold ? theme.bold(s) : s);
+  const trunc = (s: string, max: number): string =>
+    s.length > max ? `${s.slice(0, Math.max(1, max - 1))}…` : s;
+
+  const label = current.kind === "message" ? "thread" : "channel";
+  const ws = current.workspace ? `${current.workspace} · ` : "";
+  const head = bold(fg("text", trunc(`${ws}${label} ${current.channel}`, width - 14)));
+  const lines: string[] = [];
+  lines.push(`${fg("accent", " ◆ Slack")}  ${head}`);
+  lines.push(`   ${fg("mdLinkUrl", trunc(current.url, width - 3))}`);
+  return lines;
+}
+
+function updateWidget(ctx: any): void {
+  if (!ctx?.ui?.setWidget) return;
+  if (hidden || !current) {
+    if (widgetVisible) {
+      ctx.ui.setWidget(WIDGET_ID, undefined);
+      widgetVisible = false;
+    }
+    return;
+  }
+  ctx.ui.setWidget(
+    WIDGET_ID,
+    (_tui: any, theme: any) => ({
+      render(width: number): string[] {
+        return renderWidget(width, theme);
+      },
+      invalidate(): void {
+        widgetVisible = false;
+      },
+    }),
+    { placement: "aboveEditor" },
+  );
+  widgetVisible = true;
+}
+
+export default function slackTrackerExtension(pi: ExtensionAPI): void {
+  pi.on("session_start", async (_event, ctx) => {
+    sessionId = getSessionId(ctx);
+    loadState(ctx?.cwd ?? process.cwd());
+    updateWidget(ctx);
+  });
+
+  pi.on("tool_execution_end", async (event: any, ctx: any) => {
+    if (event?.isError) return;
+    const command: string = event?.args?.command ?? "";
+    const resultText = resultToText(event?.result);
+    const detected = detectFromText(`${command}\n${resultText}`);
+    if (!detected) return;
+    if (current?.url === detected.url) return;
+    current = detected;
+    saveState(ctx?.cwd ?? process.cwd());
+    updateWidget(ctx);
+  });
+
+  pi.registerCommand("slack", {
+    description:
+      "Pin the active Slack thread/channel. Usage: /slack [<url> | show | hide | clear]",
+    handler: async (args, ctx) => {
+      const raw = (args ?? "").trim();
+      const sub = raw.toLowerCase();
+      const cwd = ctx?.cwd ?? process.cwd();
+
+      if (sub === "hide") {
+        hidden = true;
+        saveState(cwd);
+        updateWidget(ctx);
+        ctx.ui.notify("Slack widget escondido.", "info");
+        return;
+      }
+      if (sub === "show") {
+        hidden = false;
+        saveState(cwd);
+        updateWidget(ctx);
+        ctx.ui.notify(
+          current ? "Slack widget visível." : "Nenhum link do Slack rastreado ainda.",
+          "info",
+        );
+        return;
+      }
+      if (sub === "clear") {
+        current = null;
+        saveState(cwd);
+        updateWidget(ctx);
+        ctx.ui.notify("Slack desafixado.", "info");
+        return;
+      }
+      if (raw) {
+        const parsed = parseSlackUrl(raw);
+        if (!parsed) {
+          ctx.ui.notify(
+            "URL inválida. Use um link slack.com/archives/... ou app.slack.com/client/...",
+            "warning",
+          );
+          return;
+        }
+        current = parsed;
+        hidden = false;
+        saveState(cwd);
+        updateWidget(ctx);
+        ctx.ui.notify(`Slack fixado: ${parsed.channel}`, "info");
+        return;
+      }
+
+      ctx.ui.notify(
+        current
+          ? `Slack atual: ${current.url}`
+          : "Usage: /slack [<url> | show | hide | clear]",
+        "info",
+      );
+    },
+  });
+}

--- a/packages/slack-tracker/src/index.ts
+++ b/packages/slack-tracker/src/index.ts
@@ -169,16 +169,25 @@ export default function slackTrackerExtension(pi: ExtensionAPI): void {
     updateWidget(ctx);
   });
 
+  const ingest = (text: string, ctx: any): void => {
+    const detected = detectFromText(text);
+    if (!detected) return;
+    if (current?.url === detected.url) return;
+    current = detected;
+    hidden = false;
+    saveState(ctx?.cwd ?? process.cwd());
+    updateWidget(ctx);
+  };
+
+  pi.on("before_agent_start", async (event: any, ctx: any) => {
+    ingest(event?.prompt ?? "", ctx);
+  });
+
   pi.on("tool_execution_end", async (event: any, ctx: any) => {
     if (event?.isError) return;
     const command: string = event?.args?.command ?? "";
     const resultText = resultToText(event?.result);
-    const detected = detectFromText(`${command}\n${resultText}`);
-    if (!detected) return;
-    if (current?.url === detected.url) return;
-    current = detected;
-    saveState(ctx?.cwd ?? process.cwd());
-    updateWidget(ctx);
+    ingest(`${command}\n${resultText}`, ctx);
   });
 
   pi.registerCommand("slack", {

--- a/packages/slack-tracker/tsconfig.json
+++ b/packages/slack-tracker/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,6 +131,21 @@ importers:
         specifier: ^5.3.0
         version: 5.9.3
 
+  packages/linear-tracker:
+    devDependencies:
+      '@earendil-works/pi-ai':
+        specifier: latest
+        version: 0.79.10(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-coding-agent':
+        specifier: latest
+        version: 0.79.10(ws@8.20.0)(zod@4.4.3)
+      '@types/node':
+        specifier: ^20.10.0
+        version: 20.19.39
+      typescript:
+        specifier: ^5.3.0
+        version: 5.9.3
+
   packages/open-editor:
     devDependencies:
       '@earendil-works/pi-ai':
@@ -209,6 +224,21 @@ importers:
         specifier: 7.17.0
         version: 7.17.0
     devDependencies:
+      '@types/node':
+        specifier: ^20.10.0
+        version: 20.19.39
+      typescript:
+        specifier: ^5.3.0
+        version: 5.9.3
+
+  packages/slack-tracker:
+    devDependencies:
+      '@earendil-works/pi-ai':
+        specifier: latest
+        version: 0.79.10(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-coding-agent':
+        specifier: latest
+        version: 0.79.10(ws@8.20.0)(zod@4.4.3)
       '@types/node':
         specifier: ^20.10.0
         version: 20.19.39
@@ -491,6 +521,10 @@ packages:
     resolution: {integrity: sha512-jQOtYjRGZ7+XC/olw9euLd2V03vkAPO8u0sSnQoLbyOQZz66dEBZrklTESk34Sf3AaeBSua28wjZR48ch1aXJQ==}
     engines: {node: '>=22.19.0'}
 
+  '@earendil-works/pi-agent-core@0.79.10':
+    resolution: {integrity: sha512-XKxgdjhcPuyjrthCOFSgfzT3xZ1uBrJ1IMVDxci1to6hIN6BIg9J5iY8q0pGXK1DLgATLP23da+1UyZLwA360Q==}
+    engines: {node: '>=22.19.0'}
+
   '@earendil-works/pi-agent-core@0.79.5':
     resolution: {integrity: sha512-yOxzx8SRJkGsZTJWfe9VACkAF4amwHUgvFShn8uoYR7/fnhF69Sz0n7TIh8qRH21fBDvo1RLex4NK/iXFQ3u2Q==}
     engines: {node: '>=22.19.0'}
@@ -515,6 +549,11 @@ packages:
 
   '@earendil-works/pi-ai@0.78.1':
     resolution: {integrity: sha512-CM2pkTs1iupG/maw381lC9Q/Y/aQaMGK7GILc28ttImD0ci3LDwKroDsGkWbly5JIy3iqxdRxB9JlG7vvzCzTg==}
+    engines: {node: '>=22.19.0'}
+    hasBin: true
+
+  '@earendil-works/pi-ai@0.79.10':
+    resolution: {integrity: sha512-9jR23tOl0BIUdQMn70Gr72xYBpM7Xgl9Lyv7gAnU1USfkNRuYG/f/edLl+n/Dp/RafDW3JI4DF7y/GhgkORuew==}
     engines: {node: '>=22.19.0'}
     hasBin: true
 
@@ -555,6 +594,11 @@ packages:
 
   '@earendil-works/pi-coding-agent@0.79.1':
     resolution: {integrity: sha512-dLnje4U5H3/ZytJpvhjhPINeDT/yvx85e4OH/ziMQRLpPlfNP12/peY9jRQd4W11Xth2+y2xGAFwS+NeVf2ZwA==}
+    engines: {node: '>=22.19.0'}
+    hasBin: true
+
+  '@earendil-works/pi-coding-agent@0.79.10':
+    resolution: {integrity: sha512-YxaRhmgyDTvLDdGVbe7YzTHV80oL5mX5odg6EhGHz3w5Wu1Ix8DCw7bhtiOBLGQNFRcknia0zPmVWIj30XP1EA==}
     engines: {node: '>=22.19.0'}
     hasBin: true
 
@@ -2875,7 +2919,21 @@ snapshots:
 
   '@earendil-works/pi-agent-core@0.79.0':
     dependencies:
-      '@earendil-works/pi-ai': 0.79.8(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.79.10(ws@8.20.0)(zod@4.4.3)
+      ignore: 7.0.5
+      typebox: 1.1.38
+      yaml: 2.9.0
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-agent-core@0.79.10(ws@8.20.0)(zod@4.4.3)':
+    dependencies:
+      '@earendil-works/pi-ai': 0.79.10(ws@8.20.0)(zod@4.4.3)
       ignore: 7.0.5
       typebox: 1.1.38
       yaml: 2.9.0
@@ -2889,7 +2947,7 @@ snapshots:
 
   '@earendil-works/pi-agent-core@0.79.5':
     dependencies:
-      '@earendil-works/pi-ai': 0.79.8(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.79.10(ws@8.20.0)(zod@4.4.3)
       ignore: 7.0.5
       typebox: 1.1.38
       yaml: 2.9.0
@@ -2903,7 +2961,7 @@ snapshots:
 
   '@earendil-works/pi-agent-core@0.79.6(ws@8.20.0)(zod@4.4.3)':
     dependencies:
-      '@earendil-works/pi-ai': 0.79.8(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.79.10(ws@8.20.0)(zod@4.4.3)
       ignore: 7.0.5
       typebox: 1.1.38
       yaml: 2.9.0
@@ -2917,7 +2975,7 @@ snapshots:
 
   '@earendil-works/pi-agent-core@0.79.8(ws@8.20.0)(zod@4.4.3)':
     dependencies:
-      '@earendil-works/pi-ai': 0.79.8(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.79.10(ws@8.20.0)(zod@4.4.3)
       ignore: 7.0.5
       typebox: 1.1.38
       yaml: 2.9.0
@@ -2977,6 +3035,27 @@ snapshots:
       '@aws-sdk/client-bedrock-runtime': 3.1048.0
       '@google/genai': 1.52.0
       '@mistralai/mistralai': 2.2.1
+      '@smithy/node-http-handler': 4.7.3
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      openai: 6.26.0(ws@8.20.0)(zod@4.4.3)
+      partial-json: 0.1.7
+      typebox: 1.1.38
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-ai@0.79.10(ws@8.20.0)(zod@4.4.3)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
+      '@aws-sdk/client-bedrock-runtime': 3.1048.0
+      '@google/genai': 1.52.0
+      '@mistralai/mistralai': 2.2.6(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.0
       '@smithy/node-http-handler': 4.7.3
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
@@ -3202,10 +3281,40 @@ snapshots:
       - ws
       - zod
 
+  '@earendil-works/pi-coding-agent@0.79.10(ws@8.20.0)(zod@4.4.3)':
+    dependencies:
+      '@earendil-works/pi-agent-core': 0.79.10(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.79.10(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-tui': 0.79.5
+      '@silvia-odwyer/photon-node': 0.3.4
+      chalk: 5.6.2
+      cross-spawn: 7.0.6
+      diff: 8.0.4
+      glob: 13.0.6
+      highlight.js: 10.7.3
+      hosted-git-info: 9.0.3
+      ignore: 7.0.5
+      jiti: 2.7.0
+      minimatch: 10.2.5
+      proper-lockfile: 4.1.2
+      semver: 7.8.0
+      typebox: 1.1.38
+      undici: 8.5.0
+      yaml: 2.9.0
+    optionalDependencies:
+      '@mariozechner/clipboard': 0.3.9
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
   '@earendil-works/pi-coding-agent@0.79.5(ws@8.20.0)(zod@4.4.3)':
     dependencies:
       '@earendil-works/pi-agent-core': 0.79.6(ws@8.20.0)(zod@4.4.3)
-      '@earendil-works/pi-ai': 0.79.8(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.79.10(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-tui': 0.79.5
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2


### PR DESCRIPTION
## Summary

Adds two new Pi extensions, in the spirit of `prs-tracker`, that pin a context link above the editor as a compact persistent widget:

- **`@arvoretech/pi-linear-tracker`** — pins the active Linear issue (`linear.app/<team>/issue/<ID>`).
- **`@arvoretech/pi-slack-tracker`** — pins the active Slack thread/channel (`slack.com/archives/...` and `app.slack.com/client/...`).

They are two independent packages so each can be installed, shown, hidden, and cleared on its own.

## Behavior

- **Auto-detect**: each listens to `tool_execution_end` and captures the latest matching URL from the command or its output. Manual override via `/linear <url>` / `/slack <url>`.
- **Compact widget**: two lines each (id/channel + URL) with `aboveEditor` placement, kept deliberately minimal to avoid screen clutter. `hide`/`show`/`clear` give full control.
- **Per-session persistence**: state stored under `.pi/<ext>-tracker-sessions/<session>.json`, mirroring `prs-tracker`.

## Commands

- `/linear [<url> | show | hide | clear]`
- `/slack [<url> | show | hide | clear]`

## Notes

- No build artifacts committed (`dist/` is gitignored, shipped on publish like `prs-tracker`).
- Both packages `tsc` build clean. Regex detection validated against message/channel/client URL variants.
- `.pi/settings.json` in arvore-hub updated separately to register both packages.

## Tested

- `pnpm build` for both packages (clean).
- Regex detection sanity-checked against Linear issue URLs (with/without slug) and Slack archives/client URLs.