### PR TITLE
feat(elevenlabs-stt): use pasteToEditor for cursor-aware transcript insertion

### DIFF
--- a/packages/elevenlabs-stt/README.md
+++ b/packages/elevenlabs-stt/README.md
@@ -7,7 +7,9 @@ PI extension for push-to-talk speech-to-text using the [ElevenLabs Scribe](https
 Registers a keyboard shortcut that toggles microphone recording. Press once to start recording from your default mic, press again to stop and transcribe. The resulting text is appended to the editor input.
 
 - **First press**: starts recording from the selected microphone via `ffmpeg` (shows `🎙 recording` in the footer).
-- **Second press**: stops recording, sends the audio to ElevenLabs Scribe, and inserts the transcript into the editor (`⏳ transcribing…`).
+- **Second press**: stops recording, sends the audio to ElevenLabs Scribe, and inserts the transcript at the cursor (`⏳ transcribing…`).
+
+The transcript is inserted via the editor's paste pipeline (`pasteToEditor`), so it composes with custom editors such as [pi-vim](https://www.npmjs.com/package/pi-vim) instead of overwriting the input buffer. With a modal editor, dictate while in insert mode — text is inserted at the cursor and the editor's mode/cursor state is preserved.
 
 ## Commands
 

--- a/packages/elevenlabs-stt/package.json
+++ b/packages/elevenlabs-stt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-elevenlabs-stt",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "PI extension for push-to-talk speech-to-text using the ElevenLabs Scribe API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/elevenlabs-stt/src/index.ts
+++ b/packages/elevenlabs-stt/src/index.ts
@@ -238,8 +238,8 @@ export default function elevenlabsStt(pi: ExtensionAPI) {
         ctx.ui.notify("No speech detected.", "info");
       } else {
         const current = ctx.ui.getEditorText();
-        const next = current ? `${current}${current.endsWith(" ") ? "" : " "}${text}` : text;
-        ctx.ui.setEditorText(next);
+        const needsSpace = current.length > 0 && !/\s$/.test(current);
+        ctx.ui.pasteToEditor(needsSpace ? ` ${text}` : text);
         ctx.ui.notify("Transcription inserted.", "info");
       }
     } catch (error) {


### PR DESCRIPTION
## Summary

Replaces `setEditorText()` with `pasteToEditor()` in the elevenlabs-stt extension so transcriptions are inserted at the cursor position instead of overwriting the entire input buffer.

## Changes

- **src/index.ts**: Use `ctx.ui.pasteToEditor()` instead of `ctx.ui.setEditorText()` — inserts text at cursor, composes with custom editors (e.g. pi-vim)
- **README.md**: Document the new paste-based insertion behavior and modal editor compatibility

## Why

`setEditorText` replaces the entire editor content, which is problematic when a user has already typed partial text or is using a modal editor. `pasteToEditor` inserts at the cursor position and preserves editor state — the same pattern already used in `element-inspector`.