### PR TITLE
fix(cloud-sessions): expand ~ in icloud dir path

### DIFF
--- a/packages/cloud-sessions/src/config.ts
+++ b/packages/cloud-sessions/src/config.ts
@@ -27,6 +27,12 @@ export interface CloudSessionsConfig {
   icloud: IcloudProviderConfig;
 }
 
+function expandTilde(value: string): string {
+  if (value === "~") return homedir();
+  if (value.startsWith("~/")) return join(homedir(), value.slice(2));
+  return value;
+}
+
 const CONFIG_DIR = join(homedir(), ".config", "pi");
 const CONFIG_FILE = join(CONFIG_DIR, "cloud-sessions.json");
 
@@ -105,7 +111,9 @@ export async function loadConfig(): Promise<CloudSessionsConfig> {
       remoteName: raw.git?.remoteName || "origin",
     },
     icloud: {
-      dir: process.env.PI_CLOUD_SESSIONS_ICLOUD_DIR || raw.icloud?.dir || defaultIcloudDir(),
+      dir: expandTilde(
+        process.env.PI_CLOUD_SESSIONS_ICLOUD_DIR || raw.icloud?.dir || defaultIcloudDir(),
+      ),
     },
   };
 }


### PR DESCRIPTION
## Summary

The cloud-sessions extension was syncing to the wrong directory when `icloud.dir` (config file or `PI_CLOUD_SESSIONS_ICLOUD_DIR`) used a leading `~`.

`node:path.join` does **not** expand `~`, so a config like:

\`\`\`json
{ "icloud": { "dir": "~/Library/Mobile Documents/com~apple~CloudDocs/pi-sessions" } }
\`\`\`

resolved to a literal `~` segment relative to the cwd, e.g.:

\`\`\`
/Users/<user>/Arvore/arvore-hub/~/Library/Mobile Documents/com~apple~CloudDocs/pi-sessions/...
\`\`\`

So sessions were written into a phantom `~` folder inside the repo instead of the real iCloud Drive folder.

## Fix

Added `expandTilde()` in `config.ts` and applied it when resolving `icloud.dir`. Covers both the config file value and the env var.

## Tested

- `pnpm build` passes; `dist/config.js` contains the expansion.
- Verified locally: config with `~/Library/...` now resolves to the absolute iCloud path. Cleaned up the stray `~` directory that had accumulated redundant session logs (all already present and up-to-date in the correct iCloud folder — no data loss).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tilde (~) path expansion in cloud sessions configuration, enabling more intuitive home directory path specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->