### PR TITLE
chore(cloud-sessions): bump version to 0.2.2

### DIFF
--- a/packages/cloud-sessions/package.json
+++ b/packages/cloud-sessions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-cloud-sessions",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "PI extension that syncs your pi sessions to a cloud backend (private Git repo or iCloud Drive) so you can resume them from any machine",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Version bump for the `@arvoretech/pi-cloud-sessions` package: `0.2.1` → `0.2.2`.

Follow-up to #64 (expand `~` in icloud dir path), which was merged without bumping the package version.