### PR TITLE
feat(prs-tracker): track CI checks and production deploy status

### DIFF
--- a/packages/prs-tracker/src/index.ts
+++ b/packages/prs-tracker/src/index.ts
@@ -114,15 +114,21 @@ function summarizeChecks(rollup: any[]): CiSummary | null {
   let failed = 0;
   let pending = 0;
   for (const c of rollup) {
-    const status: string = (c?.status ?? c?.state ?? "").toUpperCase();
-    const conclusion: string = (c?.conclusion ?? "").toUpperCase();
-    if (status && status !== "COMPLETED") {
-      pending++;
-      continue;
+    let outcome: string;
+    if (c?.__typename === "StatusContext") {
+      outcome = (c?.state ?? "").toUpperCase();
+    } else {
+      const status: string = (c?.status ?? "").toUpperCase();
+      if (status && status !== "COMPLETED") {
+        pending++;
+        continue;
+      }
+      outcome = (c?.conclusion ?? "").toUpperCase();
     }
-    const outcome = conclusion || status;
-    if (["SUCCESS", "NEUTRAL", "SKIPPED"].includes(outcome)) passed++;
-    else if (["FAILURE", "TIMED_OUT", "CANCELLED", "ACTION_REQUIRED", "ERROR", "STALE"].includes(outcome))
+    if (["SUCCESS", "NEUTRAL", "SKIPPED", "EXPECTED"].includes(outcome)) passed++;
+    else if (
+      ["FAILURE", "TIMED_OUT", "CANCELLED", "ACTION_REQUIRED", "ERROR", "STALE"].includes(outcome)
+    )
       failed++;
     else pending++;
   }


### PR DESCRIPTION
Track CI status checks and production deploy workflow runs per PR in the prs-tracker widget.

## Changes
- Pull `statusCheckRollup` + `mergeCommit` from `gh pr view` to summarize CI state (PASS/FAIL/PENDING) with check counts
- On merged PRs, look up the production deploy workflow run by merge commit and track it through `QUEUED → IN_PROGRESS → SUCCESS/FAILURE`
- Render CI and deploy status lines in the pinned widget; header shows deploy count; sort prioritizes active deploys
- Keep merged PRs in widget while their deploy is still in flight

## Bug fixed
`StatusContext` checks (e.g. CodeRabbit) expose result in `.state`, not `.status/.conclusion` like `CheckRun`. Fixed by branching on `__typename`.

## Deploy detection
Matched by `push` event on the merge commit, workflow name contains `deploy` but not `staging`.