### PR TITLE
feat(lsp): LSP bridge extension (TS/JS diagnostics, definition, references, hover, rename)

### DIFF
--- a/packages/lsp/README.md
+++ b/packages/lsp/README.md
@@ -1,0 +1,53 @@
+# @arvoretech/pi-lsp
+
+PI extension that bridges Language Server Protocol servers, giving the agent real compiler diagnostics, go-to-definition, find-references, hover types and project-wide rename — instead of guessing from text.
+
+## Tools
+
+| Tool | Purpose |
+| --- | --- |
+| `lsp_diagnostics` | Real type-checker errors/warnings for a file (e.g. `TS2345`). |
+| `lsp_definition` | Resolve a symbol to its definition (1-based line/column). |
+| `lsp_references` | Find all references to a symbol across the project. |
+| `lsp_hover` | Inferred type signature and docs for a symbol. |
+| `lsp_rename` | Compute a safe project-wide rename. Returns edits; does not apply them. |
+
+## Commands
+
+- `/lsp-status` — list configured language servers and their file extensions.
+
+## Supported languages
+
+Driven by a registry (`src/registry.ts`). Currently:
+
+- **TypeScript / JavaScript** (`.ts .tsx .js .jsx .mts .cts .mjs .cjs`) via `typescript-language-server --stdio`.
+
+Adding a language is a single entry in `LANGUAGE_SERVERS` — the JSON-RPC client, lifecycle, and document sync are language-agnostic.
+
+## Requirements
+
+The language server binary must be on `PATH`. For TS/JS:
+
+```bash
+pnpm add -g typescript-language-server typescript
+```
+
+If a server is missing, the tools return a clear message and the extension stays inert (no crash).
+
+## How it works
+
+- One server instance per `(language, project root)`, lazy-spawned on first use. Root is detected via `tsconfig.json` / `jsconfig.json` / `package.json` / `.git`.
+- Documents are synced (`didOpen` / `didChange`) from disk on each call; diagnostics are awaited with a short quiet-period debounce.
+- Servers are shut down cleanly on `session_shutdown`.
+
+## Architecture
+
+```
+src/
+  protocol.ts   LSP type subset
+  client.ts     JSON-RPC over stdio (Content-Length framing, request/notify)
+  registry.ts   language -> server config
+  manager.ts    spawn / lifecycle / root detection / doc sync / high-level ops
+  tools.ts      lsp_* tool definitions + output formatting
+  index.ts      entry shell (lifecycle + tool registration)
+```

--- a/packages/lsp/package.json
+++ b/packages/lsp/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@arvoretech/pi-lsp",
+  "version": "1.0.0",
+  "description": "PI extension that bridges Language Server Protocol servers to give the agent real compiler diagnostics, go-to-definition, references, hover and rename",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "lint": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": ">=0.74.0"
+  },
+  "devDependencies": {
+    "@earendil-works/pi-coding-agent": "latest",
+    "@earendil-works/pi-ai": "latest",
+    "@types/node": "^20.10.0",
+    "typescript": "^5.3.0"
+  },
+  "pi": {
+    "extensions": [
+      "./dist/index.js"
+    ]
+  },
+  "keywords": [
+    "pi-package",
+    "pi",
+    "extension",
+    "lsp",
+    "language-server",
+    "typescript",
+    "diagnostics"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/arvoreeducacao/arvore-pi-extensions.git",
+    "directory": "packages/lsp"
+  },
+  "author": "Arvore",
+  "license": "MIT"
+}

--- a/packages/lsp/package.json
+++ b/packages/lsp/package.json
@@ -17,8 +17,8 @@
     "@earendil-works/pi-coding-agent": ">=0.74.0"
   },
   "devDependencies": {
-    "@earendil-works/pi-coding-agent": "latest",
-    "@earendil-works/pi-ai": "latest",
+    "@earendil-works/pi-coding-agent": "0.80.2",
+    "@earendil-works/pi-ai": "0.80.2",
     "@types/node": "^20.10.0",
     "typescript": "^5.3.0"
   },

--- a/packages/lsp/src/client.ts
+++ b/packages/lsp/src/client.ts
@@ -12,6 +12,7 @@ interface PendingRequest {
   resolve: (value: unknown) => void;
   reject: (reason: unknown) => void;
   method: string;
+  timer: ReturnType<typeof setTimeout>;
 }
 
 const HEADER_SEPARATOR = "\r\n\r\n";
@@ -74,6 +75,7 @@ export class LspClient extends EventEmitter {
 
       this.pending.set(id, {
         method,
+        timer,
         resolve: (value) => {
           clearTimeout(timer);
           resolve(value as T);
@@ -183,15 +185,15 @@ export class LspClient extends EventEmitter {
       this.writeRaw({
         jsonrpc: "2.0",
         id: message.id,
-        result: this.defaultServerRequestResult(message.method),
+        result: this.defaultServerRequestResult(message.method, message.params),
       });
     }
   }
 
-  private defaultServerRequestResult(method: string): unknown {
+  private defaultServerRequestResult(method: string, params: unknown): unknown {
     switch (method) {
       case "workspace/configuration":
-        return [null];
+        return ((params as { items?: unknown[] } | undefined)?.items ?? []).map(() => null);
       case "client/registerCapability":
       case "client/unregisterCapability":
       case "window/workDoneProgress/create":
@@ -202,7 +204,10 @@ export class LspClient extends EventEmitter {
   }
 
   private rejectAll(reason: unknown): void {
-    for (const pending of this.pending.values()) pending.reject(reason);
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(reason);
+    }
     this.pending.clear();
   }
 }

--- a/packages/lsp/src/client.ts
+++ b/packages/lsp/src/client.ts
@@ -1,0 +1,208 @@
+import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
+import { EventEmitter } from "node:events";
+import type {
+  PublishDiagnosticsParams,
+  RpcId,
+  RpcNotification,
+  RpcRequest,
+  RpcResponse,
+} from "./protocol.js";
+
+interface PendingRequest {
+  resolve: (value: unknown) => void;
+  reject: (reason: unknown) => void;
+  method: string;
+}
+
+const HEADER_SEPARATOR = "\r\n\r\n";
+
+export interface LspClientOptions {
+  command: string;
+  args: string[];
+  cwd: string;
+  env?: NodeJS.ProcessEnv;
+}
+
+export class LspClient extends EventEmitter {
+  private proc: ChildProcessWithoutNullStreams | null = null;
+  private nextId = 1;
+  private pending = new Map<RpcId, PendingRequest>();
+  private buffer = Buffer.alloc(0);
+  private disposed = false;
+
+  constructor(private readonly options: LspClientOptions) {
+    super();
+  }
+
+  start(): void {
+    if (this.proc) return;
+    this.proc = spawn(this.options.command, this.options.args, {
+      cwd: this.options.cwd,
+      env: { ...process.env, ...this.options.env },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    this.proc.stdout.on("data", (chunk: Buffer) => this.onData(chunk));
+    this.proc.stderr.on("data", (chunk: Buffer) => {
+      this.emit("stderr", chunk.toString("utf-8"));
+    });
+    this.proc.on("exit", (code, sig) => {
+      this.emit("exit", code, sig);
+      this.rejectAll(new Error(`language server exited (code=${code} signal=${sig})`));
+    });
+    this.proc.on("error", (err) => {
+      this.emit("spawn_error", err);
+      this.rejectAll(err);
+    });
+  }
+
+  isRunning(): boolean {
+    return this.proc !== null && this.proc.exitCode === null && !this.disposed;
+  }
+
+  request<T = unknown>(method: string, params?: unknown, timeoutMs = 20_000): Promise<T> {
+    if (!this.proc) return Promise.reject(new Error("language server not started"));
+    const id = this.nextId++;
+    const payload: RpcRequest = { jsonrpc: "2.0", id, method, params };
+
+    return new Promise<T>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        if (this.pending.delete(id)) {
+          reject(new Error(`LSP request "${method}" timed out after ${timeoutMs}ms`));
+        }
+      }, timeoutMs);
+
+      this.pending.set(id, {
+        method,
+        resolve: (value) => {
+          clearTimeout(timer);
+          resolve(value as T);
+        },
+        reject: (reason) => {
+          clearTimeout(timer);
+          reject(reason);
+        },
+      });
+
+      this.write(payload);
+    });
+  }
+
+  notify(method: string, params?: unknown): void {
+    if (!this.proc) return;
+    const payload: RpcNotification = { jsonrpc: "2.0", method, params };
+    this.write(payload);
+  }
+
+  async dispose(): Promise<void> {
+    if (this.disposed) return;
+    this.disposed = true;
+    if (this.proc && this.proc.exitCode === null) {
+      try {
+        await this.request("shutdown", undefined, 3_000).catch(() => {});
+        this.notify("exit");
+      } catch {}
+      const proc = this.proc;
+      await new Promise<void>((resolve) => {
+        const killTimer = setTimeout(() => {
+          proc.kill("SIGKILL");
+          resolve();
+        }, 2_000);
+        proc.once("exit", () => {
+          clearTimeout(killTimer);
+          resolve();
+        });
+      });
+    }
+    this.rejectAll(new Error("language server disposed"));
+    this.proc = null;
+  }
+
+  private write(message: RpcRequest | RpcNotification): void {
+    this.writeRaw(message);
+  }
+
+  private writeRaw(message: RpcRequest | RpcNotification | RpcResponse): void {
+    if (!this.proc || this.proc.stdin.destroyed) return;
+    const body = JSON.stringify(message);
+    const header = `Content-Length: ${Buffer.byteLength(body, "utf-8")}${HEADER_SEPARATOR}`;
+    this.proc.stdin.write(header + body);
+  }
+
+  private onData(chunk: Buffer): void {
+    this.buffer = Buffer.concat([this.buffer, chunk]);
+    this.drain();
+  }
+
+  private drain(): void {
+    while (true) {
+      const headerEnd = this.buffer.indexOf(HEADER_SEPARATOR);
+      if (headerEnd === -1) return;
+
+      const header = this.buffer.subarray(0, headerEnd).toString("utf-8");
+      const match = header.match(/Content-Length:\s*(\d+)/i);
+      if (!match) {
+        this.buffer = this.buffer.subarray(headerEnd + HEADER_SEPARATOR.length);
+        continue;
+      }
+
+      const contentLength = Number(match[1]);
+      const bodyStart = headerEnd + HEADER_SEPARATOR.length;
+      if (this.buffer.length < bodyStart + contentLength) return;
+
+      const body = this.buffer.subarray(bodyStart, bodyStart + contentLength).toString("utf-8");
+      this.buffer = this.buffer.subarray(bodyStart + contentLength);
+
+      try {
+        this.handleMessage(JSON.parse(body));
+      } catch (err) {
+        this.emit("parse_error", err);
+      }
+    }
+  }
+
+  private handleMessage(message: RpcResponse & RpcNotification): void {
+    if (message.id !== undefined && (message.result !== undefined || message.error !== undefined)) {
+      const pending = this.pending.get(message.id);
+      if (!pending) return;
+      this.pending.delete(message.id);
+      if (message.error) {
+        pending.reject(new Error(`${pending.method}: ${message.error.message}`));
+      } else {
+        pending.resolve(message.result);
+      }
+      return;
+    }
+
+    if (message.method === "textDocument/publishDiagnostics") {
+      this.emit("diagnostics", message.params as PublishDiagnosticsParams);
+      return;
+    }
+
+    if (message.id !== undefined && message.method) {
+      this.writeRaw({
+        jsonrpc: "2.0",
+        id: message.id,
+        result: this.defaultServerRequestResult(message.method),
+      });
+    }
+  }
+
+  private defaultServerRequestResult(method: string): unknown {
+    switch (method) {
+      case "workspace/configuration":
+        return [null];
+      case "client/registerCapability":
+      case "client/unregisterCapability":
+      case "window/workDoneProgress/create":
+        return null;
+      default:
+        return null;
+    }
+  }
+
+  private rejectAll(reason: unknown): void {
+    for (const pending of this.pending.values()) pending.reject(reason);
+    this.pending.clear();
+  }
+}

--- a/packages/lsp/src/index.ts
+++ b/packages/lsp/src/index.ts
@@ -1,0 +1,35 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { LspManager } from "./manager.js";
+import { LANGUAGE_SERVERS } from "./registry.js";
+import { registerLspTools } from "./tools.js";
+
+export default function (pi: ExtensionAPI) {
+  let manager: LspManager | null = null;
+
+  const getManager = (): LspManager => {
+    if (!manager) throw new Error("LSP manager not initialized; session not started yet.");
+    return manager;
+  };
+
+  pi.on("session_start", async (_event, ctx) => {
+    if (manager) return;
+    manager = new LspManager(ctx.cwd, (message, level) => ctx.ui.notify(message, level ?? "info"));
+  });
+
+  pi.on("session_shutdown", async () => {
+    await manager?.disposeAll();
+    manager = null;
+  });
+
+  pi.registerCommand("lsp-status", {
+    description: "Show configured LSP language servers and their availability.",
+    handler: async (_args, ctx) => {
+      const lines = LANGUAGE_SERVERS.map(
+        (s) => `${s.label}: ${s.command} ${s.args.join(" ")} (${s.extensions.join(", ")})`,
+      );
+      ctx.ui.notify(`Configured LSP servers:\n${lines.join("\n")}`, "info");
+    },
+  });
+
+  registerLspTools(pi, getManager);
+}

--- a/packages/lsp/src/manager.ts
+++ b/packages/lsp/src/manager.ts
@@ -1,0 +1,298 @@
+import { execSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, isAbsolute, join, resolve, sep } from "node:path";
+import { pathToFileURL } from "node:url";
+import { LspClient } from "./client.js";
+import type {
+  Diagnostic,
+  Hover,
+  Location,
+  LocationLink,
+  Position,
+  PublishDiagnosticsParams,
+  WorkspaceEdit,
+} from "./protocol.js";
+import {
+  type LanguageServerConfig,
+  languageIdForPath,
+  serverForPath,
+} from "./registry.js";
+
+interface ServerInstance {
+  config: LanguageServerConfig;
+  rootPath: string;
+  client: LspClient;
+  ready: Promise<void>;
+  openDocs: Map<string, number>;
+  diagnostics: Map<string, Diagnostic[]>;
+  available: boolean;
+}
+
+export type Notifier = (message: string, level?: "info" | "warning" | "error") => void;
+
+function uriToPath(uri: string): string {
+  if (!uri.startsWith("file://")) return uri;
+  return decodeURIComponent(uri.replace(/^file:\/\//, ""));
+}
+
+export class LspManager {
+  private servers = new Map<string, ServerInstance>();
+  private commandChecked = new Map<string, boolean>();
+
+  constructor(
+    private readonly cwd: string,
+    private readonly notify: Notifier,
+  ) {}
+
+  private absPath(filePath: string): string {
+    return isAbsolute(filePath) ? filePath : resolve(this.cwd, filePath);
+  }
+
+  private commandExists(command: string): boolean {
+    if (this.commandChecked.has(command)) return this.commandChecked.get(command)!;
+    let ok = false;
+    try {
+      execSync(`command -v ${command}`, { stdio: "ignore", cwd: this.cwd });
+      ok = true;
+    } catch {
+      ok = false;
+    }
+    this.commandChecked.set(command, ok);
+    return ok;
+  }
+
+  private findRoot(filePath: string, config: LanguageServerConfig): string {
+    let dir = dirname(this.absPath(filePath));
+    let lastMatch: string | null = null;
+    const segments = dir.split(sep).length;
+    for (let i = 0; i < segments; i++) {
+      for (const marker of config.rootMarkers) {
+        if (existsSync(join(dir, marker))) {
+          lastMatch = dir;
+          if (marker === ".git") return dir;
+          break;
+        }
+      }
+      const parent = dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+    return lastMatch ?? dirname(this.absPath(filePath));
+  }
+
+  private instanceKey(config: LanguageServerConfig, rootPath: string): string {
+    return `${config.id}:${rootPath}`;
+  }
+
+  private async getOrCreate(filePath: string): Promise<ServerInstance | null> {
+    const config = serverForPath(filePath);
+    if (!config) return null;
+
+    const rootPath = this.findRoot(filePath, config);
+    const key = this.instanceKey(config, rootPath);
+    const existing = this.servers.get(key);
+    if (existing) {
+      if (!existing.available) return null;
+      if (!existing.client.isRunning()) {
+        this.servers.delete(key);
+      } else {
+        await existing.ready;
+        return existing;
+      }
+    }
+
+    if (!this.commandExists(config.command)) {
+      this.notify(
+        `LSP: "${config.command}" not found. Install it to enable ${config.label} support.`,
+        "warning",
+      );
+      this.servers.set(key, {
+        config,
+        rootPath,
+        client: new LspClient({ command: config.command, args: config.args, cwd: rootPath }),
+        ready: Promise.resolve(),
+        openDocs: new Map(),
+        diagnostics: new Map(),
+        available: false,
+      });
+      return null;
+    }
+
+    const client = new LspClient({ command: config.command, args: config.args, cwd: rootPath });
+    const instance: ServerInstance = {
+      config,
+      rootPath,
+      client,
+      ready: Promise.resolve(),
+      openDocs: new Map(),
+      diagnostics: new Map(),
+      available: true,
+    };
+
+    client.on("diagnostics", (params: PublishDiagnosticsParams) => {
+      instance.diagnostics.set(uriToPath(params.uri), params.diagnostics);
+    });
+    client.on("exit", () => {
+      this.servers.delete(key);
+    });
+    client.on("spawn_error", (err: unknown) => {
+      instance.available = false;
+      this.notify(`LSP: failed to start ${config.label}: ${String(err)}`, "error");
+    });
+
+    instance.ready = this.initialize(instance);
+    this.servers.set(key, instance);
+    await instance.ready;
+    return instance.available ? instance : null;
+  }
+
+  private async initialize(instance: ServerInstance): Promise<void> {
+    const { client, rootPath } = instance;
+    client.start();
+    const rootUri = pathToFileURL(rootPath).toString();
+    try {
+      await client.request("initialize", {
+        processId: process.pid,
+        rootPath,
+        rootUri,
+        workspaceFolders: [{ uri: rootUri, name: rootPath }],
+        initializationOptions: instance.config.initializationOptions,
+        capabilities: {
+          textDocument: {
+            synchronization: { dynamicRegistration: false, didSave: false },
+            publishDiagnostics: { relatedInformation: true },
+            hover: { contentFormat: ["markdown", "plaintext"] },
+            definition: { linkSupport: true },
+            references: {},
+            rename: { prepareSupport: false },
+          },
+          workspace: { workspaceFolders: true, configuration: true },
+        },
+      });
+      client.notify("initialized", {});
+      client.notify("workspace/didChangeConfiguration", { settings: {} });
+    } catch (err) {
+      instance.available = false;
+      this.notify(`LSP: initialize failed for ${instance.config.label}: ${String(err)}`, "error");
+    }
+  }
+
+  private async ensureOpen(instance: ServerInstance, filePath: string): Promise<string> {
+    const abs = this.absPath(filePath);
+    const uri = pathToFileURL(abs).toString();
+    let text: string;
+    try {
+      text = readFileSync(abs, "utf-8");
+    } catch {
+      throw new Error(`cannot read file: ${abs}`);
+    }
+
+    const openVersion = instance.openDocs.get(uri);
+    if (openVersion === undefined) {
+      instance.openDocs.set(uri, 1);
+      instance.client.notify("textDocument/didOpen", {
+        textDocument: { uri, languageId: languageIdForPath(abs), version: 1, text },
+      });
+    } else {
+      const version = openVersion + 1;
+      instance.openDocs.set(uri, version);
+      instance.client.notify("textDocument/didChange", {
+        textDocument: { uri, version },
+        contentChanges: [{ text }],
+      });
+    }
+    return uri;
+  }
+
+  private async waitForDiagnostics(instance: ServerInstance, path: string, timeoutMs: number): Promise<void> {
+    return new Promise((resolve) => {
+      let settled = false;
+      const finish = () => {
+        if (settled) return;
+        settled = true;
+        instance.client.off("diagnostics", onDiag);
+        resolve();
+      };
+      const onDiag = (params: PublishDiagnosticsParams) => {
+        if (uriToPath(params.uri) === path) {
+          clearTimeout(quietTimer);
+          quietTimer = setTimeout(finish, 350);
+        }
+      };
+      let quietTimer = setTimeout(finish, timeoutMs);
+      instance.client.on("diagnostics", onDiag);
+    });
+  }
+
+  async diagnostics(filePath: string): Promise<{ path: string; diagnostics: Diagnostic[] } | null> {
+    const instance = await this.getOrCreate(filePath);
+    if (!instance) return null;
+    const abs = this.absPath(filePath);
+    await this.ensureOpen(instance, filePath);
+    await this.waitForDiagnostics(instance, abs, 6_000);
+    return { path: abs, diagnostics: instance.diagnostics.get(abs) ?? [] };
+  }
+
+  async definition(filePath: string, position: Position): Promise<Location[] | null> {
+    const instance = await this.getOrCreate(filePath);
+    if (!instance) return null;
+    const uri = await this.ensureOpen(instance, filePath);
+    const result = await instance.client.request<Location | Location[] | LocationLink[] | null>(
+      "textDocument/definition",
+      { textDocument: { uri }, position },
+    );
+    return normalizeLocations(result);
+  }
+
+  async references(filePath: string, position: Position): Promise<Location[] | null> {
+    const instance = await this.getOrCreate(filePath);
+    if (!instance) return null;
+    const uri = await this.ensureOpen(instance, filePath);
+    const result = await instance.client.request<Location[] | null>("textDocument/references", {
+      textDocument: { uri },
+      position,
+      context: { includeDeclaration: false },
+    });
+    return result ?? [];
+  }
+
+  async hover(filePath: string, position: Position): Promise<Hover | null> {
+    const instance = await this.getOrCreate(filePath);
+    if (!instance) return null;
+    const uri = await this.ensureOpen(instance, filePath);
+    return instance.client.request<Hover | null>("textDocument/hover", {
+      textDocument: { uri },
+      position,
+    });
+  }
+
+  async rename(filePath: string, position: Position, newName: string): Promise<WorkspaceEdit | null> {
+    const instance = await this.getOrCreate(filePath);
+    if (!instance) return null;
+    const uri = await this.ensureOpen(instance, filePath);
+    return instance.client.request<WorkspaceEdit | null>("textDocument/rename", {
+      textDocument: { uri },
+      position,
+      newName,
+    });
+  }
+
+  async disposeAll(): Promise<void> {
+    const all = [...this.servers.values()];
+    this.servers.clear();
+    await Promise.all(all.map((i) => i.client.dispose().catch(() => {})));
+  }
+}
+
+function normalizeLocations(
+  result: Location | Location[] | LocationLink[] | null,
+): Location[] {
+  if (!result) return [];
+  const arr = Array.isArray(result) ? result : [result];
+  return arr.map((item) => {
+    if ("targetUri" in item) {
+      return { uri: item.targetUri, range: item.targetSelectionRange ?? item.targetRange };
+    }
+    return item;
+  });
+}

--- a/packages/lsp/src/manager.ts
+++ b/packages/lsp/src/manager.ts
@@ -1,7 +1,7 @@
 import { execSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { dirname, isAbsolute, join, resolve, sep } from "node:path";
-import { pathToFileURL } from "node:url";
+import { pathToFileURL, fileURLToPath } from "node:url";
 import { LspClient } from "./client.js";
 import type {
   Diagnostic,
@@ -32,7 +32,7 @@ export type Notifier = (message: string, level?: "info" | "warning" | "error") =
 
 function uriToPath(uri: string): string {
   if (!uri.startsWith("file://")) return uri;
-  return decodeURIComponent(uri.replace(/^file:\/\//, ""));
+  return fileURLToPath(uri);
 }
 
 export class LspManager {

--- a/packages/lsp/src/protocol.ts
+++ b/packages/lsp/src/protocol.ts
@@ -1,0 +1,89 @@
+export interface Position {
+  line: number;
+  character: number;
+}
+
+export interface Range {
+  start: Position;
+  end: Position;
+}
+
+export interface Location {
+  uri: string;
+  range: Range;
+}
+
+export interface LocationLink {
+  targetUri: string;
+  targetRange: Range;
+  targetSelectionRange: Range;
+}
+
+export enum DiagnosticSeverity {
+  Error = 1,
+  Warning = 2,
+  Information = 3,
+  Hint = 4,
+}
+
+export interface Diagnostic {
+  range: Range;
+  severity?: DiagnosticSeverity;
+  code?: string | number;
+  source?: string;
+  message: string;
+}
+
+export interface PublishDiagnosticsParams {
+  uri: string;
+  version?: number;
+  diagnostics: Diagnostic[];
+}
+
+export interface TextEdit {
+  range: Range;
+  newText: string;
+}
+
+export interface WorkspaceEdit {
+  changes?: Record<string, TextEdit[]>;
+  documentChanges?: Array<{
+    textDocument: { uri: string; version: number | null };
+    edits: TextEdit[];
+  }>;
+}
+
+export interface Hover {
+  contents:
+    | string
+    | { kind: string; value: string }
+    | Array<string | { language?: string; value: string }>;
+  range?: Range;
+}
+
+export interface MarkupContent {
+  kind: "plaintext" | "markdown";
+  value: string;
+}
+
+export type RpcId = number | string;
+
+export interface RpcRequest {
+  jsonrpc: "2.0";
+  id: RpcId;
+  method: string;
+  params?: unknown;
+}
+
+export interface RpcNotification {
+  jsonrpc: "2.0";
+  method: string;
+  params?: unknown;
+}
+
+export interface RpcResponse {
+  jsonrpc: "2.0";
+  id: RpcId;
+  result?: unknown;
+  error?: { code: number; message: string; data?: unknown };
+}

--- a/packages/lsp/src/registry.ts
+++ b/packages/lsp/src/registry.ts
@@ -1,0 +1,36 @@
+export interface LanguageServerConfig {
+  id: string;
+  label: string;
+  languageId: string;
+  command: string;
+  args: string[];
+  extensions: string[];
+  rootMarkers: string[];
+  initializationOptions?: Record<string, unknown>;
+}
+
+export const LANGUAGE_SERVERS: LanguageServerConfig[] = [
+  {
+    id: "typescript",
+    label: "TypeScript / JavaScript",
+    languageId: "typescript",
+    command: "typescript-language-server",
+    args: ["--stdio"],
+    extensions: [".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs"],
+    rootMarkers: ["tsconfig.json", "jsconfig.json", "package.json", ".git"],
+  },
+];
+
+export function languageIdForPath(filePath: string): string {
+  const lower = filePath.toLowerCase();
+  if (lower.endsWith(".tsx")) return "typescriptreact";
+  if (lower.endsWith(".jsx")) return "javascriptreact";
+  if (lower.endsWith(".ts") || lower.endsWith(".mts") || lower.endsWith(".cts")) return "typescript";
+  if (lower.endsWith(".js") || lower.endsWith(".mjs") || lower.endsWith(".cjs")) return "javascript";
+  return "plaintext";
+}
+
+export function serverForPath(filePath: string): LanguageServerConfig | undefined {
+  const lower = filePath.toLowerCase();
+  return LANGUAGE_SERVERS.find((s) => s.extensions.some((ext) => lower.endsWith(ext)));
+}

--- a/packages/lsp/src/tools.ts
+++ b/packages/lsp/src/tools.ts
@@ -1,5 +1,6 @@
 import { Type } from "@earendil-works/pi-ai";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { fileURLToPath } from "node:url";
 import type { LspManager } from "./manager.js";
 import {
   type Diagnostic,
@@ -45,7 +46,7 @@ function formatDiagnostics(path: string, cwd: string, diagnostics: Diagnostic[])
 }
 
 function uriToRel(uri: string, cwd: string): string {
-  const path = uri.startsWith("file://") ? decodeURIComponent(uri.replace(/^file:\/\//, "")) : uri;
+  const path = uri.startsWith("file://") ? fileURLToPath(uri) : uri;
   return relativize(path, cwd);
 }
 

--- a/packages/lsp/src/tools.ts
+++ b/packages/lsp/src/tools.ts
@@ -1,0 +1,233 @@
+import { Type } from "@earendil-works/pi-ai";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type { LspManager } from "./manager.js";
+import {
+  type Diagnostic,
+  DiagnosticSeverity,
+  type Hover,
+  type Location,
+} from "./protocol.js";
+
+function relativize(filePath: string, cwd: string): string {
+  return filePath.startsWith(cwd + "/") ? filePath.slice(cwd.length + 1) : filePath;
+}
+
+function severityLabel(severity?: DiagnosticSeverity): string {
+  switch (severity) {
+    case DiagnosticSeverity.Error:
+      return "error";
+    case DiagnosticSeverity.Warning:
+      return "warning";
+    case DiagnosticSeverity.Information:
+      return "info";
+    case DiagnosticSeverity.Hint:
+      return "hint";
+    default:
+      return "error";
+  }
+}
+
+function formatDiagnostics(path: string, cwd: string, diagnostics: Diagnostic[]): string {
+  if (diagnostics.length === 0) return `No diagnostics for ${relativize(path, cwd)}.`;
+  const rel = relativize(path, cwd);
+  const lines = diagnostics
+    .slice()
+    .sort((a, b) => a.range.start.line - b.range.start.line)
+    .map((d) => {
+      const line = d.range.start.line + 1;
+      const col = d.range.start.character + 1;
+      const code = d.code !== undefined ? ` [${d.source ?? "lsp"} ${d.code}]` : d.source ? ` [${d.source}]` : "";
+      return `${rel}:${line}:${col} ${severityLabel(d.severity)}${code}: ${d.message}`;
+    });
+  const errors = diagnostics.filter((d) => (d.severity ?? 1) === DiagnosticSeverity.Error).length;
+  const warnings = diagnostics.filter((d) => d.severity === DiagnosticSeverity.Warning).length;
+  return `${rel}: ${errors} error(s), ${warnings} warning(s)\n${lines.join("\n")}`;
+}
+
+function uriToRel(uri: string, cwd: string): string {
+  const path = uri.startsWith("file://") ? decodeURIComponent(uri.replace(/^file:\/\//, "")) : uri;
+  return relativize(path, cwd);
+}
+
+function formatLocations(locations: Location[], cwd: string): string {
+  if (locations.length === 0) return "No results.";
+  return locations
+    .map((loc) => {
+      const line = loc.range.start.line + 1;
+      const col = loc.range.start.character + 1;
+      return `${uriToRel(loc.uri, cwd)}:${line}:${col}`;
+    })
+    .join("\n");
+}
+
+function formatHover(hover: Hover | null): string {
+  if (!hover || !hover.contents) return "No hover information.";
+  const { contents } = hover;
+  if (typeof contents === "string") return contents;
+  if (Array.isArray(contents)) {
+    return contents.map((c) => (typeof c === "string" ? c : c.value)).join("\n\n");
+  }
+  return contents.value;
+}
+
+const NOT_AVAILABLE =
+  "No language server available for this file (unsupported language or server not installed).";
+
+export function registerLspTools(pi: ExtensionAPI, getManager: () => LspManager): void {
+  pi.registerTool({
+    name: "lsp_diagnostics",
+    label: "LSP Diagnostics",
+    description:
+      "Get real compiler/type-checker diagnostics (errors and warnings) for a source file from its language server. Use after editing a file to verify there are no type errors, or to understand why a file fails to compile.",
+    promptSnippet: "Get compiler diagnostics (type errors/warnings) for a file via LSP",
+    promptGuidelines: [
+      "Call lsp_diagnostics after editing a TypeScript/JavaScript file to confirm there are no type errors before moving on.",
+      "Prefer lsp_diagnostics over running a full build when you only need to validate a single file.",
+    ],
+    parameters: Type.Object({
+      file: Type.String({ description: "Path to the source file (relative to cwd or absolute)." }),
+    }),
+    async execute(_id, params, _signal, _onUpdate, ctx) {
+      const result = await getManager().diagnostics(params.file);
+      if (!result) return { content: [{ type: "text", text: NOT_AVAILABLE }], details: {} };
+      return {
+        content: [{ type: "text", text: formatDiagnostics(result.path, ctx.cwd, result.diagnostics) }],
+        details: { path: result.path, count: result.diagnostics.length },
+      };
+    },
+  });
+
+  pi.registerTool({
+    name: "lsp_definition",
+    label: "LSP Definition",
+    description:
+      "Find where a symbol is defined using the language server. Provide the file and the line/column of an occurrence of the symbol. Lines and columns are 1-based.",
+    promptSnippet: "Jump to a symbol's definition via LSP (1-based line/column)",
+    parameters: Type.Object({
+      file: Type.String({ description: "Path to the source file." }),
+      line: Type.Number({ description: "1-based line number of the symbol." }),
+      column: Type.Number({ description: "1-based column number of the symbol." }),
+    }),
+    async execute(_id, params, _signal, _onUpdate, ctx) {
+      const locations = await getManager().definition(params.file, {
+        line: params.line - 1,
+        character: params.column - 1,
+      });
+      if (locations === null) return { content: [{ type: "text", text: NOT_AVAILABLE }], details: {} };
+      return {
+        content: [{ type: "text", text: formatLocations(locations, ctx.cwd) }],
+        details: { count: locations.length },
+      };
+    },
+  });
+
+  pi.registerTool({
+    name: "lsp_references",
+    label: "LSP References",
+    description:
+      "Find all references to a symbol across the project using the language server. Provide the file and the 1-based line/column of an occurrence of the symbol.",
+    promptSnippet: "Find all references to a symbol via LSP (1-based line/column)",
+    parameters: Type.Object({
+      file: Type.String({ description: "Path to the source file." }),
+      line: Type.Number({ description: "1-based line number of the symbol." }),
+      column: Type.Number({ description: "1-based column number of the symbol." }),
+    }),
+    async execute(_id, params, _signal, _onUpdate, ctx) {
+      const locations = await getManager().references(params.file, {
+        line: params.line - 1,
+        character: params.column - 1,
+      });
+      if (locations === null) return { content: [{ type: "text", text: NOT_AVAILABLE }], details: {} };
+      return {
+        content: [{ type: "text", text: formatLocations(locations, ctx.cwd) }],
+        details: { count: locations.length },
+      };
+    },
+  });
+
+  pi.registerTool({
+    name: "lsp_hover",
+    label: "LSP Hover",
+    description:
+      "Get type information and documentation for a symbol at a position using the language server. Returns inferred types and JSDoc. Provide the file and 1-based line/column.",
+    promptSnippet: "Get a symbol's inferred type and docs via LSP (1-based line/column)",
+    parameters: Type.Object({
+      file: Type.String({ description: "Path to the source file." }),
+      line: Type.Number({ description: "1-based line number of the symbol." }),
+      column: Type.Number({ description: "1-based column number of the symbol." }),
+    }),
+    async execute(_id, params, _signal, _onUpdate, _ctx) {
+      const hover = await getManager().hover(params.file, {
+        line: params.line - 1,
+        character: params.column - 1,
+      });
+      if (hover === null) return { content: [{ type: "text", text: NOT_AVAILABLE }], details: {} };
+      return { content: [{ type: "text", text: formatHover(hover) }], details: {} };
+    },
+  });
+
+  pi.registerTool({
+    name: "lsp_rename",
+    label: "LSP Rename",
+    description:
+      "Compute a project-wide rename of a symbol using the language server. Returns the set of edits (files, ranges, new text) WITHOUT applying them — review and apply the edits yourself with the edit tool. Provide the file, 1-based line/column of the symbol, and the new name.",
+    promptSnippet: "Compute a safe project-wide symbol rename via LSP (does not apply edits)",
+    promptGuidelines: [
+      "lsp_rename only returns the edits; you must apply them with the edit/write tools.",
+      "Use lsp_rename instead of text search-and-replace when renaming a symbol, to avoid touching unrelated matches.",
+    ],
+    parameters: Type.Object({
+      file: Type.String({ description: "Path to the source file." }),
+      line: Type.Number({ description: "1-based line number of the symbol." }),
+      column: Type.Number({ description: "1-based column number of the symbol." }),
+      newName: Type.String({ description: "The new name for the symbol." }),
+    }),
+    async execute(_id, params, _signal, _onUpdate, ctx) {
+      const edit = await getManager().rename(
+        params.file,
+        { line: params.line - 1, character: params.column - 1 },
+        params.newName,
+      );
+      if (edit === null) return { content: [{ type: "text", text: NOT_AVAILABLE }], details: {} };
+
+      const changes: Record<string, Array<{ range: unknown; newText: string }>> = {};
+      if (edit.changes) {
+        for (const [uri, edits] of Object.entries(edit.changes)) {
+          changes[uriToRel(uri, ctx.cwd)] = edits;
+        }
+      }
+      if (edit.documentChanges) {
+        for (const dc of edit.documentChanges) {
+          changes[uriToRel(dc.textDocument.uri, ctx.cwd)] = dc.edits;
+        }
+      }
+
+      const fileCount = Object.keys(changes).length;
+      if (fileCount === 0) {
+        return { content: [{ type: "text", text: "Rename produced no edits (symbol may not be renameable here)." }], details: {} };
+      }
+
+      const summary = Object.entries(changes)
+        .map(([file, edits]) => {
+          const lines = edits
+            .map((e) => {
+              const r = e.range as { start: { line: number; character: number } };
+              return `  ${r.start.line + 1}:${r.start.character + 1} -> "${e.newText}"`;
+            })
+            .join("\n");
+          return `${file} (${edits.length} edit(s)):\n${lines}`;
+        })
+        .join("\n\n");
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Rename "${params.newName}" affects ${fileCount} file(s). Apply these edits yourself:\n\n${summary}`,
+          },
+        ],
+        details: { files: fileCount, changes },
+      };
+    },
+  });
+}

--- a/packages/lsp/tsconfig.json
+++ b/packages/lsp/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,10 +174,10 @@ importers:
   packages/lsp:
     devDependencies:
       '@earendil-works/pi-ai':
-        specifier: latest
+        specifier: 0.80.2
         version: 0.80.2(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-coding-agent':
-        specifier: latest
+        specifier: 0.80.2
         version: 0.80.2(ws@8.20.0)(zod@4.4.3)
       '@types/node':
         specifier: ^20.10.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,6 +64,24 @@ importers:
         specifier: ^5.3.0
         version: 5.9.3
 
+  packages/cloud-sessions:
+    devDependencies:
+      '@earendil-works/pi-ai':
+        specifier: ^0.79.4
+        version: 0.79.6(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-coding-agent':
+        specifier: ^0.79.4
+        version: 0.79.6(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-tui':
+        specifier: 0.79.5
+        version: 0.79.5
+      '@types/node':
+        specifier: ^20.10.0
+        version: 20.19.39
+      typescript:
+        specifier: ^5.3.0
+        version: 5.9.3
+
   packages/element-inspector:
     dependencies:
       ws:
@@ -101,7 +119,14 @@ importers:
         specifier: ^5.3.0
         version: 5.9.3
 
-  packages/fan-out:
+  packages/git-review:
+    dependencies:
+      parse-diff:
+        specifier: ^0.11.1
+        version: 0.11.1
+      ws:
+        specifier: ^8.18.0
+        version: 8.20.0
     devDependencies:
       '@earendil-works/pi-ai':
         specifier: latest
@@ -109,12 +134,12 @@ importers:
       '@earendil-works/pi-coding-agent':
         specifier: latest
         version: 0.80.2(ws@8.20.0)(zod@4.4.3)
-      '@earendil-works/pi-tui':
-        specifier: 0.79.5
-        version: 0.79.5
       '@types/node':
         specifier: ^20.10.0
         version: 20.19.39
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
       typescript:
         specifier: ^5.3.0
         version: 5.9.3
@@ -124,6 +149,36 @@ importers:
       '@earendil-works/pi-coding-agent':
         specifier: 0.79.1
         version: 0.79.1
+      '@types/node':
+        specifier: ^20.10.0
+        version: 20.19.39
+      typescript:
+        specifier: ^5.3.0
+        version: 5.9.3
+
+  packages/linear-tracker:
+    devDependencies:
+      '@earendil-works/pi-ai':
+        specifier: latest
+        version: 0.80.2(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-coding-agent':
+        specifier: latest
+        version: 0.80.2(ws@8.20.0)(zod@4.4.3)
+      '@types/node':
+        specifier: ^20.10.0
+        version: 20.19.39
+      typescript:
+        specifier: ^5.3.0
+        version: 5.9.3
+
+  packages/lsp:
+    devDependencies:
+      '@earendil-works/pi-ai':
+        specifier: latest
+        version: 0.80.2(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-coding-agent':
+        specifier: latest
+        version: 0.80.2(ws@8.20.0)(zod@4.4.3)
       '@types/node':
         specifier: ^20.10.0
         version: 20.19.39
@@ -200,15 +255,14 @@ importers:
         specifier: ^5.3.0
         version: 5.9.3
 
-  packages/slack-agent:
-    dependencies:
-      '@slack/bolt':
-        specifier: 4.7.3
-        version: 4.7.3(@types/express@5.0.6)
-      '@slack/web-api':
-        specifier: 7.17.0
-        version: 7.17.0
+  packages/slack-tracker:
     devDependencies:
+      '@earendil-works/pi-ai':
+        specifier: latest
+        version: 0.80.2(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-coding-agent':
+        specifier: latest
+        version: 0.80.2(ws@8.20.0)(zod@4.4.3)
       '@types/node':
         specifier: ^20.10.0
         version: 20.19.39
@@ -1029,32 +1083,6 @@ packages:
   '@silvia-odwyer/photon-node@0.3.4':
     resolution: {integrity: sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==}
 
-  '@slack/bolt@4.7.3':
-    resolution: {integrity: sha512-bODs8q/yNDWUPoxmQhFrRqLMA5vhB/PDizYWqb6CkQhLWEUo5JFtfJcmeU4ElGl6qSt++OKjSYNa4MPc77CleQ==}
-    engines: {node: '>=18', npm: '>=8.6.0'}
-    peerDependencies:
-      '@types/express': ^5.0.0
-
-  '@slack/logger@4.0.1':
-    resolution: {integrity: sha512-6cmdPrV/RYfd2U0mDGiMK8S7OJqpCTm7enMLRR3edccsPX8j7zXTLnaEF4fhxxJJTAIOil6+qZrnUPTuaLvwrQ==}
-    engines: {node: '>= 18', npm: '>= 8.6.0'}
-
-  '@slack/oauth@3.0.5':
-    resolution: {integrity: sha512-exqFQySKhNDptWYSWhvRUJ4/+ndu2gayIy7vg/JfmJq3wGtGdHk531P96fAZyBm5c1Le3yaPYqv92rL4COlU3A==}
-    engines: {node: '>=18', npm: '>=8.6.0'}
-
-  '@slack/socket-mode@2.0.7':
-    resolution: {integrity: sha512-qYy07je71WnEHgRwmw12DlAnZLi5HXmdlI2WUzUK2LH/rYXQpP6uEg462S5CwfE8FoCKUdIigHtYnOOfzZH1lQ==}
-    engines: {node: '>= 18', npm: '>= 8.6.0'}
-
-  '@slack/types@2.21.1':
-    resolution: {integrity: sha512-I8vmSjNYWsaxuWPx6dz4yeh0h7vRBWbgAMK14LEmblbZ404BtrPbXs6jDPx4cYgGf8msDGF4A9opLZBu21FViQ==}
-    engines: {node: '>= 12.13.0', npm: '>= 6.12.0'}
-
-  '@slack/web-api@7.17.0':
-    resolution: {integrity: sha512-jejr34a8B4L5AS713wOAx1LAqNkW16HVMDEa6sYBvFDc/llUBl8hXaiI4BwF+Al+Sug19Vn2O7iokTVIhVvZ1Q==}
-    engines: {node: '>= 18', npm: '>= 8.6.0'}
-
   '@smithy/config-resolver@4.4.17':
     resolution: {integrity: sha512-TzDZcAnhTyAHbXVxWZo7/tEcrIeFq20IBk8So3OLOetWpR8EwY/yEqBMBFaJMeyEiREDq4NfEl+qO3OAUD+vbQ==}
     engines: {node: '>=18.0.0'}
@@ -1245,53 +1273,20 @@ packages:
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
 
-  '@types/body-parser@1.19.6':
-    resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
-
-  '@types/connect@3.4.38':
-    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
-
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
-  '@types/express-serve-static-core@5.1.1':
-    resolution: {integrity: sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==}
-
-  '@types/express@5.0.6':
-    resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
-
-  '@types/http-errors@2.0.5':
-    resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
-
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
-
-  '@types/jsonwebtoken@9.0.10':
-    resolution: {integrity: sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==}
-
-  '@types/ms@2.1.0':
-    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
   '@types/node@20.19.39':
     resolution: {integrity: sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==}
 
-  '@types/qs@6.15.1':
-    resolution: {integrity: sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==}
-
-  '@types/range-parser@1.2.7':
-    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
-
   '@types/retry@0.12.0':
     resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
-
-  '@types/send@1.2.1':
-    resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
-
-  '@types/serve-static@2.2.0':
-    resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -1358,10 +1353,6 @@ packages:
     resolution: {integrity: sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  accepts@2.0.0:
-    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
-    engines: {node: '>= 0.6'}
-
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1371,10 +1362,6 @@ packages:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
-
-  agent-base@6.0.2:
-    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
-    engines: {node: '>= 6.0.0'}
 
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
@@ -1402,12 +1389,6 @@ packages:
     resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
     engines: {node: '>=4'}
 
-  asynckit@0.4.0:
-    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
-
-  axios@1.18.0:
-    resolution: {integrity: sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==}
-
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -1422,10 +1403,6 @@ packages:
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
-  body-parser@2.3.0:
-    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
-    engines: {node: '>=18'}
-
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
@@ -1438,18 +1415,6 @@ packages:
 
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
-
-  bytes@3.1.2:
-    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
-    engines: {node: '>= 0.8'}
-
-  call-bind-apply-helpers@1.0.2:
-    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
-    engines: {node: '>= 0.4'}
-
-  call-bound@1.0.4:
-    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
-    engines: {node: '>= 0.4'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -1473,30 +1438,6 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
-
-  combined-stream@1.0.8:
-    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
-    engines: {node: '>= 0.8'}
-
-  content-disposition@1.1.0:
-    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
-    engines: {node: '>=18'}
-
-  content-type@1.0.5:
-    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
-    engines: {node: '>= 0.6'}
-
-  content-type@2.0.0:
-    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
-    engines: {node: '>=18'}
-
-  cookie-signature@1.2.2:
-    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
-    engines: {node: '>=6.6.0'}
-
-  cookie@0.7.2:
-    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
-    engines: {node: '>= 0.6'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1526,14 +1467,6 @@ packages:
     resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
     engines: {node: '>= 14'}
 
-  delayed-stream@1.0.0:
-    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
-    engines: {node: '>=0.4.0'}
-
-  depd@2.0.0:
-    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
-    engines: {node: '>= 0.8'}
-
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
@@ -1542,48 +1475,18 @@ packages:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
     engines: {node: '>=0.3.1'}
 
-  dunder-proto@1.0.1:
-    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
-    engines: {node: '>= 0.4'}
-
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
-
-  ee-first@1.1.1:
-    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
-  encodeurl@2.0.0:
-    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
-    engines: {node: '>= 0.8'}
-
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
-
-  es-define-property@1.0.1:
-    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
-    engines: {node: '>= 0.4'}
-
-  es-errors@1.3.0:
-    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
-    engines: {node: '>= 0.4'}
-
-  es-object-atoms@1.1.2:
-    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
-    engines: {node: '>= 0.4'}
-
-  es-set-tostringtag@2.1.0:
-    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
-    engines: {node: '>= 0.4'}
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
-
-  escape-html@1.0.3:
-    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -1641,20 +1544,6 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
-  etag@1.8.1:
-    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
-    engines: {node: '>= 0.6'}
-
-  eventemitter3@4.0.7:
-    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
-
-  eventemitter3@5.0.4:
-    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
-
-  express@5.2.1:
-    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
-    engines: {node: '>= 18'}
-
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
@@ -1703,10 +1592,6 @@ packages:
     resolution: {integrity: sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==}
     engines: {node: '>=20'}
 
-  finalhandler@2.1.1:
-    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
-    engines: {node: '>= 18.0.0'}
-
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
@@ -1718,33 +1603,9 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
-  follow-redirects@1.16.0:
-    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-
-  form-data@4.0.6:
-    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
-    engines: {node: '>= 6'}
-
   formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
-
-  forwarded@0.2.0:
-    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
-    engines: {node: '>= 0.6'}
-
-  fresh@2.0.0:
-    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
-    engines: {node: '>= 0.8'}
-
-  function-bind@1.1.2:
-    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
   gaxios@7.1.4:
     resolution: {integrity: sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==}
@@ -1761,14 +1622,6 @@ packages:
   get-east-asian-width@1.6.0:
     resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
     engines: {node: '>=18'}
-
-  get-intrinsic@1.3.0:
-    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
-    engines: {node: '>= 0.4'}
-
-  get-proto@1.0.1:
-    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
-    engines: {node: '>= 0.4'}
 
   get-stream@5.2.0:
     resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
@@ -1794,28 +1647,12 @@ packages:
     resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
     engines: {node: '>=14'}
 
-  gopd@1.2.0:
-    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
-    engines: {node: '>= 0.4'}
-
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
-
-  has-symbols@1.1.0:
-    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
-    engines: {node: '>= 0.4'}
-
-  has-tostringtag@1.0.2:
-    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
-    engines: {node: '>= 0.4'}
-
-  hasown@2.0.4:
-    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
-    engines: {node: '>= 0.4'}
 
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
@@ -1824,25 +1661,13 @@ packages:
     resolution: {integrity: sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  http-errors@2.0.1:
-    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
-    engines: {node: '>= 0.8'}
-
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
 
-  https-proxy-agent@5.0.1:
-    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
-    engines: {node: '>= 6'}
-
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
-
-  iconv-lite@0.7.2:
-    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
-    engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -1859,19 +1684,9 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
-  inherits@2.0.4:
-    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
-
   ip-address@10.2.0:
     resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
-
-  ipaddr.js@1.9.1:
-    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
-    engines: {node: '>= 0.10'}
-
-  is-electron@2.2.2:
-    resolution: {integrity: sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -1884,13 +1699,6 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
-
-  is-promise@4.0.0:
-    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
-
-  is-stream@2.0.1:
-    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
-    engines: {node: '>=8'}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -1915,10 +1723,6 @@ packages:
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
-  jsonwebtoken@9.0.3:
-    resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
-    engines: {node: '>=12', npm: '>=6'}
-
   jwa@2.0.1:
     resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
 
@@ -1935,27 +1739,6 @@ packages:
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
-
-  lodash.includes@4.3.0:
-    resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
-
-  lodash.isboolean@3.0.3:
-    resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
-
-  lodash.isinteger@4.0.4:
-    resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
-
-  lodash.isnumber@3.0.3:
-    resolution: {integrity: sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==}
-
-  lodash.isplainobject@4.0.6:
-    resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
-
-  lodash.isstring@4.0.1:
-    resolution: {integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==}
-
-  lodash.once@4.1.1:
-    resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
 
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
@@ -1978,34 +1761,6 @@ packages:
     engines: {node: '>= 20'}
     hasBin: true
 
-  math-intrinsics@1.1.0:
-    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
-    engines: {node: '>= 0.4'}
-
-  media-typer@1.1.0:
-    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
-    engines: {node: '>= 0.8'}
-
-  merge-descriptors@2.0.0:
-    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
-    engines: {node: '>=18'}
-
-  mime-db@1.52.0:
-    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
-    engines: {node: '>= 0.6'}
-
-  mime-db@1.54.0:
-    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
-    engines: {node: '>= 0.6'}
-
-  mime-types@2.1.35:
-    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
-    engines: {node: '>= 0.6'}
-
-  mime-types@3.0.2:
-    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
-    engines: {node: '>=18'}
-
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -2023,10 +1778,6 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
-  negotiator@1.0.0:
-    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
-    engines: {node: '>= 0.6'}
-
   netmask@2.1.1:
     resolution: {integrity: sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==}
     engines: {node: '>= 0.4.0'}
@@ -2043,14 +1794,6 @@ packages:
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
-
-  object-inspect@1.13.4:
-    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
-    engines: {node: '>= 0.4'}
-
-  on-finished@2.4.1:
-    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
-    engines: {node: '>= 0.8'}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -2071,10 +1814,6 @@ packages:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
 
-  p-finally@1.0.0:
-    resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
-    engines: {node: '>=4'}
-
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
@@ -2083,16 +1822,8 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
-  p-queue@6.6.2:
-    resolution: {integrity: sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==}
-    engines: {node: '>=8'}
-
   p-retry@4.6.2:
     resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
-    engines: {node: '>=8'}
-
-  p-timeout@3.2.0:
-    resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
     engines: {node: '>=8'}
 
   pac-proxy-agent@7.2.0:
@@ -2103,6 +1834,9 @@ packages:
     resolution: {integrity: sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==}
     engines: {node: '>= 14'}
 
+  parse-diff@0.11.1:
+    resolution: {integrity: sha512-Oq4j8LAOPOcssanQkIjxosjATBIEJhCxMCxPhMu+Ci4wdNmAEdx0O+a7gzbR2PyKXgKPvRLIN5g224+dJAsKHA==}
+
   parse5-htmlparser2-tree-adapter@6.0.1:
     resolution: {integrity: sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==}
 
@@ -2111,10 +1845,6 @@ packages:
 
   parse5@6.0.1:
     resolution: {integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==}
-
-  parseurl@1.3.3:
-    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
-    engines: {node: '>= 0.8'}
 
   partial-json@0.1.7:
     resolution: {integrity: sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==}
@@ -2135,9 +1865,6 @@ packages:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
 
-  path-to-regexp@8.4.2:
-    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
-
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
@@ -2156,10 +1883,6 @@ packages:
     resolution: {integrity: sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==}
     engines: {node: '>=12.0.0'}
 
-  proxy-addr@2.0.7:
-    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
-    engines: {node: '>= 0.10'}
-
   proxy-agent@6.5.0:
     resolution: {integrity: sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==}
     engines: {node: '>= 14'}
@@ -2167,28 +1890,12 @@ packages:
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
-  proxy-from-env@2.1.0:
-    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
-    engines: {node: '>=10'}
-
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
-
-  qs@6.15.2:
-    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
-    engines: {node: '>=0.6'}
-
-  range-parser@1.2.1:
-    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
-    engines: {node: '>= 0.6'}
-
-  raw-body@3.0.2:
-    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
-    engines: {node: '>= 0.10'}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -2202,15 +1909,8 @@ packages:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
     engines: {node: '>= 4'}
 
-  router@2.2.0:
-    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
-    engines: {node: '>= 18'}
-
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
-
-  safer-buffer@2.1.2:
-    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
@@ -2221,17 +1921,6 @@ packages:
     resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
     engines: {node: '>=10'}
     hasBin: true
-
-  send@1.2.1:
-    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
-    engines: {node: '>= 18'}
-
-  serve-static@2.2.1:
-    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
-    engines: {node: '>= 18'}
-
-  setprototypeof@1.2.0:
-    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
@@ -2244,22 +1933,6 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
-
-  side-channel-list@1.0.1:
-    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
-    engines: {node: '>= 0.4'}
-
-  side-channel-map@1.0.1:
-    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
-    engines: {node: '>= 0.4'}
-
-  side-channel-weakmap@1.0.2:
-    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
-    engines: {node: '>= 0.4'}
-
-  side-channel@1.1.1:
-    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
-    engines: {node: '>= 0.4'}
 
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
@@ -2279,10 +1952,6 @@ packages:
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
-
-  statuses@2.0.2:
-    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
-    engines: {node: '>= 0.8'}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -2318,10 +1987,6 @@ packages:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
-  toidentifier@1.0.1:
-    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
-    engines: {node: '>=0.6'}
-
   token-types@6.1.2:
     resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
     engines: {node: '>=14.16'}
@@ -2338,17 +2003,9 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  tsscmp@1.0.6:
-    resolution: {integrity: sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==}
-    engines: {node: '>=0.6.x'}
-
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
-
-  type-is@2.1.0:
-    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
-    engines: {node: '>= 18'}
 
   typebox@0.0.1:
     resolution: {integrity: sha512-pJc2iszaWtRS4mIX73nT2IvgtTTuW0yu3unrbMcszsNxzypSpMiTmt7Cr/2t59amfI0naGEE6jvSWeqMFynL+g==}
@@ -2387,20 +2044,12 @@ packages:
     resolution: {integrity: sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==}
     engines: {node: '>=22.19.0'}
 
-  unpipe@1.0.0:
-    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
-    engines: {node: '>= 0.8'}
-
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
   uuid@14.0.0:
     resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
-
-  vary@1.1.2:
-    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
-    engines: {node: '>= 0.8'}
 
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
@@ -3643,74 +3292,6 @@ snapshots:
 
   '@silvia-odwyer/photon-node@0.3.4': {}
 
-  '@slack/bolt@4.7.3(@types/express@5.0.6)':
-    dependencies:
-      '@slack/logger': 4.0.1
-      '@slack/oauth': 3.0.5
-      '@slack/socket-mode': 2.0.7
-      '@slack/types': 2.21.1
-      '@slack/web-api': 7.17.0
-      '@types/express': 5.0.6
-      axios: 1.18.0
-      express: 5.2.1
-      path-to-regexp: 8.4.2
-      raw-body: 3.0.2
-      tsscmp: 1.0.6
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - supports-color
-      - utf-8-validate
-
-  '@slack/logger@4.0.1':
-    dependencies:
-      '@types/node': 20.19.39
-
-  '@slack/oauth@3.0.5':
-    dependencies:
-      '@slack/logger': 4.0.1
-      '@slack/web-api': 7.17.0
-      '@types/jsonwebtoken': 9.0.10
-      '@types/node': 20.19.39
-      jsonwebtoken: 9.0.3
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-
-  '@slack/socket-mode@2.0.7':
-    dependencies:
-      '@slack/logger': 4.0.1
-      '@slack/web-api': 7.17.0
-      '@types/node': 20.19.39
-      '@types/ws': 8.18.1
-      eventemitter3: 5.0.4
-      ws: 8.20.0
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - supports-color
-      - utf-8-validate
-
-  '@slack/types@2.21.1': {}
-
-  '@slack/web-api@7.17.0':
-    dependencies:
-      '@slack/logger': 4.0.1
-      '@slack/types': 2.21.1
-      '@types/node': 20.19.39
-      '@types/retry': 0.12.0
-      axios: 1.18.0
-      eventemitter3: 5.0.4
-      form-data: 4.0.6
-      is-electron: 2.2.2
-      is-stream: 2.0.1
-      p-queue: 6.6.2
-      p-retry: 4.6.2
-      retry: 0.13.1
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-
   '@smithy/config-resolver@4.4.17':
     dependencies:
       '@smithy/node-config-provider': 4.3.14
@@ -3995,61 +3576,17 @@ snapshots:
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
 
-  '@types/body-parser@1.19.6':
-    dependencies:
-      '@types/connect': 3.4.38
-      '@types/node': 20.19.39
-
-  '@types/connect@3.4.38':
-    dependencies:
-      '@types/node': 20.19.39
-
   '@types/esrecurse@4.3.1': {}
 
   '@types/estree@1.0.9': {}
 
-  '@types/express-serve-static-core@5.1.1':
-    dependencies:
-      '@types/node': 20.19.39
-      '@types/qs': 6.15.1
-      '@types/range-parser': 1.2.7
-      '@types/send': 1.2.1
-
-  '@types/express@5.0.6':
-    dependencies:
-      '@types/body-parser': 1.19.6
-      '@types/express-serve-static-core': 5.1.1
-      '@types/serve-static': 2.2.0
-
-  '@types/http-errors@2.0.5': {}
-
   '@types/json-schema@7.0.15': {}
-
-  '@types/jsonwebtoken@9.0.10':
-    dependencies:
-      '@types/ms': 2.1.0
-      '@types/node': 20.19.39
-
-  '@types/ms@2.1.0': {}
 
   '@types/node@20.19.39':
     dependencies:
       undici-types: 6.21.0
 
-  '@types/qs@6.15.1': {}
-
-  '@types/range-parser@1.2.7': {}
-
   '@types/retry@0.12.0': {}
-
-  '@types/send@1.2.1':
-    dependencies:
-      '@types/node': 20.19.39
-
-  '@types/serve-static@2.2.0':
-    dependencies:
-      '@types/http-errors': 2.0.5
-      '@types/node': 20.19.39
 
   '@types/ws@8.18.1':
     dependencies:
@@ -4151,22 +3688,11 @@ snapshots:
       '@typescript-eslint/types': 8.59.3
       eslint-visitor-keys: 5.0.1
 
-  accepts@2.0.0:
-    dependencies:
-      mime-types: 3.0.2
-      negotiator: 1.0.0
-
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
 
   acorn@8.16.0: {}
-
-  agent-base@6.0.2:
-    dependencies:
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
 
   agent-base@7.1.4: {}
 
@@ -4191,18 +3717,6 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  asynckit@0.4.0: {}
-
-  axios@1.18.0:
-    dependencies:
-      follow-redirects: 1.16.0
-      form-data: 4.0.6
-      https-proxy-agent: 5.0.1
-      proxy-from-env: 2.1.0
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-
   balanced-match@4.0.4: {}
 
   base64-js@1.5.1: {}
@@ -4210,20 +3724,6 @@ snapshots:
   basic-ftp@5.3.1: {}
 
   bignumber.js@9.3.1: {}
-
-  body-parser@2.3.0:
-    dependencies:
-      bytes: 3.1.2
-      content-type: 2.0.0
-      debug: 4.4.3
-      http-errors: 2.0.1
-      iconv-lite: 0.7.2
-      on-finished: 2.4.1
-      qs: 6.15.2
-      raw-body: 3.0.2
-      type-is: 2.1.0
-    transitivePeerDependencies:
-      - supports-color
 
   bowser@2.14.1: {}
 
@@ -4234,18 +3734,6 @@ snapshots:
   buffer-crc32@0.2.13: {}
 
   buffer-equal-constant-time@1.0.1: {}
-
-  bytes@3.1.2: {}
-
-  call-bind-apply-helpers@1.0.2:
-    dependencies:
-      es-errors: 1.3.0
-      function-bind: 1.1.2
-
-  call-bound@1.0.4:
-    dependencies:
-      call-bind-apply-helpers: 1.0.2
-      get-intrinsic: 1.3.0
 
   chalk@4.1.2:
     dependencies:
@@ -4275,20 +3763,6 @@ snapshots:
 
   color-name@1.1.4: {}
 
-  combined-stream@1.0.8:
-    dependencies:
-      delayed-stream: 1.0.0
-
-  content-disposition@1.1.0: {}
-
-  content-type@1.0.5: {}
-
-  content-type@2.0.0: {}
-
-  cookie-signature@1.2.2: {}
-
-  cookie@0.7.2: {}
-
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -4311,52 +3785,21 @@ snapshots:
       escodegen: 2.1.0
       esprima: 4.0.1
 
-  delayed-stream@1.0.0: {}
-
-  depd@2.0.0: {}
-
   detect-libc@2.1.2: {}
 
   diff@8.0.4: {}
-
-  dunder-proto@1.0.1:
-    dependencies:
-      call-bind-apply-helpers: 1.0.2
-      es-errors: 1.3.0
-      gopd: 1.2.0
 
   ecdsa-sig-formatter@1.0.11:
     dependencies:
       safe-buffer: 5.2.1
 
-  ee-first@1.1.1: {}
-
   emoji-regex@8.0.0: {}
-
-  encodeurl@2.0.0: {}
 
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
 
-  es-define-property@1.0.1: {}
-
-  es-errors@1.3.0: {}
-
-  es-object-atoms@1.1.2:
-    dependencies:
-      es-errors: 1.3.0
-
-  es-set-tostringtag@2.1.0:
-    dependencies:
-      es-errors: 1.3.0
-      get-intrinsic: 1.3.0
-      has-tostringtag: 1.0.2
-      hasown: 2.0.4
-
   escalade@3.2.0: {}
-
-  escape-html@1.0.3: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -4436,45 +3879,6 @@ snapshots:
 
   esutils@2.0.3: {}
 
-  etag@1.8.1: {}
-
-  eventemitter3@4.0.7: {}
-
-  eventemitter3@5.0.4: {}
-
-  express@5.2.1:
-    dependencies:
-      accepts: 2.0.0
-      body-parser: 2.3.0
-      content-disposition: 1.1.0
-      content-type: 1.0.5
-      cookie: 0.7.2
-      cookie-signature: 1.2.2
-      debug: 4.4.3
-      depd: 2.0.0
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      etag: 1.8.1
-      finalhandler: 2.1.1
-      fresh: 2.0.0
-      http-errors: 2.0.1
-      merge-descriptors: 2.0.0
-      mime-types: 3.0.2
-      on-finished: 2.4.1
-      once: 1.4.0
-      parseurl: 1.3.3
-      proxy-addr: 2.0.7
-      qs: 6.15.2
-      range-parser: 1.2.1
-      router: 2.2.0
-      send: 1.2.1
-      serve-static: 2.2.1
-      statuses: 2.0.2
-      type-is: 2.1.0
-      vary: 1.1.2
-    transitivePeerDependencies:
-      - supports-color
-
   extend@3.0.2: {}
 
   extract-zip@2.0.1:
@@ -4530,17 +3934,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  finalhandler@2.1.1:
-    dependencies:
-      debug: 4.4.3
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      on-finished: 2.4.1
-      parseurl: 1.3.3
-      statuses: 2.0.2
-    transitivePeerDependencies:
-      - supports-color
-
   find-up@5.0.0:
     dependencies:
       locate-path: 6.0.0
@@ -4553,25 +3946,9 @@ snapshots:
 
   flatted@3.4.2: {}
 
-  follow-redirects@1.16.0: {}
-
-  form-data@4.0.6:
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      es-set-tostringtag: 2.1.0
-      hasown: 2.0.4
-      mime-types: 2.1.35
-
   formdata-polyfill@4.0.10:
     dependencies:
       fetch-blob: 3.2.0
-
-  forwarded@0.2.0: {}
-
-  fresh@2.0.0: {}
-
-  function-bind@1.1.2: {}
 
   gaxios@7.1.4:
     dependencies:
@@ -4592,24 +3969,6 @@ snapshots:
   get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.6.0: {}
-
-  get-intrinsic@1.3.0:
-    dependencies:
-      call-bind-apply-helpers: 1.0.2
-      es-define-property: 1.0.1
-      es-errors: 1.3.0
-      es-object-atoms: 1.1.2
-      function-bind: 1.1.2
-      get-proto: 1.0.1
-      gopd: 1.2.0
-      has-symbols: 1.1.0
-      hasown: 2.0.4
-      math-intrinsics: 1.1.0
-
-  get-proto@1.0.1:
-    dependencies:
-      dunder-proto: 1.0.1
-      es-object-atoms: 1.1.2
 
   get-stream@5.2.0:
     dependencies:
@@ -4646,21 +4005,9 @@ snapshots:
 
   google-logging-utils@1.1.3: {}
 
-  gopd@1.2.0: {}
-
   graceful-fs@4.2.11: {}
 
   has-flag@4.0.0: {}
-
-  has-symbols@1.1.0: {}
-
-  has-tostringtag@1.0.2:
-    dependencies:
-      has-symbols: 1.1.0
-
-  hasown@2.0.4:
-    dependencies:
-      function-bind: 1.1.2
 
   highlight.js@10.7.3: {}
 
@@ -4668,24 +4015,9 @@ snapshots:
     dependencies:
       lru-cache: 11.3.6
 
-  http-errors@2.0.1:
-    dependencies:
-      depd: 2.0.0
-      inherits: 2.0.4
-      setprototypeof: 1.2.0
-      statuses: 2.0.2
-      toidentifier: 1.0.1
-
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
-  https-proxy-agent@5.0.1:
-    dependencies:
-      agent-base: 6.0.2
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
@@ -4697,10 +4029,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  iconv-lite@0.7.2:
-    dependencies:
-      safer-buffer: 2.1.2
-
   ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
@@ -4709,13 +4037,7 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
-  inherits@2.0.4: {}
-
   ip-address@10.2.0: {}
-
-  ipaddr.js@1.9.1: {}
-
-  is-electron@2.2.2: {}
 
   is-extglob@2.1.1: {}
 
@@ -4724,10 +4046,6 @@ snapshots:
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
-
-  is-promise@4.0.0: {}
-
-  is-stream@2.0.1: {}
 
   isexe@2.0.0: {}
 
@@ -4747,19 +4065,6 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
-
-  jsonwebtoken@9.0.3:
-    dependencies:
-      jws: 4.0.1
-      lodash.includes: 4.3.0
-      lodash.isboolean: 3.0.3
-      lodash.isinteger: 4.0.4
-      lodash.isnumber: 3.0.3
-      lodash.isplainobject: 4.0.6
-      lodash.isstring: 4.0.1
-      lodash.once: 4.1.1
-      ms: 2.1.3
-      semver: 7.8.0
 
   jwa@2.0.1:
     dependencies:
@@ -4785,20 +4090,6 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
-  lodash.includes@4.3.0: {}
-
-  lodash.isboolean@3.0.3: {}
-
-  lodash.isinteger@4.0.4: {}
-
-  lodash.isnumber@3.0.3: {}
-
-  lodash.isplainobject@4.0.6: {}
-
-  lodash.isstring@4.0.1: {}
-
-  lodash.once@4.1.1: {}
-
   long@5.3.2: {}
 
   lru-cache@11.3.6: {}
@@ -4808,24 +4099,6 @@ snapshots:
   marked@15.0.12: {}
 
   marked@18.0.5: {}
-
-  math-intrinsics@1.1.0: {}
-
-  media-typer@1.1.0: {}
-
-  merge-descriptors@2.0.0: {}
-
-  mime-db@1.52.0: {}
-
-  mime-db@1.54.0: {}
-
-  mime-types@2.1.35:
-    dependencies:
-      mime-db: 1.52.0
-
-  mime-types@3.0.2:
-    dependencies:
-      mime-db: 1.54.0
 
   minimatch@10.2.5:
     dependencies:
@@ -4843,8 +4116,6 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  negotiator@1.0.0: {}
-
   netmask@2.1.1: {}
 
   node-domexception@1.0.0: {}
@@ -4856,12 +4127,6 @@ snapshots:
       formdata-polyfill: 4.0.10
 
   object-assign@4.1.1: {}
-
-  object-inspect@1.13.4: {}
-
-  on-finished@2.4.1:
-    dependencies:
-      ee-first: 1.1.1
 
   once@1.4.0:
     dependencies:
@@ -4881,8 +4146,6 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
-  p-finally@1.0.0: {}
-
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
@@ -4891,19 +4154,10 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
-  p-queue@6.6.2:
-    dependencies:
-      eventemitter3: 4.0.7
-      p-timeout: 3.2.0
-
   p-retry@4.6.2:
     dependencies:
       '@types/retry': 0.12.0
       retry: 0.13.1
-
-  p-timeout@3.2.0:
-    dependencies:
-      p-finally: 1.0.0
 
   pac-proxy-agent@7.2.0:
     dependencies:
@@ -4923,6 +4177,8 @@ snapshots:
       degenerator: 5.0.1
       netmask: 2.1.1
 
+  parse-diff@0.11.1: {}
+
   parse5-htmlparser2-tree-adapter@6.0.1:
     dependencies:
       parse5: 6.0.1
@@ -4930,8 +4186,6 @@ snapshots:
   parse5@5.1.1: {}
 
   parse5@6.0.1: {}
-
-  parseurl@1.3.3: {}
 
   partial-json@0.1.7: {}
 
@@ -4945,8 +4199,6 @@ snapshots:
     dependencies:
       lru-cache: 11.3.6
       minipass: 7.1.3
-
-  path-to-regexp@8.4.2: {}
 
   pend@1.2.0: {}
 
@@ -4975,11 +4227,6 @@ snapshots:
       '@types/node': 20.19.39
       long: 5.3.2
 
-  proxy-addr@2.0.7:
-    dependencies:
-      forwarded: 0.2.0
-      ipaddr.js: 1.9.1
-
   proxy-agent@6.5.0:
     dependencies:
       agent-base: 7.1.4
@@ -4995,8 +4242,6 @@ snapshots:
 
   proxy-from-env@1.1.0: {}
 
-  proxy-from-env@2.1.0: {}
-
   pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
@@ -5004,69 +4249,17 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  qs@6.15.2:
-    dependencies:
-      side-channel: 1.1.1
-
-  range-parser@1.2.1: {}
-
-  raw-body@3.0.2:
-    dependencies:
-      bytes: 3.1.2
-      http-errors: 2.0.1
-      iconv-lite: 0.7.2
-      unpipe: 1.0.0
-
   require-directory@2.1.1: {}
 
   retry@0.12.0: {}
 
   retry@0.13.1: {}
 
-  router@2.2.0:
-    dependencies:
-      debug: 4.4.3
-      depd: 2.0.0
-      is-promise: 4.0.0
-      parseurl: 1.3.3
-      path-to-regexp: 8.4.2
-    transitivePeerDependencies:
-      - supports-color
-
   safe-buffer@5.2.1: {}
-
-  safer-buffer@2.1.2: {}
 
   semver@7.7.4: {}
 
   semver@7.8.0: {}
-
-  send@1.2.1:
-    dependencies:
-      debug: 4.4.3
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      etag: 1.8.1
-      fresh: 2.0.0
-      http-errors: 2.0.1
-      mime-types: 3.0.2
-      ms: 2.1.3
-      on-finished: 2.4.1
-      range-parser: 1.2.1
-      statuses: 2.0.2
-    transitivePeerDependencies:
-      - supports-color
-
-  serve-static@2.2.1:
-    dependencies:
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      parseurl: 1.3.3
-      send: 1.2.1
-    transitivePeerDependencies:
-      - supports-color
-
-  setprototypeof@1.2.0: {}
 
   sharp@0.34.5:
     dependencies:
@@ -5105,34 +4298,6 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  side-channel-list@1.0.1:
-    dependencies:
-      es-errors: 1.3.0
-      object-inspect: 1.13.4
-
-  side-channel-map@1.0.1:
-    dependencies:
-      call-bound: 1.0.4
-      es-errors: 1.3.0
-      get-intrinsic: 1.3.0
-      object-inspect: 1.13.4
-
-  side-channel-weakmap@1.0.2:
-    dependencies:
-      call-bound: 1.0.4
-      es-errors: 1.3.0
-      get-intrinsic: 1.3.0
-      object-inspect: 1.13.4
-      side-channel-map: 1.0.1
-
-  side-channel@1.1.1:
-    dependencies:
-      es-errors: 1.3.0
-      object-inspect: 1.13.4
-      side-channel-list: 1.0.1
-      side-channel-map: 1.0.1
-      side-channel-weakmap: 1.0.2
-
   signal-exit@3.0.7: {}
 
   smart-buffer@4.2.0: {}
@@ -5152,8 +4317,6 @@ snapshots:
 
   source-map@0.6.1:
     optional: true
-
-  statuses@2.0.2: {}
 
   string-width@4.2.3:
     dependencies:
@@ -5192,8 +4355,6 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
-  toidentifier@1.0.1: {}
-
   token-types@6.1.2:
     dependencies:
       '@borewit/text-codec': 0.2.2
@@ -5208,17 +4369,9 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsscmp@1.0.6: {}
-
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
-
-  type-is@2.1.0:
-    dependencies:
-      content-type: 2.0.0
-      media-typer: 1.1.0
-      mime-types: 3.0.2
 
   typebox@0.0.1: {}
 
@@ -5247,15 +4400,11 @@ snapshots:
 
   undici@8.5.0: {}
 
-  unpipe@1.0.0: {}
-
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
 
   uuid@14.0.0: {}
-
-  vary@1.1.2: {}
 
   web-streams-polyfill@3.3.3: {}
 


### PR DESCRIPTION
## O que muda

Adiciona a extensão `@arvoretech/pi-lsp`: uma ponte para Language Server Protocol que dá ao agente diagnostics reais do type-checker, go-to-definition, find-references, hover de tipos e rename project-wide — em vez de adivinhar a partir de texto.

## Contexto

Hoje o agente infere erros de tipo e referências por busca textual. Plugando um LSP real (tsserver via `typescript-language-server`), ele passa a ver os mesmos erros do compilador (`TS2345` etc.) e a navegar símbolos com precisão. A arquitetura nasce multi-linguagem: começa por TS/JS (cobre Next e Nest), e adicionar Python/Elixir/Go é uma entrada no registry.

## Tools

- `lsp_diagnostics` — erros/warnings reais do type-checker para um arquivo
- `lsp_definition` — resolve um símbolo até sua definição (linha/coluna 1-based)
- `lsp_references` — todas as referências a um símbolo no projeto
- `lsp_hover` — assinatura de tipo inferida e docs de um símbolo
- `lsp_rename` — calcula um rename project-wide; retorna os edits, **não os aplica**

Comando `/lsp-status` lista os servers configurados.

## Arquitetura

```
packages/lsp/src/
  protocol.ts   subset de tipos LSP
  client.ts     JSON-RPC sobre stdio (framing Content-Length, request/notify, server-requests)
  registry.ts   language -> server config (só TS/JS preenchido)
  manager.ts    spawn / lifecycle / root detection / doc sync / ops de alto nível
  tools.ts      definição das tools lsp_* + formatação de saída
  index.ts      entry shell (lifecycle + registro das tools)
```

- Um server por `(linguagem, project root)`, lazy-spawn no primeiro uso. Root via `tsconfig.json` / `jsconfig.json` / `package.json` / `.git`.
- Documentos sincronizados do disco (`didOpen`/`didChange`); diagnostics aguardados com debounce de quiet-period.
- Shutdown gracioso no `session_shutdown` (`shutdown`→`exit`→SIGKILL fallback).
- Coordenadas 1-based na interface do agente, convertidas para 0-based do LSP.

## Decisões

- **Pull-only nesta v1**: tools sob demanda. Auto-diagnostics pós-edit (hook em `tool_result` + steer) fica para a fase 2 — a infra (`manager.diagnostics`) já existe.
- **Graceful degradation**: se o binário do server não estiver no `PATH`, as tools retornam mensagem clara e a extensão fica inerte (sem crash).

## Verificação

- `pnpm build` (tsc) e `pnpm lint` (`tsc --noEmit`): limpos
- Smoke test contra um `typescript-language-server` real, dirigindo o `LspManager` compilado:
  - diagnostics retornaram `TS2322`, `TS2345`, `TS6133` corretos
  - hover trouxe a assinatura inferida
  - definition e references resolveram posições corretas
  - rename retornou os dois edits (declaração + uso) sem aplicar
- Shutdown limpo do processo

## Requisito de runtime

Para TS/JS o binário precisa estar no `PATH`:

```bash
pnpm add -g typescript-language-server typescript
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added LSP-powered tools for diagnostics, go-to-definition, references, hover, and rename.
  * Added a `/lsp-status` command to view configured language servers.
  * Expanded support for TypeScript/JavaScript files with language-server detection and project-root handling.
* **Bug Fixes**
  * Improved LSP session lifecycle management for more reliable startup, shutdown, and diagnostics updates.
  * Better formatting of hover results, diagnostics, and rename output for easier reading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->