### PR TITLE
fix(lsp): distinguish null LSP response from unavailable server (1.0.1)

### DIFF
--- a/packages/lsp/package.json
+++ b/packages/lsp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-lsp",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "PI extension that bridges Language Server Protocol servers to give the agent real compiler diagnostics, go-to-definition, references, hover and rename",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/lsp/src/manager.ts
+++ b/packages/lsp/src/manager.ts
@@ -224,18 +224,18 @@ export class LspManager {
     });
   }
 
-  async diagnostics(filePath: string): Promise<{ path: string; diagnostics: Diagnostic[] } | null> {
+  async diagnostics(filePath: string): Promise<{ path: string; diagnostics: Diagnostic[] } | undefined> {
     const instance = await this.getOrCreate(filePath);
-    if (!instance) return null;
+    if (!instance) return undefined;
     const abs = this.absPath(filePath);
     await this.ensureOpen(instance, filePath);
     await this.waitForDiagnostics(instance, abs, 6_000);
     return { path: abs, diagnostics: instance.diagnostics.get(abs) ?? [] };
   }
 
-  async definition(filePath: string, position: Position): Promise<Location[] | null> {
+  async definition(filePath: string, position: Position): Promise<Location[] | undefined> {
     const instance = await this.getOrCreate(filePath);
-    if (!instance) return null;
+    if (!instance) return undefined;
     const uri = await this.ensureOpen(instance, filePath);
     const result = await instance.client.request<Location | Location[] | LocationLink[] | null>(
       "textDocument/definition",
@@ -244,9 +244,9 @@ export class LspManager {
     return normalizeLocations(result);
   }
 
-  async references(filePath: string, position: Position): Promise<Location[] | null> {
+  async references(filePath: string, position: Position): Promise<Location[] | undefined> {
     const instance = await this.getOrCreate(filePath);
-    if (!instance) return null;
+    if (!instance) return undefined;
     const uri = await this.ensureOpen(instance, filePath);
     const result = await instance.client.request<Location[] | null>("textDocument/references", {
       textDocument: { uri },
@@ -256,9 +256,9 @@ export class LspManager {
     return result ?? [];
   }
 
-  async hover(filePath: string, position: Position): Promise<Hover | null> {
+  async hover(filePath: string, position: Position): Promise<Hover | null | undefined> {
     const instance = await this.getOrCreate(filePath);
-    if (!instance) return null;
+    if (!instance) return undefined;
     const uri = await this.ensureOpen(instance, filePath);
     return instance.client.request<Hover | null>("textDocument/hover", {
       textDocument: { uri },
@@ -266,9 +266,9 @@ export class LspManager {
     });
   }
 
-  async rename(filePath: string, position: Position, newName: string): Promise<WorkspaceEdit | null> {
+  async rename(filePath: string, position: Position, newName: string): Promise<WorkspaceEdit | null | undefined> {
     const instance = await this.getOrCreate(filePath);
-    if (!instance) return null;
+    if (!instance) return undefined;
     const uri = await this.ensureOpen(instance, filePath);
     return instance.client.request<WorkspaceEdit | null>("textDocument/rename", {
       textDocument: { uri },

--- a/packages/lsp/src/tools.ts
+++ b/packages/lsp/src/tools.ts
@@ -90,7 +90,7 @@ export function registerLspTools(pi: ExtensionAPI, getManager: () => LspManager)
     }),
     async execute(_id, params, _signal, _onUpdate, ctx) {
       const result = await getManager().diagnostics(params.file);
-      if (!result) return { content: [{ type: "text", text: NOT_AVAILABLE }], details: {} };
+      if (result === undefined) return { content: [{ type: "text", text: NOT_AVAILABLE }], details: {} };
       return {
         content: [{ type: "text", text: formatDiagnostics(result.path, ctx.cwd, result.diagnostics) }],
         details: { path: result.path, count: result.diagnostics.length },
@@ -114,7 +114,7 @@ export function registerLspTools(pi: ExtensionAPI, getManager: () => LspManager)
         line: params.line - 1,
         character: params.column - 1,
       });
-      if (locations === null) return { content: [{ type: "text", text: NOT_AVAILABLE }], details: {} };
+      if (locations === undefined) return { content: [{ type: "text", text: NOT_AVAILABLE }], details: {} };
       return {
         content: [{ type: "text", text: formatLocations(locations, ctx.cwd) }],
         details: { count: locations.length },
@@ -138,7 +138,7 @@ export function registerLspTools(pi: ExtensionAPI, getManager: () => LspManager)
         line: params.line - 1,
         character: params.column - 1,
       });
-      if (locations === null) return { content: [{ type: "text", text: NOT_AVAILABLE }], details: {} };
+      if (locations === undefined) return { content: [{ type: "text", text: NOT_AVAILABLE }], details: {} };
       return {
         content: [{ type: "text", text: formatLocations(locations, ctx.cwd) }],
         details: { count: locations.length },
@@ -162,7 +162,8 @@ export function registerLspTools(pi: ExtensionAPI, getManager: () => LspManager)
         line: params.line - 1,
         character: params.column - 1,
       });
-      if (hover === null) return { content: [{ type: "text", text: NOT_AVAILABLE }], details: {} };
+      if (hover === undefined) return { content: [{ type: "text", text: NOT_AVAILABLE }], details: {} };
+      if (hover === null) return { content: [{ type: "text", text: "No hover information." }], details: {} };
       return { content: [{ type: "text", text: formatHover(hover) }], details: {} };
     },
   });
@@ -189,7 +190,8 @@ export function registerLspTools(pi: ExtensionAPI, getManager: () => LspManager)
         { line: params.line - 1, character: params.column - 1 },
         params.newName,
       );
-      if (edit === null) return { content: [{ type: "text", text: NOT_AVAILABLE }], details: {} };
+      if (edit === undefined) return { content: [{ type: "text", text: NOT_AVAILABLE }], details: {} };
+      if (edit === null) return { content: [{ type: "text", text: "Rename produced no edits (symbol may not be renameable here)." }], details: {} };
 
       const changes: Record<string, Array<{ range: unknown; newText: string }>> = {};
       if (edit.changes) {


### PR DESCRIPTION
**Bug:** `lsp_hover` (and definition/references/rename) returned "No language server available" when the LSP responded with `null` (e.g. cursor not on a symbol), because `null` was used for both "no server" and "LSP returned null".

**Fix:** Manager methods now return `undefined` for "no server" and `null` for "LSP returned null". Tools distinguish both cases correctly.

**Bump:** `1.0.0` → `1.0.1`