### PR TITLE
feat(prs-tracker): inject tracked PR status into AI context

### DIFF
--- a/packages/prs-tracker/README.md
+++ b/packages/prs-tracker/README.md
@@ -1,6 +1,6 @@
 # @arvoretech/pi-prs-tracker
 
-Keeps your open and recently-merged PRs pinned in the chat as a persistent widget — now with CI and production deploy status. PRs are auto-detected from `gh pr create` calls (and any GitHub PR URL) the agent runs during the session, and their status is refreshed in the background.
+Keeps your open and recently-merged PRs pinned in the chat as a persistent widget — now with CI and production deploy status. PRs are auto-detected from `gh pr create` calls (and any GitHub PR URL) the agent runs during the session, and their status is refreshed in the background. The current status of every tracked PR is also injected into the AI's context on each LLM call, so the agent always knows whether a PR is merged and how its CI/deploy is doing.
 
 ## Install
 
@@ -26,6 +26,10 @@ Or in `.pi/settings.json`:
   - CI: `CI passed` / `CI failed` / `CI running` with check counts
   - Deploy: `deploy queued` / `deploying to main` / `deployed to main` / `deploy failed`
 - Background polling (every 60s) refreshes CI and deploy statuses. Merged PRs stay for 24h (and are kept longer if a deploy is still in flight); closed PRs drop off immediately.
+
+## AI context injection
+
+On every LLM call the extension injects a non-displayed `custom` message (`customType: "prs-tracker-context"`) with a fresh snapshot of all tracked PRs — state (`OPEN`/`MERGED`/`CLOSED`), CI summary and deploy status. The block is rebuilt each call from the latest background poll and the previous one is filtered out, so the history is never polluted and the agent always sees the current state instead of stale info. This lets the agent answer "is this PR merged / did CI pass / did it deploy?" without re-running `gh`.
 
 ## Deploy detection
 

--- a/packages/prs-tracker/package.json
+++ b/packages/prs-tracker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-prs-tracker",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "PI extension that keeps open/recently-merged PRs pinned in the chat as a persistent widget",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/prs-tracker/src/index.ts
+++ b/packages/prs-tracker/src/index.ts
@@ -349,6 +349,64 @@ function resultToText(result: any): string {
   return parts.join("\n");
 }
 
+const CONTEXT_CUSTOM_TYPE = "prs-tracker-context";
+
+function ciLabel(ci: CiSummary | null): string {
+  if (!ci || ci.state === "NONE") return "sem CI";
+  if (ci.state === "PENDING") return `CI rodando (${ci.passed}/${ci.total} ok, ${ci.pending} pendente, ${ci.failed} falha)`;
+  if (ci.state === "FAIL") return `CI FALHOU (${ci.failed}/${ci.total} falharam)`;
+  return `CI passou (${ci.passed}/${ci.total})`;
+}
+
+function deployLabel(deploy: DeployInfo | null): string | null {
+  if (!deploy || deploy.state === "NONE") return null;
+  switch (deploy.state) {
+    case "QUEUED":
+      return `deploy na fila (${deploy.workflow})`;
+    case "IN_PROGRESS":
+      return `deploy em andamento (${deploy.workflow})`;
+    case "SUCCESS":
+      return `deploy concluído (${deploy.workflow})`;
+    case "FAILURE":
+      return `deploy FALHOU (${deploy.workflow})`;
+    case "SKIPPED":
+      return `deploy pulado (${deploy.workflow})`;
+    default:
+      return null;
+  }
+}
+
+function prStateLabel(pr: TrackedPr): string {
+  if (pr.state === "MERGED") return "MERGED";
+  if (pr.state === "CLOSED") return "CLOSED (sem merge)";
+  return pr.isDraft ? "OPEN (draft)" : "OPEN";
+}
+
+function buildContextSummary(): string | null {
+  const prs = [...tracked.values()].filter(
+    (pr) => pr.state === "OPEN" || pr.state === "MERGED" || pr.state === "CLOSED",
+  );
+  if (prs.length === 0) return null;
+  const lines = prs
+    .sort((a, b) => b.number - a.number)
+    .map((pr) => {
+      const parts = [
+        `${pr.repo}#${pr.number} "${pr.title}"`,
+        `estado=${prStateLabel(pr)}`,
+        ciLabel(pr.ci),
+      ];
+      const dep = deployLabel(pr.deploy);
+      if (dep) parts.push(dep);
+      parts.push(pr.url);
+      return `- ${parts.join(" | ")}`;
+    });
+  return [
+    "[PRS RASTREADOS — estado atual, atualizado automaticamente]",
+    "Status real dos PRs rastreados nesta sessão (poll via gh). Use como fonte de verdade; não afirme merge/CI/deploy sem checar este bloco ou rodar gh.",
+    ...lines,
+  ].join("\n");
+}
+
 function sortedPrs(): TrackedPr[] {
   const order = (pr: TrackedPr): number => {
     if (pr.state === "OPEN") return 0;
@@ -541,6 +599,22 @@ export default function prsTrackerExtension(pi: ExtensionAPI): void {
   pi.on("session_shutdown", async () => {
     stopPolling();
     stopSpinner();
+  });
+
+  pi.on("context", async (event: any) => {
+    const messages = event.messages.filter(
+      (m: any) => m?.customType !== CONTEXT_CUSTOM_TYPE,
+    );
+    const summary = buildContextSummary();
+    if (!summary) return { messages };
+    messages.push({
+      role: "custom",
+      customType: CONTEXT_CUSTOM_TYPE,
+      content: summary,
+      display: false,
+      timestamp: Date.now(),
+    });
+    return { messages };
   });
 
   pi.on("tool_execution_end", async (event: any, ctx: any) => {


### PR DESCRIPTION
## Resumo

A extensão `prs-tracker` já coletava todo o estado dos PRs rastreados (`state` OPEN/MERGED/CLOSED, `mergedAt`, `mergeCommit`, resumo de CI e status de deploy), mas isso só virava widget visual — **nada chegava ao contexto do modelo**. Resultado: a IA não sabia se um PR já tinha mergeado nem como estava o CI/deploy.

Este PR leva esse estado para o contexto da IA.

## O que mudou

- **`buildContextSummary()`**: monta um bloco de texto compacto, uma linha por PR rastreado — `repo#n "título" | estado=MERGED | CI passou (5/5) | deploy concluído | url`.
- **Hook `pi.on("context")`**: roda antes de cada chamada do modelo. Remove o bloco antigo (`customType: "prs-tracker-context"`) e injeta um novo com o snapshot atual (`display: false`).
  - Sempre **fresco** (do último poll de 60s), **sem poluir** o histórico permanente.
  - O texto instrui o agente a usar o bloco como fonte de verdade, alinhado à regra do Fact Checker.

## Decisão de design

Não rodo `gh` dentro do hook `context` — é `execSync` (síncrono) e bloquearia o turn do modelo. A frescura vem do poll de background; o hook só serializa o estado já em memória. Para estado garantidamente fresco sob demanda, o `/prs refresh` continua disponível.

## Verificação

- `tsc --noEmit` e `npm run build` passam limpos.
- `dist/index.js` regenerado localmente (gitignored, buildado no publish).

## Versão

Bump `1.3.0 → 1.4.0` (feature nova).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added richer PR tracking context, including CI and production deploy status.
  * The app now keeps the latest PR snapshot available during AI interactions so responses reflect current PR state.
  * Added a localized “PRs tracked” context summary for improved visibility.

* **Documentation**
  * Updated the README to describe the enhanced PR status information and AI context behavior.

* **Chores**
  * Bumped the package version to **1.4.0**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->