### PR TITLE
fix(lsp): resolve project root over .git and allow init retry

### DIFF
--- a/packages/lsp/README.md
+++ b/packages/lsp/README.md
@@ -36,7 +36,8 @@ If a server is missing, the tools return a clear message and the extension stays
 
 ## How it works
 
-- One server instance per `(language, project root)`, lazy-spawned on first use. Root is detected via `tsconfig.json` / `jsconfig.json` / `package.json` / `.git`.
+- One server instance per `(language, project root)`, lazy-spawned on first use. Root is detected by walking up from the file and preferring the nearest `tsconfig.json` / `jsconfig.json` / `package.json` over `.git`, so files inside a subproject of a monorepo resolve to the subproject (which has its own TypeScript install) rather than the repo root.
+- If a server fails to initialize (e.g. no TypeScript found at the resolved root), the instance is not cached as permanently unavailable — a later call can retry once the root resolution improves.
 - Documents are synced (`didOpen` / `didChange`) from disk on each call; diagnostics are awaited with a short quiet-period debounce.
 - Servers are shut down cleanly on `session_shutdown`.
 

--- a/packages/lsp/src/manager.ts
+++ b/packages/lsp/src/manager.ts
@@ -62,22 +62,25 @@ export class LspManager {
   }
 
   private findRoot(filePath: string, config: LanguageServerConfig): string {
-    let dir = dirname(this.absPath(filePath));
-    let lastMatch: string | null = null;
+    const startDir = dirname(this.absPath(filePath));
+    const projectMarkers = config.rootMarkers.filter((m) => m !== ".git");
+    const hasVcsMarker = config.rootMarkers.includes(".git");
+    let dir = startDir;
+    let projectMatch: string | null = null;
+    let vcsMatch: string | null = null;
     const segments = dir.split(sep).length;
     for (let i = 0; i < segments; i++) {
-      for (const marker of config.rootMarkers) {
-        if (existsSync(join(dir, marker))) {
-          lastMatch = dir;
-          if (marker === ".git") return dir;
-          break;
-        }
+      if (projectMatch === null && projectMarkers.some((marker) => existsSync(join(dir, marker)))) {
+        projectMatch = dir;
+      }
+      if (hasVcsMarker && vcsMatch === null && existsSync(join(dir, ".git"))) {
+        vcsMatch = dir;
       }
       const parent = dirname(dir);
       if (parent === dir) break;
       dir = parent;
     }
-    return lastMatch ?? dirname(this.absPath(filePath));
+    return projectMatch ?? vcsMatch ?? startDir;
   }
 
   private instanceKey(config: LanguageServerConfig, rootPath: string): string {
@@ -143,7 +146,11 @@ export class LspManager {
     instance.ready = this.initialize(instance);
     this.servers.set(key, instance);
     await instance.ready;
-    return instance.available ? instance : null;
+    if (!instance.available) {
+      this.servers.delete(key);
+      return null;
+    }
+    return instance;
   }
 
   private async initialize(instance: ServerInstance): Promise<void> {
@@ -173,6 +180,7 @@ export class LspManager {
       client.notify("workspace/didChangeConfiguration", { settings: {} });
     } catch (err) {
       instance.available = false;
+      await client.dispose().catch(() => {});
       this.notify(`LSP: initialize failed for ${instance.config.label}: ${String(err)}`, "error");
     }
   }


### PR DESCRIPTION
## Problema

No `arvore-hub` (monorepo guarda-chuva), o LSP de TypeScript parava de funcionar com:

```
LSP: initialize failed for TypeScript / JavaScript: Could not find a valid TypeScript installation. ... Exiting.
```

e depois, em qualquer arquivo:

```
No language server available for this file (unsupported language or server not installed).
```

### Causa raiz (dois bugs)

1. **`findRoot` priorizava `.git`.** A varredura subia a árvore testando `rootMarkers` na ordem `["tsconfig.json", "jsconfig.json", "package.json", ".git"]`, com *early-return* no `.git`. Para um arquivo dentro de um subprojeto que **não** tem `.git` próprio (o caso comum no monorepo — todo subprojeto tem `package.json`, mas só alguns têm `.git`), a subida encontrava o `.git` da **raiz** e resolvia o root como a raiz `arvore-hub`. A raiz não tem `node_modules/typescript`, então o `typescript-language-server` subia, não achava TS e o `tsserver` **crashava no initialize** (`Exiting`).

2. **Falha de initialize envenenava o cache da sessão.** Quando o `initialize` falhava, a instância ficava cacheada com `available: false` para sempre (`servers.set(key, { available: false })`). A partir daí, toda chamada caía no `NOT_AVAILABLE`, mesmo para arquivos cujo root resolveria para um subprojeto com TS instalado. Por isso "tinha funcionado antes" e parou no meio da sessão.

## Correção

- **`findRoot`** agora caminha pra cima e prefere o **marcador de projeto mais próximo** (`tsconfig.json` / `jsconfig.json` / `package.json`), usando `.git` apenas como *fallback*. Arquivos de subprojeto passam a resolver para o subprojeto (que tem seu próprio TypeScript), não para a raiz.
- **Falha de `initialize`** não cacheia mais como permanentemente indisponível: a instância é removida do mapa e o client é disposto, permitindo *retry* numa chamada futura.

## Validação

`OLD` vs `NEW` para um arquivo em `monorepo/sub/src/file.ts` (sub com `tsconfig.json`/`package.json`, `.git` só na raiz):

```
OLD (buggy): /monorepo        -> sem TypeScript -> tsserver crasha
NEW (fixed): /monorepo/sub    -> TypeScript do subprojeto -> ok
```

Smoke test direto do `typescript-language-server` com `cwd` no subprojeto confirma:

```
Using Typescript version (workspace) 5.9.3 from path
".../frontend-arvore-nextjs/node_modules/typescript/lib/tsserver.js"
```

- `pnpm build` ✅
- `pnpm lint` (`tsc --noEmit`) ✅

## Testado

- Build e lint do pacote `@arvoretech/pi-lsp`.
- Teste de comportamento do `findRoot` com fixtures simulando a estrutura do monorepo (subprojeto com e sem `.git` próprio, arquivo na raiz).
