### PR TITLE
chore(lsp): bump @arvoretech/pi-lsp to 1.0.2

### DIFF
--- a/packages/lsp/package.json
+++ b/packages/lsp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-lsp",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "PI extension that bridges Language Server Protocol servers to give the agent real compiler diagnostics, go-to-definition, references, hover and rename",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Bumps package version after fix in #78.