### PR TITLE
feat(git-review): add PR review mode

### DIFF
--- a/packages/git-review/README.md
+++ b/packages/git-review/README.md
@@ -1,6 +1,6 @@
 # @arvoretech/pi-git-review
 
-A PI extension that opens a **browser-based git diff reviewer**. You read the diff in a
+A PI extension that opens a **browser-based git diff & PR reviewer**. You read the diff in a
 tab, select lines or code, type a question, and it lands in your PI session in real time as
 a user message. The agent's answers appear in your terminal (PI TUI).
 
@@ -9,8 +9,11 @@ a user message. The agent's answers appear in your terminal (PI TUI).
 ```
 /review  ──►  extension starts a localhost HTTP+WS server, opens a browser tab
               │
-   browser ──┤  GET /api/diff   → parsed `git diff` (per file + hunks)
-              │  WS /ws          → you send { file, lines, code, question }
+   browser ──┤  GET /api/diff     → parsed `git diff` (per file + hunks)
+              │  GET /api/prs      → open PRs per repo (`gh pr list`)
+              │  GET /api/pr-diff  → parsed PR diff + metadata (`gh pr diff/view`)
+              │  WS /ws            → you send { file, lines, code, question }
+              │                       or a pr_context primer when a PR is opened
               ▼
    extension calls pi.sendUserMessage(...)  → agent answers in the terminal
 ```
@@ -27,9 +30,25 @@ a user message. The agent's answers appear in your terminal (PI TUI).
 /review staged          # staged changes
 /review branch          # current branch vs `main`
 /review branch develop  # current branch vs `develop`
+/review prs             # list open PRs across all repos and review them
 ```
 
-The scope and base can also be changed live from the toolbar in the browser tab.
+The scope and base can also be changed live from the toolbar in the browser tab. The
+**Diff / PRs** tabs at the top switch between reviewing local changes and reviewing open
+pull requests.
+
+### Reviewing PRs
+
+The **PRs** tab runs `gh pr list` in each discovered repo and shows every open PR
+(grouped by repo, newest first). Click a PR to load its full diff via `gh pr diff`
+(base...head, independent of your local checkout). When you open a PR, a one-time
+**context primer** — title, author, branch, link, and the PR description — is sent to the
+agent so it understands what it is reviewing. Every line question you ask afterwards is
+answered with that context in mind. The banner links back to the PR list and out to
+GitHub.
+
+> Requires the [`gh` CLI](https://cli.github.com) installed and authenticated
+> (`gh auth status`).
 
 In the tab:
 

--- a/packages/git-review/package.json
+++ b/packages/git-review/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-git-review",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "PI extension that opens a browser-based git diff reviewer; selected code + comments are sent to the agent in real time",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/git-review/package.json
+++ b/packages/git-review/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-git-review",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "PI extension that opens a browser-based git diff reviewer; selected code + comments are sent to the agent in real time",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/git-review/package.json
+++ b/packages/git-review/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-git-review",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "PI extension that opens a browser-based git diff reviewer; selected code + comments are sent to the agent in real time",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/git-review/src/index.ts
+++ b/packages/git-review/src/index.ts
@@ -5,6 +5,7 @@ import {
   startGitReviewServer,
   type DiffScope,
   type GitReviewServer,
+  type PrContext,
   type ReviewComment,
 } from "./server.js";
 
@@ -19,16 +20,30 @@ function openBrowser(pi: ExtensionAPI, url: string): void {
 }
 
 const VALID_SCOPES = ["working", "staged", "branch"] as const;
-const USAGE = "Usage: /review [working|staged|branch [base]]";
+const USAGE = "Usage: /review [working|staged|branch [base] | prs]";
 
-function parseScopeArgs(args: string): { scope: DiffScope; base: string; error?: string } {
+function parseScopeArgs(args: string): {
+  mode: "diff" | "prs";
+  scope: DiffScope;
+  base: string;
+  error?: string;
+} {
   const parts = args.trim().split(/\s+/).filter(Boolean);
-  if (!parts.length) return { scope: "working", base: "main" };
-  const scopeArg = parts[0].toLowerCase() as DiffScope;
-  if (!(VALID_SCOPES as readonly string[]).includes(scopeArg)) {
-    return { scope: "working", base: "main", error: `Unknown scope "${parts[0]}". ${USAGE}` };
+  if (!parts.length) return { mode: "diff", scope: "working", base: "main" };
+  const first = parts[0].toLowerCase();
+  if (first === "prs" || first === "pr") {
+    return { mode: "prs", scope: "working", base: "main" };
   }
-  return { scope: scopeArg, base: parts[1] || "main" };
+  const scopeArg = first as DiffScope;
+  if (!(VALID_SCOPES as readonly string[]).includes(scopeArg)) {
+    return {
+      mode: "diff",
+      scope: "working",
+      base: "main",
+      error: `Unknown scope "${parts[0]}". ${USAGE}`,
+    };
+  }
+  return { mode: "diff", scope: scopeArg, base: parts[1] || "main" };
 }
 
 function formatComment(c: ReviewComment): string {
@@ -52,13 +67,37 @@ function formatComment(c: ReviewComment): string {
   return lines.join("\n");
 }
 
+function formatPrContext(c: PrContext): string {
+  const lines: string[] = [];
+  lines.push(`I'm reviewing a pull request. Here is the context for the questions that follow:`);
+  lines.push("");
+  lines.push(`- Repo: ${c.repo}`);
+  lines.push(`- PR #${c.number}: ${c.title}`);
+  lines.push(`- Author: ${c.author}`);
+  lines.push(`- Branch: ${c.headRefName} → ${c.baseRefName}`);
+  lines.push(`- Link: ${c.url}`);
+  lines.push("");
+  if (c.body.trim()) {
+    lines.push("Description:");
+    lines.push("");
+    lines.push(c.body.trim().replace(/```/g, "ʼʼʼ"));
+  } else {
+    lines.push("(No description provided.)");
+  }
+  lines.push("");
+  lines.push(
+    `I'll ask about specific lines next. Use \`gh pr view ${c.number} -R ${c.repo}\` or \`gh pr diff ${c.number} -R ${c.repo}\` if you need more than the snippets I send.`,
+  );
+  return lines.join("\n");
+}
+
 export default function (pi: ExtensionAPI) {
   let server: GitReviewServer | null = null;
   const clients: Set<WebSocket> = new Set();
   let isIdle: () => boolean = () => true;
 
-  const handleComment = (comment: ReviewComment) => {
-    const message = formatComment(comment);
+  const handleMessage = (msg: ReviewComment | PrContext) => {
+    const message = msg.type === "pr_context" ? formatPrContext(msg) : formatComment(msg);
     if (isIdle()) {
       pi.sendUserMessage(message);
     } else {
@@ -72,7 +111,7 @@ export default function (pi: ExtensionAPI) {
     if (server) return server;
     for (let port = PORT_RANGE_START; port <= PORT_RANGE_END; port++) {
       try {
-        server = await startGitReviewServer(port, pi, clients, handleComment);
+        server = await startGitReviewServer(port, pi, clients, handleMessage);
         return server;
       } catch {}
     }
@@ -82,7 +121,7 @@ export default function (pi: ExtensionAPI) {
 
   pi.registerCommand("review", {
     description:
-      "Open a browser-based git diff reviewer. Usage: /review [working|staged|branch [base]]",
+      "Open a browser-based git diff & PR reviewer. Usage: /review [working|staged|branch [base] | prs]",
     handler: async (args, ctx) => {
       isIdle = () => ctx.isIdle();
       if (!ctx.hasUI) {
@@ -90,7 +129,7 @@ export default function (pi: ExtensionAPI) {
         return;
       }
 
-      const { scope, base, error } = parseScopeArgs(args);
+      const { mode, scope, base, error } = parseScopeArgs(args);
       if (error) {
         ctx.ui.notify(error, "error");
         return;
@@ -98,7 +137,10 @@ export default function (pi: ExtensionAPI) {
 
       const srv = await ensureServer(ctx);
       if (!srv) return;
-      const url = `${srv.url}&scope=${scope}&base=${encodeURIComponent(base)}`;
+      const url =
+        mode === "prs"
+          ? `${srv.url}&mode=prs`
+          : `${srv.url}&scope=${scope}&base=${encodeURIComponent(base)}`;
       openBrowser(pi, url);
       ctx.ui.notify(
         `git-review open at ${srv.url} — comments arrive in this terminal.`,

--- a/packages/git-review/src/index.ts
+++ b/packages/git-review/src/index.ts
@@ -85,10 +85,17 @@ function formatPrContext(c: PrContext): string {
     lines.push("(No description provided.)");
   }
   lines.push("");
+  const slug = repoSlugFromUrl(c.url);
+  const repoFlag = slug ? ` -R ${slug}` : "";
   lines.push(
-    `I'll ask about specific lines next. Use \`gh pr view ${c.number} -R ${c.repo}\` or \`gh pr diff ${c.number} -R ${c.repo}\` if you need more than the snippets I send.`,
+    `I'll ask about specific lines next. Use \`gh pr view ${c.number}${repoFlag}\` or \`gh pr diff ${c.number}${repoFlag}\` if you need more than the snippets I send.`,
   );
   return lines.join("\n");
+}
+
+function repoSlugFromUrl(url: string): string | null {
+  const match = /github\.com\/([^/]+\/[^/]+)\/pull\//.exec(url);
+  return match ? match[1] : null;
 }
 
 export default function (pi: ExtensionAPI) {

--- a/packages/git-review/src/server.ts
+++ b/packages/git-review/src/server.ts
@@ -44,6 +44,37 @@ export interface RepoGroup {
   files: parseDiff.File[];
 }
 
+export interface PullRequest {
+  repo: string;
+  number: number;
+  title: string;
+  author: string;
+  url: string;
+  baseRefName: string;
+  headRefName: string;
+  isDraft: boolean;
+  updatedAt: string;
+  additions: number;
+  deletions: number;
+}
+
+export interface PullRequestGroup {
+  repo: string;
+  prs: PullRequest[];
+}
+
+export interface PrContext {
+  type: "pr_context";
+  repo: string;
+  number: number;
+  title: string;
+  author: string;
+  url: string;
+  baseRefName: string;
+  headRefName: string;
+  body: string;
+}
+
 async function detectBranch(pi: ExtensionAPI, dir: string): Promise<string> {
   try {
     const { stdout } = await pi.exec("git", ["-C", dir, "rev-parse", "--abbrev-ref", "HEAD"]);
@@ -174,6 +205,115 @@ async function collectRepoGroups(
   return groups;
 }
 
+async function collectPullRequests(pi: ExtensionAPI): Promise<PullRequestGroup[]> {
+  const repos = await findRepoDirs(pi);
+  const seen = new Set<string>();
+  const groups: PullRequestGroup[] = [];
+
+  for (const { dir, label } of repos) {
+    if (seen.has(label)) continue;
+    seen.add(label);
+    try {
+      const { stdout } = await pi.exec("gh", [
+        "pr",
+        "list",
+        "--state",
+        "open",
+        "--limit",
+        "50",
+        "--json",
+        "number,title,author,url,baseRefName,headRefName,isDraft,updatedAt,additions,deletions",
+      ], { cwd: dir });
+      const parsed = JSON.parse(stdout || "[]") as Array<{
+        number: number;
+        title: string;
+        author?: { login?: string };
+        url: string;
+        baseRefName: string;
+        headRefName: string;
+        isDraft: boolean;
+        updatedAt: string;
+        additions?: number;
+        deletions?: number;
+      }>;
+      if (!parsed.length) continue;
+      const prs: PullRequest[] = parsed.map((p) => ({
+        repo: label,
+        number: p.number,
+        title: p.title,
+        author: p.author?.login || "unknown",
+        url: p.url,
+        baseRefName: p.baseRefName,
+        headRefName: p.headRefName,
+        isDraft: p.isDraft,
+        updatedAt: p.updatedAt,
+        additions: p.additions || 0,
+        deletions: p.deletions || 0,
+      }));
+      prs.sort((a, b) => b.number - a.number);
+      groups.push({ repo: label, prs });
+    } catch {}
+  }
+
+  groups.sort((a, b) => a.repo.localeCompare(b.repo));
+  return groups;
+}
+
+function repoDirForLabel(repos: RepoDir[], label: string): string | null {
+  const match = repos.find((r) => r.label === label);
+  return match ? match.dir : null;
+}
+
+async function collectPrDiff(
+  pi: ExtensionAPI,
+  repo: string,
+  prNumber: number,
+): Promise<{ files: parseDiff.File[]; context: PrContext } | null> {
+  const repos = await findRepoDirs(pi);
+  const dir = repoDirForLabel(repos, repo);
+  if (!dir) return null;
+  const prefix = repo === "." ? "" : repo + "/";
+
+  const { stdout: viewOut } = await pi.exec("gh", [
+    "pr",
+    "view",
+    String(prNumber),
+    "--json",
+    "number,title,author,url,baseRefName,headRefName,body",
+  ], { cwd: dir });
+  const view = JSON.parse(viewOut) as {
+    number: number;
+    title: string;
+    author?: { login?: string };
+    url: string;
+    baseRefName: string;
+    headRefName: string;
+    body: string;
+  };
+
+  const { stdout: diffOut } = await pi.exec("gh", ["pr", "diff", String(prNumber)], {
+    cwd: dir,
+  });
+  const prefixed = diffOut
+    .replace(/^diff --git a\//gm, `diff --git a/${prefix}`)
+    .replace(/^(\+\+\+|---) ([ab])\//gm, `$1 $2/${prefix}`);
+  const files = parseDiff(prefixed);
+
+  const context: PrContext = {
+    type: "pr_context",
+    repo,
+    number: view.number,
+    title: view.title,
+    author: view.author?.login || "unknown",
+    url: view.url,
+    baseRefName: view.baseRefName,
+    headRefName: view.headRefName,
+    body: view.body || "",
+  };
+
+  return { files, context };
+}
+
 function sendJson(res: ServerResponse, status: number, body: unknown): void {
   const payload = JSON.stringify(body);
   res.writeHead(status, {
@@ -199,7 +339,7 @@ export function startGitReviewServer(
   port: number,
   pi: ExtensionAPI,
   clients: Set<WebSocket>,
-  onComment: (comment: ReviewComment) => void,
+  onMessage: (msg: ReviewComment | PrContext) => void,
 ): Promise<GitReviewServer> {
   const token = randomBytes(16).toString("hex");
 
@@ -228,6 +368,44 @@ export function startGitReviewServer(
         return;
       }
 
+      if (url.pathname === "/api/prs") {
+        if (url.searchParams.get("token") !== token) {
+          sendJson(res, 403, { error: "forbidden" });
+          return;
+        }
+        try {
+          const groups = await collectPullRequests(pi);
+          sendJson(res, 200, { groups });
+        } catch (err) {
+          sendJson(res, 500, { error: String(err) });
+        }
+        return;
+      }
+
+      if (url.pathname === "/api/pr-diff") {
+        if (url.searchParams.get("token") !== token) {
+          sendJson(res, 403, { error: "forbidden" });
+          return;
+        }
+        const repo = url.searchParams.get("repo") || ".";
+        const number = Number(url.searchParams.get("number"));
+        if (!Number.isInteger(number) || number <= 0) {
+          sendJson(res, 400, { error: "invalid pr number" });
+          return;
+        }
+        try {
+          const result = await collectPrDiff(pi, repo, number);
+          if (!result) {
+            sendJson(res, 404, { error: "repo not found" });
+            return;
+          }
+          sendJson(res, 200, { repo, number, context: result.context, files: result.files });
+        } catch (err) {
+          sendJson(res, 500, { error: String(err) });
+        }
+        return;
+      }
+
       res.writeHead(404, { "Content-Type": "text/plain" });
       res.end("Not found");
     });
@@ -248,7 +426,9 @@ export function startGitReviewServer(
         try {
           const msg = JSON.parse(raw.toString());
           if (msg.type === "comment" && typeof msg.question === "string" && msg.question.trim()) {
-            onComment(msg as ReviewComment);
+            onMessage(msg as ReviewComment);
+          } else if (msg.type === "pr_context" && typeof msg.url === "string") {
+            onMessage(msg as PrContext);
           }
         } catch {}
       });

--- a/packages/git-review/src/server.ts
+++ b/packages/git-review/src/server.ts
@@ -220,7 +220,7 @@ async function collectPullRequests(pi: ExtensionAPI): Promise<PullRequestGroup[]
         "--state",
         "open",
         "--limit",
-        "50",
+        "200",
         "--json",
         "number,title,author,url,baseRefName,headRefName,isDraft,updatedAt,additions,deletions",
       ], { cwd: dir });

--- a/packages/git-review/web/index.html
+++ b/packages/git-review/web/index.html
@@ -99,6 +99,123 @@
         background: var(--accent);
         border-color: var(--accent);
       }
+      .tabs {
+        display: flex;
+        gap: 4px;
+        background: var(--bg);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 3px;
+      }
+      .tabs button {
+        border: 0;
+        background: transparent;
+        padding: 5px 14px;
+        border-radius: 6px;
+        color: var(--fg-dim);
+      }
+      .tabs button:hover {
+        border-color: transparent;
+        color: var(--fg);
+      }
+      .tabs button.active {
+        background: var(--accent-bg);
+        color: var(--bg-dark);
+      }
+      .pr-list {
+        display: flex;
+        flex-direction: column;
+        gap: 28px;
+      }
+      .pr-repo-name {
+        font-size: 13px;
+        font-weight: 600;
+        color: var(--accent);
+        margin-bottom: 8px;
+        font-family: var(--mono);
+      }
+      .pr-card {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 12px 14px;
+        margin-bottom: 8px;
+        border: 1px solid var(--border);
+        border-radius: var(--radius);
+        background: var(--bg-elev);
+        cursor: pointer;
+        transition: border-color 0.12s;
+      }
+      .pr-card:hover {
+        border-color: var(--accent);
+      }
+      .pr-num {
+        font-family: var(--mono);
+        font-size: 12px;
+        color: var(--fg-dim);
+        min-width: 48px;
+      }
+      .pr-main {
+        flex: 1;
+        min-width: 0;
+      }
+      .pr-title {
+        font-size: 14px;
+        font-weight: 500;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .pr-meta {
+        font-size: 12px;
+        color: var(--fg-dim);
+        margin-top: 3px;
+      }
+      .pr-badge {
+        font-size: 11px;
+        padding: 1px 7px;
+        border-radius: 999px;
+        border: 1px solid var(--border);
+      }
+      .pr-badge.draft {
+        color: var(--fg-dim);
+      }
+      .pr-stat-add {
+        color: var(--success);
+        font-family: var(--mono);
+        font-size: 12px;
+      }
+      .pr-stat-del {
+        color: var(--error);
+        font-family: var(--mono);
+        font-size: 12px;
+      }
+      .pr-banner {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 10px 14px;
+        margin-bottom: 16px;
+        border: 1px solid var(--accent);
+        border-radius: var(--radius);
+        background: var(--bg-elev);
+      }
+      .pr-banner .pr-banner-title {
+        flex: 1;
+        min-width: 0;
+        font-weight: 500;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .pr-banner a {
+        color: var(--accent);
+        text-decoration: none;
+        font-size: 12px;
+      }
+      .pr-banner a:hover {
+        text-decoration: underline;
+      }
       .status {
         font-size: 12px;
         color: var(--fg-dim);
@@ -442,12 +559,18 @@
   <body>
     <header>
       <h1>git-review</h1>
-      <select id="scope">
-        <option value="working">Working tree (vs HEAD)</option>
-        <option value="staged">Staged</option>
-        <option value="branch">Branch vs base</option>
-      </select>
-      <input id="base" type="text" value="main" size="10" title="base ref for branch scope" />
+      <div class="tabs">
+        <button id="tab-diff" class="active" data-mode="diff">Diff</button>
+        <button id="tab-prs" data-mode="prs">PRs</button>
+      </div>
+      <span id="diff-controls" style="display: contents">
+        <select id="scope">
+          <option value="working">Working tree (vs HEAD)</option>
+          <option value="staged">Staged</option>
+          <option value="branch">Branch vs base</option>
+        </select>
+        <input id="base" type="text" value="main" size="10" title="base ref for branch scope" />
+      </span>
       <select id="view" title="diff layout">
         <option value="unified">Unified</option>
         <option value="split">Split</option>
@@ -474,6 +597,12 @@
       let viewMode = localStorage.getItem("gr-view") || "unified";
       viewSel.value = viewMode;
       let lastGroups = [];
+
+      const diffControls = document.getElementById("diff-controls");
+      const tabDiff = document.getElementById("tab-diff");
+      const tabPrs = document.getElementById("tab-prs");
+      let appMode = "diff";
+      let currentPr = null;
 
       if (params.get("scope")) scopeSel.value = params.get("scope");
       if (params.get("base")) baseInput.value = params.get("base");
@@ -531,12 +660,163 @@
         return "unknown";
       }
 
-      function renderDiff(groups) {
+      function timeAgo(iso) {
+        const then = new Date(iso).getTime();
+        if (Number.isNaN(then)) return "";
+        const secs = Math.max(0, (Date.now() - then) / 1000);
+        const units = [
+          ["y", 31536000],
+          ["mo", 2592000],
+          ["d", 86400],
+          ["h", 3600],
+          ["m", 60],
+        ];
+        for (const [label, size] of units) {
+          const v = Math.floor(secs / size);
+          if (v >= 1) return `${v}${label} ago`;
+        }
+        return "just now";
+      }
+
+      async function loadPrs() {
+        content.innerHTML = '<div class="empty">Loading open PRs…</div>';
+        try {
+          const res = await fetch(`/api/prs?token=${TOKEN}`);
+          const data = await res.json();
+          renderPrList(data.groups || []);
+        } catch (err) {
+          content.innerHTML = `<div class="empty">Failed to load PRs: ${escapeHtml(String(err))}</div>`;
+        }
+      }
+
+      function renderPrList(groups) {
         if (!groups.length) {
-          content.innerHTML = '<div class="empty">No changes in this scope.</div>';
+          content.innerHTML =
+            '<div class="empty">No open PRs found across repos.<br/>Requires the <code>gh</code> CLI authenticated.</div>';
           return;
         }
         content.innerHTML = "";
+        const list = document.createElement("div");
+        list.className = "pr-list";
+        groups.forEach((group) => {
+          const repoEl = document.createElement("div");
+          const name = document.createElement("div");
+          name.className = "pr-repo-name";
+          name.textContent = group.repo;
+          repoEl.appendChild(name);
+          group.prs.forEach((pr) => {
+            const card = document.createElement("div");
+            card.className = "pr-card";
+            const draft = pr.isDraft
+              ? '<span class="pr-badge draft">draft</span>'
+              : "";
+            card.innerHTML =
+              `<span class="pr-num">#${pr.number}</span>` +
+              `<div class="pr-main">` +
+              `<div class="pr-title">${escapeHtml(pr.title)}</div>` +
+              `<div class="pr-meta">${escapeHtml(pr.author)} · ${escapeHtml(pr.headRefName)} → ${escapeHtml(pr.baseRefName)} · ${escapeHtml(timeAgo(pr.updatedAt))}</div>` +
+              `</div>` +
+              draft +
+              `<span class="pr-stat-add">+${pr.additions}</span>` +
+              `<span class="pr-stat-del">-${pr.deletions}</span>`;
+            card.addEventListener("click", () => openPr(pr));
+            repoEl.appendChild(card);
+          });
+          list.appendChild(repoEl);
+        });
+        content.appendChild(list);
+      }
+
+      async function openPr(pr) {
+        content.innerHTML = `<div class="empty">Loading PR #${pr.number}…</div>`;
+        try {
+          const res = await fetch(
+            `/api/pr-diff?token=${TOKEN}&repo=${encodeURIComponent(pr.repo)}&number=${pr.number}`,
+          );
+          const data = await res.json();
+          if (data.error) {
+            content.innerHTML = `<div class="empty">Failed to load PR: ${escapeHtml(String(data.error))}</div>`;
+            return;
+          }
+          currentPr = { ...pr, context: data.context, started: false };
+          lastGroups = [
+            {
+              repo: `${pr.repo} · PR #${pr.number}`,
+              branch: pr.headRefName,
+              worktree: null,
+              files: data.files || [],
+            },
+          ];
+          renderPrDiff(pr, lastGroups);
+        } catch (err) {
+          content.innerHTML = `<div class="empty">Failed to load PR: ${escapeHtml(String(err))}</div>`;
+        }
+      }
+
+      function startReview() {
+        if (!currentPr || currentPr.started) return;
+        if (!ws || ws.readyState !== WebSocket.OPEN) {
+          toast(`${currentPr.repo} #${currentPr.number}`, null, null, "Not connected — try again");
+          return;
+        }
+        ws.send(JSON.stringify(currentPr.context));
+        currentPr.started = true;
+        toast(`${currentPr.repo} #${currentPr.number}`, null, null, "PR context sent to agent");
+        const btn = document.getElementById("pr-start");
+        if (btn) {
+          btn.textContent = "Review started";
+          btn.disabled = true;
+          btn.classList.remove("primary");
+        }
+      }
+
+      function renderPrDiff(pr, groups) {
+        content.innerHTML = "";
+        const banner = document.createElement("div");
+        banner.className = "pr-banner";
+        const startLabel = pr.started ? "Review started" : "Start review";
+        const startCls = pr.started ? "" : "primary";
+        banner.innerHTML =
+          `<button id="pr-back">← PRs</button>` +
+          `<span class="pr-num">#${pr.number}</span>` +
+          `<span class="pr-banner-title">${escapeHtml(pr.title)}</span>` +
+          `<a href="${escapeHtml(pr.url)}" target="_blank" rel="noreferrer">open on GitHub ↗</a>` +
+          `<button id="pr-start" class="${startCls}"${pr.started ? " disabled" : ""}>${startLabel}</button>`;
+        content.appendChild(banner);
+        banner.querySelector("#pr-back").onclick = () => {
+          currentPr = null;
+          loadPrs();
+        };
+        banner.querySelector("#pr-start").onclick = startReview;
+        const diffHost = document.createElement("div");
+        content.appendChild(diffHost);
+        renderDiff(groups, diffHost);
+      }
+
+      function setMode(mode) {
+        appMode = mode;
+        tabDiff.classList.toggle("active", mode === "diff");
+        tabPrs.classList.toggle("active", mode === "prs");
+        diffControls.style.display = mode === "diff" ? "contents" : "none";
+        closePopover();
+        clearSelection();
+        selection = null;
+        hideAskBtn();
+        if (mode === "diff") {
+          currentPr = null;
+          loadDiff();
+        } else {
+          loadPrs();
+        }
+      }
+
+      function renderDiff(groups, host) {
+        const target = host || content;
+        if (!groups.length) {
+          target.innerHTML = '<div class="empty">No changes in this scope.</div>';
+          return;
+        }
+        target.innerHTML = "";
         let fi = 0;
         groups.forEach((group) => {
           const groupEl = document.createElement("div");
@@ -571,7 +851,7 @@
             groupEl.classList.toggle("open");
           });
           if (groups.length === 1) groupEl.classList.add("open");
-          content.appendChild(groupEl);
+          target.appendChild(groupEl);
         });
 
         wireSelection();
@@ -985,8 +1265,16 @@
         openPopover(last.querySelector("td.gutter"));
       });
 
-      document.getElementById("refresh").onclick = loadDiff;
+      document.getElementById("refresh").onclick = () => {
+        if (appMode === "prs") {
+          currentPr ? openPr(currentPr) : loadPrs();
+        } else {
+          loadDiff();
+        }
+      };
       scopeSel.onchange = loadDiff;
+      tabDiff.onclick = () => setMode("diff");
+      tabPrs.onclick = () => setMode("prs");
       viewSel.onchange = () => {
         viewMode = viewSel.value;
         localStorage.setItem("gr-view", viewMode);
@@ -994,7 +1282,11 @@
         clearSelection();
         selection = null;
         hideAskBtn();
-        renderDiff(lastGroups);
+        if (appMode === "prs" && currentPr) {
+          renderPrDiff(currentPr, lastGroups);
+        } else if (appMode === "diff") {
+          renderDiff(lastGroups);
+        }
       };
       baseInput.addEventListener("keydown", (e) => {
         if (e.key === "Enter") loadDiff();
@@ -1006,7 +1298,11 @@
       });
 
       connect();
-      loadDiff();
+      if (params.get("mode") === "prs") {
+        setMode("prs");
+      } else {
+        loadDiff();
+      }
     </script>
   </body>
 </html>

--- a/packages/git-review/web/index.html
+++ b/packages/git-review/web/index.html
@@ -138,11 +138,15 @@
         display: flex;
         align-items: center;
         gap: 12px;
+        width: 100%;
         padding: 12px 14px;
         margin-bottom: 8px;
         border: 1px solid var(--border);
         border-radius: var(--radius);
         background: var(--bg-elev);
+        color: inherit;
+        font: inherit;
+        text-align: left;
         cursor: pointer;
         transition: border-color 0.12s;
       }
@@ -603,6 +607,7 @@
       const tabPrs = document.getElementById("tab-prs");
       let appMode = "diff";
       let currentPr = null;
+      let prRequestSeq = 0;
 
       if (params.get("scope")) scopeSel.value = params.get("scope");
       if (params.get("base")) baseInput.value = params.get("base");
@@ -679,10 +684,12 @@
       }
 
       async function loadPrs() {
+        const requestSeq = ++prRequestSeq;
         content.innerHTML = '<div class="empty">Loading open PRs…</div>';
         try {
           const res = await fetch(`/api/prs?token=${TOKEN}`);
           const data = await res.json();
+          if (requestSeq !== prRequestSeq || appMode !== "prs") return;
           renderPrList(data.groups || []);
         } catch (err) {
           content.innerHTML = `<div class="empty">Failed to load PRs: ${escapeHtml(String(err))}</div>`;
@@ -705,7 +712,8 @@
           name.textContent = group.repo;
           repoEl.appendChild(name);
           group.prs.forEach((pr) => {
-            const card = document.createElement("div");
+            const card = document.createElement("button");
+            card.type = "button";
             card.className = "pr-card";
             const draft = pr.isDraft
               ? '<span class="pr-badge draft">draft</span>'
@@ -728,17 +736,28 @@
       }
 
       async function openPr(pr) {
+        const requestSeq = ++prRequestSeq;
         content.innerHTML = `<div class="empty">Loading PR #${pr.number}…</div>`;
         try {
           const res = await fetch(
             `/api/pr-diff?token=${TOKEN}&repo=${encodeURIComponent(pr.repo)}&number=${pr.number}`,
           );
           const data = await res.json();
+          if (requestSeq !== prRequestSeq || appMode !== "prs") return;
           if (data.error) {
             content.innerHTML = `<div class="empty">Failed to load PR: ${escapeHtml(String(data.error))}</div>`;
             return;
           }
-          currentPr = { ...pr, context: data.context, started: false };
+          const wasStarted =
+            currentPr &&
+            currentPr.repo === pr.repo &&
+            currentPr.number === pr.number &&
+            currentPr.started;
+          currentPr = {
+            ...pr,
+            context: data.context,
+            started: Boolean(pr.started || wasStarted),
+          };
           lastGroups = [
             {
               repo: `${pr.repo} · PR #${pr.number}`,
@@ -747,8 +766,9 @@
               files: data.files || [],
             },
           ];
-          renderPrDiff(pr, lastGroups);
+          renderPrDiff(currentPr, lastGroups);
         } catch (err) {
+          if (requestSeq !== prRequestSeq || appMode !== "prs") return;
           content.innerHTML = `<div class="empty">Failed to load PR: ${escapeHtml(String(err))}</div>`;
         }
       }
@@ -806,6 +826,7 @@
           currentPr = null;
           loadDiff();
         } else {
+          currentPr = null;
           loadPrs();
         }
       }


### PR DESCRIPTION
## Summary

Adds a **PR review mode** to the `git-review` tool. Alongside the existing working/staged/branch diff views, you can now browse and review open pull requests across every repo in the workspace, directly from the browser reviewer.

## What changed

**New PRs tab**
- Lists open PRs per repo via `gh pr list`, grouped by repo and sorted by **PR number descending** (newest PR first — not by last activity).
- Each card shows number, title, author, `head → base` branch, draft badge, +/- stats, and relative time.

**Opening a PR**
- Loads the full PR diff via `gh pr diff` (base...head, independent of local checkout), rendered through the existing diff viewer (unified/split, line selection, ask-the-agent popover).
- Paths are prefixed per repo, consistent with the multi-repo diff mode.

**Start review**
- Opening a PR loads the diff only — no context is sent yet.
- A **Start review** button in the banner sends a one-time context primer to the agent (title, author, branch, link, and the full PR description), then flips to a disabled "Review started" state.
- This decouples browsing the diff from committing PR context to the agent.

**Command**
- `/review prs` opens the UI directly on the PRs tab.

## Implementation

- `src/server.ts` — `collectPullRequests` (`gh pr list`), `collectPrDiff` (`gh pr view` + `gh pr diff`), routes `/api/prs` and `/api/pr-diff` (token-gated), new `pr_context` WS message type; generalized `onComment` → `onMessage`.
- `src/index.ts` — `formatPrContext` primer, `prs` arg parsing, `mode=prs` deep link.
- `web/index.html` — Diff/PRs tab switcher, PR list/cards, PR diff banner with Start review, reusing the existing render/selection pipeline.
- `README.md` — documented the PR flow.

## Requirements

- Requires the `gh` CLI installed and authenticated. The PRs tab degrades to an empty-state message if `gh` is unavailable.

## Testing

- `tsc --noEmit` and `npm run build` pass.
- Verified `gh pr list` / `gh pr view` / `gh pr diff` JSON shapes against real `api-arvore` PRs, and confirmed `parse-diff` parses the prefixed PR diff correctly (files, paths, stats intact).
- Manually tested in-browser: PR listing, opening a PR, Start review primer delivery, and unified/split toggle preserving review state.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new **PRs view** alongside the existing diff view, with tab switching in the interface.
  * Users can now browse open pull requests, open one, and see its review context and file changes.
  * Added support for starting reviews directly in PR mode and sending PR context to the reviewer.

* **Documentation**
  * Updated the README with clearer setup, API, and PR-review usage instructions, including required authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->