### PR TITLE
feat(worktree): add Herdr terminal support to shell command

### DIFF
--- a/packages/worktree/package.json
+++ b/packages/worktree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-worktree",
-  "version": "1.8.2",
+  "version": "1.9.0",
   "description": "PI extension to manage git worktrees across multi-repo workspaces with tree-themed names",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/worktree/src/index.ts
+++ b/packages/worktree/src/index.ts
@@ -304,7 +304,7 @@ function formatHelp(): string {
     "  use    <name>     — activate worktree (agent works in worktree paths)",
     "  stop              — deactivate current worktree",
     "  mode   [on|off]   — toggle worktree mode (agent auto-creates worktrees)",
-    "  shell             — open tmux panes or Warp tabs in the worktree (tmux/Warp only)",
+    "  shell             — open Herdr panes, tmux panes, or Warp tabs in the worktree (Herdr/tmux/Warp only)",
     "  list   [--repos repo1,repo2]",
     "  delete <name> [--repos repo1,repo2]",
     "",
@@ -832,26 +832,40 @@ export default function worktreeExtension(pi: ExtensionAPI): void {
             return;
           }
 
+          const inHerdr = !!process.env.HERDR_ENV || !!process.env.HERDR_PANE_ID;
           const inTmux = !!process.env.TMUX;
           const inWarp = process.env.TERM_PROGRAM === "WarpTerminal" || !!process.env.WARP_IS_LOCAL_SHELL_SESSION;
 
-          if (!inTmux && !inWarp) {
-            ctx.ui.notify("shell requires tmux or Warp Terminal.", "error");
+          if (!inHerdr && !inTmux && !inWarp) {
+            ctx.ui.notify("shell requires Herdr, tmux, or Warp Terminal.", "error");
             return;
           }
 
           const paths = [...activeWorktreePaths.values()];
 
-          for (let i = 0; i < paths.length; i++) {
-            if (inTmux) {
-              if (i === 0) {
-                spawn("tmux", ["split-window", "-h", "-c", paths[i]], { stdio: "ignore" });
-              } else {
-                spawn("tmux", ["split-window", "-v", "-c", paths[i]], { stdio: "ignore" });
+          if (inHerdr) {
+            const sourcePane = process.env.HERDR_PANE_ID;
+            for (let i = 0; i < paths.length; i++) {
+              const args = ["pane", "split", "--direction", i === 0 ? "right" : "down", "--cwd", paths[i], "--no-focus"];
+              if (sourcePane) args.splice(2, 0, sourcePane);
+              const result = spawnSync("herdr", args, { encoding: "utf-8" });
+              if (result.status !== 0) {
+                ctx.ui.notify(`herdr pane split failed: ${result.stderr?.trim() || result.error?.message || "unknown error"}`, "error");
+                return;
               }
-            } else {
-              const opener = process.platform === "darwin" ? "open" : "xdg-open";
-              spawn(opener, [`warp://action/new_tab?path=${encodeURIComponent(paths[i])}`], { detached: true, stdio: "ignore" }).unref();
+            }
+          } else {
+            for (let i = 0; i < paths.length; i++) {
+              if (inTmux) {
+                if (i === 0) {
+                  spawn("tmux", ["split-window", "-h", "-c", paths[i]], { stdio: "ignore" });
+                } else {
+                  spawn("tmux", ["split-window", "-v", "-c", paths[i]], { stdio: "ignore" });
+                }
+              } else {
+                const opener = process.platform === "darwin" ? "open" : "xdg-open";
+                spawn(opener, [`warp://action/new_tab?path=${encodeURIComponent(paths[i])}`], { detached: true, stdio: "ignore" }).unref();
+              }
             }
           }
 


### PR DESCRIPTION
## Summary

Adds support for [Herdr](https://github.com/) terminal panes to the worktree extension's `shell` command, alongside the existing tmux and Warp support.

## Changes

- Detect a Herdr session via the `HERDR_ENV` / `HERDR_PANE_ID` environment variables.
- When running inside Herdr, `shell` now splits panes using `herdr pane split`:
  - First worktree path opens to the `right`, subsequent paths open `down`.
  - Uses `--cwd <path>` and `--no-focus`, and targets the source pane via `HERDR_PANE_ID` when available.
  - Surfaces a clear error notification if the `herdr pane split` call fails.
- tmux and Warp behavior is unchanged (now in the `else` branch).
- Updated the `shell` help text and the unsupported-terminal error message to mention Herdr.

## Testing

- Manual review of the diff; `spawnSync` was already imported.
