### PR TITLE
feat(lsp): block tsc/build for type checking, enforce lsp_diagnostics

### DIFF
--- a/packages/lsp/package.json
+++ b/packages/lsp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-lsp",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "PI extension that bridges Language Server Protocol servers to give the agent real compiler diagnostics, go-to-definition, references, hover and rename",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/lsp/src/index.ts
+++ b/packages/lsp/src/index.ts
@@ -21,6 +21,18 @@ export default function (pi: ExtensionAPI) {
     manager = null;
   });
 
+  pi.on("before_agent_start", async (event) => {
+    if (!manager) return;
+    return {
+      systemPrompt:
+        event.systemPrompt +
+        "\n\n## Type checking\n" +
+        "To validate TypeScript/JavaScript types, ALWAYS use the lsp_diagnostics tool. " +
+        "NEVER run `tsc`, `tsc --noEmit`, `vue-tsc`, `pnpm build`, `pnpm typecheck`, or any compiler/build command for the sole purpose of checking types. " +
+        "Run a full build only when the user explicitly asks for a build or when build artifacts are the actual deliverable.",
+    };
+  });
+
   pi.registerCommand("lsp-status", {
     description: "Show configured LSP language servers and their availability.",
     handler: async (_args, ctx) => {

--- a/packages/lsp/src/tools.ts
+++ b/packages/lsp/src/tools.ts
@@ -83,7 +83,8 @@ export function registerLspTools(pi: ExtensionAPI, getManager: () => LspManager)
     promptSnippet: "Get compiler diagnostics (type errors/warnings) for a file via LSP",
     promptGuidelines: [
       "Call lsp_diagnostics after editing a TypeScript/JavaScript file to confirm there are no type errors before moving on.",
-      "Prefer lsp_diagnostics over running a full build when you only need to validate a single file.",
+      "To type-check TypeScript/JavaScript, ALWAYS use lsp_diagnostics. NEVER run `tsc`, `tsc --noEmit`, `pnpm build`, `pnpm typecheck`, `vue-tsc`, or any compiler/build command just to check types — lsp_diagnostics is faster and is the only sanctioned way to validate types.",
+      "Only run a full build (tsc/pnpm build) when the user explicitly asks for a build or when producing build artifacts is the actual goal — not for type validation.",
     ],
     parameters: Type.Object({
       file: Type.String({ description: "Path to the source file (relative to cwd or absolute)." }),


### PR DESCRIPTION
Proíbe o modelo de usar `tsc`, `vue-tsc`, `pnpm build` para checar tipos. Força uso de `lsp_diagnostics` via dois vetores: `promptGuidelines` na tool e injeção no system prompt via `before_agent_start`. Bump `@arvoretech/pi-lsp` 1.0.2 → 1.0.3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer guidance for type validation, directing the agent to use diagnostics for TypeScript and JavaScript checks.
* **Chores**
  * Bumped the LSP package version to 1.0.3.
* **Bug Fixes**
  * Tightened the type-checking workflow to reduce unnecessary compiler or build runs unless a full build is explicitly requested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->