### PR TITLE
feat(secret-firewall): auto-export pattern-matched tokens to shell

### DIFF
--- a/packages/secret-firewall/README.md
+++ b/packages/secret-firewall/README.md
@@ -26,7 +26,13 @@ Redaction happens on two channels:
 
 A pattern fallback also catches well-known token shapes (AWS keys, JWTs,
 `sk-...`, GitHub/Slack tokens, PEM private keys) that leak into output even when
-they were never in an env var.
+they were never in an env var. When such a token is caught, it is **captured and
+auto-exported** to the shell: the matched value is assigned a stable placeholder
+(`$SECRET_JWT`, `$SECRET_JWT_2`, ...), written to `process.env`, and replaced in
+the context. So if you paste a JWT into the chat, it is redacted to
+`$SECRET_JWT` for the model *and* becomes a real shell variable you can use:
+`curl -H "Authorization: Bearer $SECRET_JWT"`. Captured names show up under
+`/secret-firewall` status.
 
 ## Security model — the model never sees the value
 
@@ -42,6 +48,15 @@ The extension never re-hydrates placeholders itself. If the model writes the
 literal *value* instead of the placeholder, that value is redacted on the way
 back, but the model must use the `$SECRET_*` reference for a command to actually
 use the secret.
+
+### Pasted/leaked tokens are captured and exported
+
+When a value is caught by a **pattern rule** (JWT, AWS key, `sk-...`, etc.) it is
+not only masked — its real value is captured and exported as a `$SECRET_*` shell
+variable on the fly. This means a token pasted into the chat becomes usable in
+bash (`$SECRET_JWT`) without the model ever seeing the value, and without
+needing it in `.env` beforehand. Distinct values caught by the same pattern get
+suffixed placeholders (`$SECRET_JWT_2`).
 
 ### Limits / non-goals
 

--- a/packages/secret-firewall/package.json
+++ b/packages/secret-firewall/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-secret-firewall",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Redacts secrets (env vars, .env files, token patterns) from the model context and tool outputs, exposing them only as $SECRET_* shell env vars the model can reference but never read",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/secret-firewall/src/index.ts
+++ b/packages/secret-firewall/src/index.ts
@@ -14,7 +14,7 @@ export default function (pi: ExtensionAPI) {
   let entries: SecretEntry[] = [];
   const redactor = createRedactor([]);
   let exportedNames: string[] = [];
-  const stats = { redactedHits: 0, lastScan: 0 };
+  const stats = { redactedHits: 0, lastScan: 0, capturedCount: 0 };
 
   function exportToShell(list: SecretEntry[]): void {
     for (const name of exportedNames) {
@@ -35,6 +35,14 @@ export default function (pi: ExtensionAPI) {
     redactor.refresh(entries);
     exportToShell(entries);
     stats.lastScan = entries.length;
+  }
+
+  function exportCaptured(): void {
+    for (const secret of redactor.drainCaptured()) {
+      process.env[secret.name] = secret.value;
+      if (!exportedNames.includes(secret.name)) exportedNames.push(secret.name);
+      stats.capturedCount++;
+    }
   }
 
   function redactBlocks(content: ContentBlock[]): ContentBlock[] | undefined {
@@ -107,7 +115,7 @@ export default function (pi: ExtensionAPI) {
   });
 
   pi.on("context", async (event, _ctx) => {
-    if (!enabled || entries.length === 0) return;
+    if (!enabled) return;
     let changed = false;
     const messages = (event.messages as unknown[]).map((msg) => {
       const m = msg as Record<string, unknown>;
@@ -120,12 +128,14 @@ export default function (pi: ExtensionAPI) {
       }
       return msg;
     });
+    exportCaptured();
     if (changed) return { messages } as never;
   });
 
   pi.on("tool_result", async (event) => {
-    if (!enabled || entries.length === 0) return;
+    if (!enabled) return;
     const redacted = redactBlocks(event.content as ContentBlock[]);
+    exportCaptured();
     if (redacted) return { content: redacted } as never;
   });
 
@@ -134,9 +144,10 @@ export default function (pi: ExtensionAPI) {
     handler: async (_args, ctx) => {
       rescan(ctx.cwd);
       const names = entries.map((e) => e.placeholder).join(", ") || "(none)";
+      const captured = redactor.knownPlaceholders().join(", ") || "(none)";
       ctx.ui.notify(
         `secret-firewall [${enabled ? "on" : "off"}] | protecting ${entries.length} secret(s) | ` +
-          `redacted ${stats.redactedHits} value(s) so far\nReferenceable as shell env: ${names}`,
+          `redacted ${stats.redactedHits} value(s) so far\nReferenceable as shell env: ${names}\nCaptured from context (auto-exported): ${captured}`,
         "info",
       );
     },

--- a/packages/secret-firewall/src/redact.ts
+++ b/packages/secret-firewall/src/redact.ts
@@ -1,8 +1,16 @@
 import type { SecretEntry } from "./secrets.js";
 
+export interface DynamicSecret {
+  name: string;
+  placeholder: string;
+  value: string;
+}
+
 export interface Redactor {
   redactString(text: string): { text: string; hits: number };
   refresh(entries: SecretEntry[]): void;
+  drainCaptured(): DynamicSecret[];
+  knownPlaceholders(): string[];
 }
 
 interface PatternRule {
@@ -30,10 +38,39 @@ function escapeRe(s: string): string {
 export function createRedactor(initial: SecretEntry[]): Redactor {
   let valueRules: { re: RegExp; placeholder: string }[] = [];
 
+  const captured = new Map<string, DynamicSecret>();
+  const takenPlaceholders = new Set<string>();
+  let pending: DynamicSecret[] = [];
+
   function refresh(entries: SecretEntry[]): void {
     valueRules = entries
       .filter((e) => e.value.length > 0)
       .map((e) => ({ re: new RegExp(escapeRe(e.value), "g"), placeholder: e.placeholder }));
+    for (const e of entries) takenPlaceholders.add(e.placeholder);
+  }
+
+  function allocatePlaceholder(patternName: string): string {
+    const base = `$SECRET_${patternName}`;
+    if (!takenPlaceholders.has(base)) return base;
+    let i = 2;
+    while (takenPlaceholders.has(`${base}_${i}`)) i++;
+    return `${base}_${i}`;
+  }
+
+  function capture(patternName: string, value: string): string {
+    const existing = captured.get(value);
+    if (existing) return existing.placeholder;
+    const placeholder = allocatePlaceholder(patternName);
+    takenPlaceholders.add(placeholder);
+    const entry: DynamicSecret = {
+      name: placeholder.replace(/^\$/, ""),
+      placeholder,
+      value,
+    };
+    captured.set(value, entry);
+    pending.push(entry);
+    valueRules.push({ re: new RegExp(escapeRe(value), "g"), placeholder });
+    return placeholder;
   }
 
   function redactString(text: string): { text: string; hits: number } {
@@ -47,14 +84,25 @@ export function createRedactor(initial: SecretEntry[]): Redactor {
       });
     }
     for (const { name, re } of PATTERN_RULES) {
-      out = out.replace(re, () => {
+      out = out.replace(re, (match) => {
         hits++;
-        return `$SECRET_${name}`;
+        return capture(name, match);
       });
     }
     return { text: out, hits };
   }
 
+  function drainCaptured(): DynamicSecret[] {
+    if (pending.length === 0) return [];
+    const out = pending;
+    pending = [];
+    return out;
+  }
+
+  function knownPlaceholders(): string[] {
+    return Array.from(captured.values()).map((e) => e.placeholder);
+  }
+
   refresh(initial);
-  return { redactString, refresh };
+  return { redactString, refresh, drainCaptured, knownPlaceholders };
 }

--- a/packages/secret-firewall/test/smoke.test.ts
+++ b/packages/secret-firewall/test/smoke.test.ts
@@ -71,3 +71,38 @@ test("redactor leaves non-secret text untouched", () => {
   assert.equal(out.text, "server listening on port 3000");
   assert.equal(out.hits, 0);
 });
+
+test("captures pattern-matched secrets for shell export", () => {
+  const r = createRedactor([]);
+  const jwt =
+    "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJVc2VyOjEyMyJ9.abcDEFghiJKLmnoPQRstuVWXyz0123456789";
+  const out = r.redactString(`Authorization: Bearer ${jwt}`);
+  assert.equal(out.text, "Authorization: Bearer $SECRET_JWT");
+  const captured = r.drainCaptured();
+  assert.equal(captured.length, 1);
+  assert.equal(captured[0].name, "SECRET_JWT");
+  assert.equal(captured[0].placeholder, "$SECRET_JWT");
+  assert.equal(captured[0].value, jwt);
+});
+
+test("drainCaptured returns each captured secret only once", () => {
+  const r = createRedactor([]);
+  const jwt =
+    "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJVc2VyOjEyMyJ9.abcDEFghiJKLmnoPQRstuVWXyz0123456789";
+  r.redactString(jwt);
+  assert.equal(r.drainCaptured().length, 1);
+  r.redactString(jwt);
+  assert.equal(r.drainCaptured().length, 0);
+});
+
+test("distinct pattern matches get distinct placeholders", () => {
+  const r = createRedactor([]);
+  const a =
+    "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJVc2VyOjFhYWEifQ.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+  const b =
+    "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJVc2VyOjJiYmIifQ.bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+  const out = r.redactString(`${a} and ${b}`);
+  assert.equal(out.text, "$SECRET_JWT and $SECRET_JWT_2");
+  const captured = r.drainCaptured();
+  assert.equal(captured.length, 2);
+});


### PR DESCRIPTION
## Resumo

A `secret-firewall` antes apenas **mascarava** tokens pegos por pattern (JWT, AWS key, `sk-*`, GitHub/Slack, PEM) — o valor era trocado por `$SECRET_JWT` no contexto do modelo, mas nunca ficava disponível no shell. Isso causava confusão: o placeholder `$SECRET_JWT` parecia uma variável usável, mas resolvia para vazio no bash (→ 401 em chamadas autenticadas).

Agora esses tokens são **capturados e exportados automaticamente** como variáveis de ambiente. Um token colado no chat é redatado para o modelo **e** vira um `$SECRET_*` real e utilizável no shell, sem precisar estar no `.env` antes.

## Mudanças

- **`redact.ts`**: redactor agora captura o valor real de cada match de pattern, atribui um placeholder estável (`$SECRET_JWT`, `$SECRET_JWT_2`, …) e expõe `drainCaptured()` / `knownPlaceholders()`.
- **`index.ts`**: após cada passada de redação (`context` e `tool_result`), os secrets capturados são exportados para `process.env`. Removido o curto-circuito `entries.length === 0` que impedia a captura por pattern quando não havia `.env`.
- **`secret-firewall` (status)**: passa a listar os placeholders capturados/auto-exportados.
- Bump `0.1.0` → `0.2.0`.

## Fluxo novo

1. Token colado no chat → redatado para `$SECRET_JWT` (modelo nunca vê o valor).
2. Valor real exportado para `process.env.SECRET_JWT`.
3. `curl -H "Authorization: Bearer $SECRET_JWT"` funciona na próxima chamada de bash.

## Trade-off de segurança

Isso afrouxa o modelo original: tokens que aparecem em **qualquer** output (logs, respostas de API, arquivos lidos) agora são promovidos a env vars disponíveis pela sessão inteira, não só mascarados e descartados. É o comportamento desejado, mas amplia a superfície. Possível refinamento futuro: restringir a captura ao canal `context` (texto do usuário) e não ao `tool_result`.

## Testes

- `pnpm build`, `pnpm lint`, `pnpm test` — 9/9 passando.
- 3 testes novos: captura de pattern, `drainCaptured` retorna cada secret uma vez, placeholders distintos para valores distintos.