### PR TITLE
feat(pi-codebase-index): semantic codebase search extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,22 @@
   "pnpm": {
     "overrides": {
       "@earendil-works/pi-tui": "0.79.5"
-    }
+    },
+    "ignoredBuiltDependencies": [
+      "tree-sitter-typescript",
+      "tree-sitter-javascript",
+      "tree-sitter-python",
+      "tree-sitter-go",
+      "tree-sitter-ruby",
+      "tree-sitter-rust",
+      "tree-sitter-java",
+      "tree-sitter-php",
+      "tree-sitter-c",
+      "tree-sitter-cpp",
+      "tree-sitter-c-sharp",
+      "tree-sitter-elixir",
+      "@tree-sitter-grammars/tree-sitter-kotlin"
+    ]
   },
   "packageManager": "pnpm@10.28.0",
   "engines": {

--- a/packages/pi-codebase-index/PROTOCOL.md
+++ b/packages/pi-codebase-index/PROTOCOL.md
@@ -1,0 +1,156 @@
+# Codebase Index Protocol
+
+This document defines the **vendor-neutral contract** between the `pi-codebase-index`
+client (a Pi extension) and any backend that powers semantic code search.
+
+The client never knows which vector store, embedding model, or reranker the backend
+uses. It only speaks the four HTTP endpoints described here. Implement these endpoints
+on top of any stack (Qdrant, pgvector, Pinecone, Weaviate, Milvus, ...) and the client
+works unchanged. A runnable reference backend lives in `reference-backend/`.
+
+## Concepts
+
+- **Repo**: a versioned project in the workspace. Identified by a stable `name`.
+- **Chunk**: a unit of code the backend embeds and stores. Produced by the client.
+- **Merkle root**: a single hash per repo derived from the content hashes of all its
+  tracked files. The backend stores the last root it indexed per repo so it can return
+  only the files that changed.
+
+## Authentication
+
+All four endpoints require a bearer token obtained through an OAuth-style flow. The
+provider is configurable (GitHub in the reference backend) and is not part of the data
+contract.
+
+```
+GET  /auth/<provider>/start?redirect_url=<client_local_url>
+  -> redirects the browser through the provider, then to:
+     <client_local_url>?token=<jwt>&refresh_token=<jwt>
+
+POST /auth/<provider>/refresh
+  body:  { "refresh_token": "<jwt>" }
+  reply: { "access_token": "<jwt>", "refresh_token": "<jwt>", "expires_in": <seconds> }
+```
+
+The access token is a JWT whose payload carries `username`, `exp`, and `iat`. The
+backend is responsible for restricting access (e.g. to members of an allowed org). The
+client treats the token as opaque except for reading those three fields.
+
+Every data request below carries `Authorization: Bearer <access_token>`.
+
+## Data endpoints
+
+Base path is implementation-defined (the reference backend mounts them under
+`/codebase-index`). All bodies are JSON.
+
+### POST /sync
+
+The client sends one Merkle root per repo. The backend compares each root with what it
+last indexed and returns the files that must be re-indexed. A repo the backend has never
+seen returns all of its files (this is how a newly added repo gets indexed automatically).
+
+```jsonc
+// request
+{
+  "repos": [
+    { "name": "api-arvore", "rootHash": "<sha256>", "files": [
+        { "path": "src/main.ts", "hash": "<sha256>" }
+    ] }
+  ]
+}
+```
+
+`files` is optional. When omitted the backend may treat a changed `rootHash` as "reindex
+the whole repo". When present the backend diffs file hashes and returns only the deltas,
+which is the cheap path the client uses by default.
+
+```jsonc
+// reply
+{
+  "changed": [
+    { "repo": "api-arvore", "path": "src/main.ts" }
+  ],
+  "removed": [
+    { "repo": "api-arvore", "path": "src/old.ts" }
+  ]
+}
+```
+
+`changed` are files to (re)index. `removed` are files whose chunks the backend has
+already dropped (returned for transparency; the client does not act on them).
+
+### POST /index
+
+The client embeds nothing. It sends raw chunks; the backend embeds and stores them.
+Chunks are upserted by `(repo, path, symbol)` identity, so re-sending a changed file
+replaces its previous chunks.
+
+```jsonc
+// request
+{
+  "chunks": [
+    {
+      "repo": "api-arvore",
+      "path": "src/billing/subscription.service.ts",
+      "symbol": "SubscriptionService.renew",
+      "lang": "typescript",
+      "gitSha": "<commit sha or file hash>",
+      "lineStart": 42,
+      "lineEnd": 88,
+      "content": "<the code, optionally context-enriched by the client>"
+    }
+  ]
+}
+```
+
+```jsonc
+// reply
+{ "indexed": 1 }
+```
+
+The client also calls `/index` with `{ "chunks": [], "remove": [{ "repo", "path" }] }`
+to drop chunks for deleted files. `remove` is optional.
+
+### POST /search
+
+```jsonc
+// request
+{ "query": "where is subscription renewal handled", "repo": "api-arvore", "lang": "typescript", "limit": 10 }
+```
+
+`repo` and `lang` are optional filters. Omitting `repo` searches across all repos
+(cross-repo ranking). `limit` defaults to 10.
+
+```jsonc
+// reply
+{
+  "results": [
+    {
+      "repo": "api-arvore",
+      "path": "src/billing/subscription.service.ts",
+      "symbol": "SubscriptionService.renew",
+      "lang": "typescript",
+      "snippet": "<~15 lines of the matched chunk>",
+      "score": 0.83,
+      "lineStart": 42,
+      "lineEnd": 88
+    }
+  ]
+}
+```
+
+The backend owns retrieval quality: it may do pure vector search, hybrid
+vector+lexical recall, and/or cross-encoder reranking. The contract only fixes the shape
+of the response.
+
+## Error model
+
+Non-2xx responses carry a plain-text or `{ "message": string }` body. `401` means the
+token is missing/expired (client re-authenticates), `403` means the user is not allowed.
+
+## What the backend must guarantee
+
+1. The **same embedding model and dimension** are used for `/index` and `/search`.
+2. Chunk identity is stable across re-indexing: upsert by `(repo, path, symbol)`.
+3. `/sync` is idempotent and cheap for unchanged repos (returns empty `changed`).
+4. Access control happens in the guard, not in the client.

--- a/packages/pi-codebase-index/README.md
+++ b/packages/pi-codebase-index/README.md
@@ -1,0 +1,77 @@
+# @arvoretech/pi-codebase-index
+
+A [Pi](https://github.com/earendil-works/pi-coding-agent) extension that gives the
+agent **semantic code search** across your repositories. Ask for code by concept
+("where is subscription renewal handled") and get ranked results across every repo,
+even when you don't know the exact symbol name.
+
+The extension is **vendor-neutral**: it talks to a backend over a small HTTP contract
+(see [`PROTOCOL.md`](./PROTOCOL.md) / [`openapi.yaml`](./openapi.yaml)). You bring the
+backend — use the runnable [`reference-backend/`](./reference-backend) or implement the
+contract on your own infrastructure. The choice of vector store (Qdrant, pgvector,
+Pinecone, ...) and embedding model lives entirely in the backend.
+
+## How it works
+
+1. On session start the extension scans the git repos in your workspace and computes a
+   content hash per file (a Merkle root per repo).
+2. It sends those hashes to the backend's `/sync`, which returns only the files that
+   changed since the last index. A newly added repo returns all its files, so new repos
+   index automatically.
+3. Changed files are chunked and sent to `/index` in the background — the backend embeds
+   and stores them. A status widget shows progress.
+4. The agent calls the `search_codebase` tool, which hits `/search` and returns ranked
+   snippets with file paths and line numbers.
+
+## Install
+
+```bash
+pnpm add @arvoretech/pi-codebase-index
+```
+
+Point it at your backend and authenticate:
+
+```bash
+export PI_CODEBASE_API_URL="https://your-backend.example.com/api"
+```
+
+Inside Pi:
+
+```
+/codebase-login
+```
+
+That's it — sync runs automatically from then on.
+
+## Commands
+
+| Command | What it does |
+|---|---|
+| `/codebase-login` | Authenticate with the backend |
+| `/codebase-logout` | Clear credentials |
+| `/codebase-search <query>` | Manual search (debugging) |
+| `/codebase-reindex` | Force a fresh sync of the workspace |
+| `/codebase-hide` | Hide the status widget (sync keeps running) |
+| `/codebase-show` | Show the status widget again |
+
+## Configuration
+
+| Env var | Required | Default | Purpose |
+|---|---|---|---|
+| `PI_CODEBASE_API_URL` | yes | — | Base URL of a backend implementing the protocol |
+| `PI_CODEBASE_AUTH_PROVIDER` | no | `github` | Auth provider segment in the `/auth/<provider>/...` routes |
+
+There is **no built-in backend URL** — the extension fails loudly until you set
+`PI_CODEBASE_API_URL`. This keeps the package free of any single company's
+infrastructure.
+
+## Running your own backend
+
+See [`SETUP.md`](./SETUP.md). The short version: start a Qdrant instance and run the
+service in [`reference-backend/`](./reference-backend) (`npm install && npm run build &&
+npm start`). Swap the vector store or embedder by implementing the `VectorStore` /
+`Embedder` interfaces in `reference-backend/src/ports.ts`.
+
+## License
+
+MIT

--- a/packages/pi-codebase-index/README.md
+++ b/packages/pi-codebase-index/README.md
@@ -19,7 +19,10 @@ Pinecone, ...) and embedding model lives entirely in the backend.
    changed since the last index. A newly added repo returns all its files, so new repos
    index automatically.
 3. Changed files are chunked and sent to `/index` in the background — the backend embeds
-   and stores them. A status widget shows progress.
+   and stores them. A status widget shows progress. Chunking is **AST-aware**
+   (via tree-sitter) for the languages it recognizes, so each chunk maps to a real
+   function/class/method and carries its actual symbol name; files in unsupported
+   languages fall back to fixed-size line windows.
 4. The agent calls the `search_codebase` tool, which hits `/search` and returns ranked
    snippets with file paths and line numbers.
 

--- a/packages/pi-codebase-index/SETUP.md
+++ b/packages/pi-codebase-index/SETUP.md
@@ -1,0 +1,100 @@
+# Setup — running your own backend
+
+The `pi-codebase-index` client is generic. To use it you point `PI_CODEBASE_API_URL`
+at a backend that implements the [Codebase Index Protocol](./PROTOCOL.md). You have two
+paths.
+
+## Option A — run the reference backend (≈15 min)
+
+The fastest way to "anyone can run it". The reference backend ships a Qdrant adapter and
+an OpenAI embedder, wired behind the vendor-neutral `VectorStore` / `Embedder`
+interfaces.
+
+You need a running vector store and the backend process:
+
+```bash
+# 1. Start a vector store. Any Qdrant instance works — local binary, a container,
+#    or a managed cloud cluster. It just needs to be reachable over HTTP.
+#    (The default adapter expects Qdrant on http://localhost:6333.)
+
+# 2. Configure and run the backend
+cd reference-backend
+cp .env.example .env
+# edit .env: set OPENAI_API_KEY, a long random JWT_SECRET, and QDRANT_URL
+npm install
+npm run build
+npm start
+```
+
+This serves the contract under `/codebase-index` on `:8080` (health at `/health`).
+
+Point the client at it:
+
+```bash
+export PI_CODEBASE_API_URL="http://localhost:8080"
+```
+
+Inside Pi: `/codebase-login`. With `ENABLE_DEV_AUTH=true` the backend mints a token
+without a real OAuth provider, so login works immediately for local use.
+
+### Authentication
+
+Once logged in, the client **stays logged in**: it stores credentials in
+`~/.config/pi/codebase-credentials.json` and silently refreshes the access token via
+`/auth/<provider>/refresh` before it expires. You only run `/codebase-login` again if you
+log out or the refresh token itself expires.
+
+For production, turn `ENABLE_DEV_AUTH=false` and implement a real provider:
+- `GET /auth/<provider>/start?redirect_url=...` → run OAuth, then redirect to
+  `redirect_url?token=<jwt>&refresh_token=<jwt>`
+- `POST /auth/<provider>/refresh` `{ refresh_token }` →
+  `{ access_token, refresh_token, expires_in }`
+
+The access token must be a JWT carrying `sub`, `username`, `orgs[]`, `iat`, `exp`. Restrict
+access with `ALLOWED_ORGS`.
+
+## Option B — implement the contract on your own backend
+
+If you already run an API and a vector store, implement the four endpoints from
+[`PROTOCOL.md`](./PROTOCOL.md) / [`openapi.yaml`](./openapi.yaml):
+
+- `POST /codebase-index/sync`
+- `POST /codebase-index/index`
+- `POST /codebase-index/search`
+- the `/auth/<provider>/start` + `/refresh` pair
+
+Then `export PI_CODEBASE_API_URL=https://your-api.example.com`. Nothing in the client
+changes.
+
+## Swapping the vector store or embedder
+
+In the reference backend, both are behind interfaces in `reference-backend/src/ports.ts`:
+
+```ts
+export interface Embedder {
+  dimension: number;
+  embed(texts: string[]): Promise<number[][]>;
+}
+
+export interface VectorStore {
+  init(dimension: number): Promise<void>;
+  upsert(points: VectorPoint[]): Promise<void>;
+  deleteByPath(org, repo, path): Promise<void>;
+  listFileHashes(org, repo): Promise<Map<string, string>>;
+  search(vector, filter, limit, threshold): Promise<VectorMatch[]>;
+}
+```
+
+To use pgvector, Pinecone, Weaviate, etc., write a class implementing `VectorStore` and
+construct it in `src/server.ts` instead of `QdrantVectorStore`. To use a different
+embedding provider, implement `Embedder`. Keep the embedding model and dimension
+**consistent between indexing and search** — that is the one invariant the protocol
+requires.
+
+## Choosing where the index lives
+
+- **Cloud (recommended for teams):** one shared backend + a managed vector store. The
+  first developer to index a repo pays the cost; everyone else gets `changed: []` on sync.
+  Code is embedded server-side and never leaves your infrastructure.
+- **Local per developer:** run a local Qdrant plus the backend process on each machine.
+  Simpler, fully private, but no shared index across the team.

--- a/packages/pi-codebase-index/openapi.yaml
+++ b/packages/pi-codebase-index/openapi.yaml
@@ -1,0 +1,175 @@
+openapi: 3.1.0
+info:
+  title: Codebase Index Protocol
+  version: 1.0.0
+  description: >
+    Vendor-neutral contract between the pi-codebase-index client and any backend
+    that powers semantic code search. The client speaks only these endpoints; the
+    vector store, embedding model and reranker are backend implementation details.
+  license:
+    name: MIT
+servers:
+  - url: https://your-backend.example.com/codebase-index
+    description: Backend base path (implementation-defined)
+security:
+  - bearerAuth: []
+paths:
+  /sync:
+    post:
+      summary: Diff repo Merkle roots, return files to (re)index
+      operationId: sync
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SyncRequest"
+      responses:
+        "200":
+          description: Files that changed since the last index
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SyncResponse"
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+  /index:
+    post:
+      summary: Embed and store chunks (backend embeds, client does not)
+      operationId: index
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/IndexRequest"
+      responses:
+        "200":
+          description: Number of chunks indexed
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [indexed]
+                properties:
+                  indexed: { type: integer }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+  /search:
+    post:
+      summary: Semantic (optionally hybrid + reranked) code search
+      operationId: search
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SearchRequest"
+      responses:
+        "200":
+          description: Ranked matches
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SearchResponse"
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  responses:
+    Unauthorized:
+      description: Missing or expired token
+    Forbidden:
+      description: User not allowed
+  schemas:
+    FileHash:
+      type: object
+      required: [path, hash]
+      properties:
+        path: { type: string }
+        hash: { type: string, description: content hash (sha256) }
+    RepoSync:
+      type: object
+      required: [name, rootHash]
+      properties:
+        name: { type: string }
+        rootHash: { type: string, description: Merkle root over all tracked files }
+        files:
+          type: array
+          items: { $ref: "#/components/schemas/FileHash" }
+    SyncRequest:
+      type: object
+      required: [repos]
+      properties:
+        repos:
+          type: array
+          items: { $ref: "#/components/schemas/RepoSync" }
+    RepoPath:
+      type: object
+      required: [repo, path]
+      properties:
+        repo: { type: string }
+        path: { type: string }
+    SyncResponse:
+      type: object
+      required: [changed]
+      properties:
+        changed:
+          type: array
+          items: { $ref: "#/components/schemas/RepoPath" }
+        removed:
+          type: array
+          items: { $ref: "#/components/schemas/RepoPath" }
+    Chunk:
+      type: object
+      required: [repo, path, symbol, lang, content]
+      properties:
+        repo: { type: string }
+        path: { type: string }
+        symbol: { type: string, description: symbol id, e.g. Class.method or file-level }
+        lang: { type: string }
+        gitSha: { type: string }
+        lineStart: { type: integer }
+        lineEnd: { type: integer }
+        content: { type: string, description: code, optionally context-enriched }
+    IndexRequest:
+      type: object
+      required: [chunks]
+      properties:
+        chunks:
+          type: array
+          items: { $ref: "#/components/schemas/Chunk" }
+        remove:
+          type: array
+          items: { $ref: "#/components/schemas/RepoPath" }
+    SearchRequest:
+      type: object
+      required: [query]
+      properties:
+        query: { type: string }
+        repo: { type: string }
+        lang: { type: string }
+        limit: { type: integer, default: 10 }
+    SearchResult:
+      type: object
+      required: [repo, path, symbol, snippet, score]
+      properties:
+        repo: { type: string }
+        path: { type: string }
+        symbol: { type: string }
+        lang: { type: string }
+        snippet: { type: string }
+        score: { type: number }
+        lineStart: { type: integer }
+        lineEnd: { type: integer }
+    SearchResponse:
+      type: object
+      required: [results]
+      properties:
+        results:
+          type: array
+          items: { $ref: "#/components/schemas/SearchResult" }

--- a/packages/pi-codebase-index/package.json
+++ b/packages/pi-codebase-index/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@arvoretech/pi-codebase-index",
+  "version": "0.1.0",
+  "description": "PI extension for semantic codebase search (vendor-neutral backend contract)",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "files": [
+    "dist",
+    "PROTOCOL.md",
+    "openapi.yaml"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "lint": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": ">=0.74.0"
+  },
+  "devDependencies": {
+    "@earendil-works/pi-coding-agent": "latest",
+    "@earendil-works/pi-ai": "latest",
+    "@earendil-works/pi-tui": "latest",
+    "@types/node": "^20.10.0",
+    "typescript": "^5.3.0"
+  },
+  "pi": {
+    "extensions": [
+      "./dist/index.js"
+    ]
+  },
+  "keywords": [
+    "pi-package",
+    "pi",
+    "extension",
+    "codebase",
+    "search",
+    "rag",
+    "embeddings"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/arvoreeducacao/arvore-pi-extensions.git",
+    "directory": "packages/pi-codebase-index"
+  },
+  "author": "Arvore",
+  "license": "MIT"
+}

--- a/packages/pi-codebase-index/package.json
+++ b/packages/pi-codebase-index/package.json
@@ -18,6 +18,22 @@
   "peerDependencies": {
     "@earendil-works/pi-coding-agent": ">=0.74.0"
   },
+  "dependencies": {
+    "web-tree-sitter": "0.25.6",
+    "tree-sitter-typescript": "^0.23.2",
+    "tree-sitter-javascript": "^0.25.0",
+    "tree-sitter-python": "^0.25.0",
+    "tree-sitter-go": "^0.25.0",
+    "tree-sitter-ruby": "^0.23.1",
+    "tree-sitter-rust": "^0.24.0",
+    "tree-sitter-java": "^0.23.5",
+    "tree-sitter-php": "^0.24.2",
+    "tree-sitter-c": "^0.24.1",
+    "tree-sitter-cpp": "^0.23.4",
+    "tree-sitter-c-sharp": "^0.23.1",
+    "tree-sitter-elixir": "^0.3.5",
+    "@tree-sitter-grammars/tree-sitter-kotlin": "^1.1.0"
+  },
   "devDependencies": {
     "@earendil-works/pi-coding-agent": "latest",
     "@earendil-works/pi-ai": "latest",

--- a/packages/pi-codebase-index/reference-backend/.env.example
+++ b/packages/pi-codebase-index/reference-backend/.env.example
@@ -1,0 +1,17 @@
+# OpenAI API key used by the default embedder adapter.
+OPENAI_API_KEY=sk-...
+
+# Embedding model + dimension. Must match between indexing and search.
+EMBEDDING_MODEL=text-embedding-3-large
+EMBEDDING_DIMENSIONS=1024
+
+# Secret used to sign/verify access tokens. Use a long random string.
+JWT_SECRET=change-me-to-a-long-random-string
+
+# Comma-separated org allowlist. Leave empty to allow any org in the token.
+ALLOWED_ORGS=
+
+# Dev auth: mints tokens without a real OAuth provider. Turn OFF in production
+# and plug a real provider into /auth/<provider>/start + /refresh.
+ENABLE_DEV_AUTH=true
+DEV_AUTH_ORG=local

--- a/packages/pi-codebase-index/reference-backend/README.md
+++ b/packages/pi-codebase-index/reference-backend/README.md
@@ -1,0 +1,51 @@
+# Codebase Index — reference backend
+
+A small, runnable backend implementing the [Codebase Index Protocol](../PROTOCOL.md). It
+exists so anyone can stand up the `pi-codebase-index` extension without writing a backend
+from scratch.
+
+It is intentionally minimal (~5 files of logic) and built around two interfaces so the
+storage and embedding choices are swappable:
+
+```
+src/
+  ports.ts                 VectorStore + Embedder interfaces (the seam)
+  adapters/
+    qdrant-store.ts        default VectorStore (Qdrant)
+    openai-embedder.ts     default Embedder (OpenAI)
+  service.ts               sync / index / search logic (vendor-agnostic)
+  auth.ts                  JWT bearer guard + org allowlist
+  dev-auth.ts              dev-only token minting (no real OAuth)
+  server.ts               wiring
+```
+
+## Run
+
+You need a reachable Qdrant instance (local binary, container, or managed cloud) and
+the backend process:
+
+```bash
+cp .env.example .env       # set OPENAI_API_KEY, JWT_SECRET, and QDRANT_URL
+npm install
+npm run build
+npm start
+```
+
+Backend: `http://localhost:8080`, contract under `/codebase-index`. Health: `/health`.
+The default Qdrant adapter expects `QDRANT_URL` (defaults to `http://localhost:6333`).
+
+## Swap the vector store
+
+Implement `VectorStore` from `src/ports.ts` (e.g. a `PgVectorStore`) and construct it in
+`src/server.ts` in place of `QdrantVectorStore`. No other file changes.
+
+## Swap the embedder
+
+Implement `Embedder` from `src/ports.ts` and construct it in `src/server.ts`. Keep
+`dimension` consistent with what was used to index.
+
+## Production auth
+
+Set `ENABLE_DEV_AUTH=false` and replace `dev-auth.ts` with routes that run your real
+OAuth provider, returning a JWT with `sub`, `username`, `orgs[]`, `iat`, `exp`. The data
+endpoints already enforce the `ALLOWED_ORGS` allowlist via `auth.ts`.

--- a/packages/pi-codebase-index/reference-backend/package.json
+++ b/packages/pi-codebase-index/reference-backend/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "codebase-index-reference-backend",
+  "version": "0.1.0",
+  "description": "Runnable reference backend implementing the Codebase Index Protocol",
+  "type": "module",
+  "private": true,
+  "main": "dist/server.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/server.js",
+    "dev": "tsc --watch"
+  },
+  "dependencies": {
+    "@qdrant/js-client-rest": "^1.11.0",
+    "express": "^4.19.2",
+    "jsonwebtoken": "^9.0.2",
+    "openai": "^4.56.0"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/jsonwebtoken": "^9.0.6",
+    "@types/node": "^20.10.0",
+    "typescript": "^5.3.0"
+  },
+  "license": "MIT"
+}

--- a/packages/pi-codebase-index/reference-backend/src/adapters/openai-embedder.ts
+++ b/packages/pi-codebase-index/reference-backend/src/adapters/openai-embedder.ts
@@ -1,0 +1,28 @@
+import OpenAI from "openai";
+import type { Embedder } from "../ports.js";
+
+export class OpenAIEmbedder implements Embedder {
+  readonly dimension: number;
+  private readonly client: OpenAI;
+  private readonly model: string;
+
+  constructor() {
+    const apiKey = process.env.OPENAI_API_KEY;
+    if (!apiKey) {
+      throw new Error("OPENAI_API_KEY is required for the OpenAI embedder.");
+    }
+    this.client = new OpenAI({ apiKey });
+    this.model = process.env.EMBEDDING_MODEL || "text-embedding-3-large";
+    this.dimension = Number(process.env.EMBEDDING_DIMENSIONS || 1024);
+  }
+
+  async embed(texts: string[]): Promise<number[][]> {
+    if (texts.length === 0) return [];
+    const response = await this.client.embeddings.create({
+      model: this.model,
+      input: texts,
+      dimensions: this.dimension,
+    });
+    return response.data.map((d) => d.embedding);
+  }
+}

--- a/packages/pi-codebase-index/reference-backend/src/adapters/qdrant-store.ts
+++ b/packages/pi-codebase-index/reference-backend/src/adapters/qdrant-store.ts
@@ -1,0 +1,117 @@
+import { createHash } from "node:crypto";
+import { QdrantClient } from "@qdrant/js-client-rest";
+import type {
+  SearchFilter,
+  StoredChunk,
+  VectorMatch,
+  VectorPoint,
+  VectorStore,
+} from "../ports.js";
+
+const COLLECTION = process.env.QDRANT_COLLECTION || "codebase_index";
+
+export class QdrantVectorStore implements VectorStore {
+  private readonly client: QdrantClient;
+
+  constructor() {
+    const url = process.env.QDRANT_URL || "http://localhost:6333";
+    const apiKey = process.env.QDRANT_API_KEY;
+    this.client = new QdrantClient({ url, apiKey });
+  }
+
+  async init(dimension: number): Promise<void> {
+    const { collections } = await this.client.getCollections();
+    if (collections.some((c) => c.name === COLLECTION)) {
+      return;
+    }
+    await this.client.createCollection(COLLECTION, {
+      vectors: { size: dimension, distance: "Cosine" },
+    });
+    for (const field of ["org", "repo", "path", "lang"]) {
+      await this.client.createPayloadIndex(COLLECTION, {
+        field_name: field,
+        field_schema: "keyword",
+      });
+    }
+  }
+
+  static pointId(org: string, repo: string, path: string, symbol: string): string {
+    const hash = createHash("md5").update(`${org}:${repo}:${path}:${symbol}`).digest("hex");
+    return `${hash.slice(0, 8)}-${hash.slice(8, 12)}-${hash.slice(12, 16)}-${hash.slice(16, 20)}-${hash.slice(20, 32)}`;
+  }
+
+  async upsert(points: VectorPoint[]): Promise<void> {
+    if (points.length === 0) return;
+    await this.client.upsert(COLLECTION, {
+      wait: true,
+      points: points.map((p) => ({
+        id: p.id,
+        vector: p.vector,
+        payload: p.payload as unknown as Record<string, unknown>,
+      })),
+    });
+  }
+
+  async deleteByPath(org: string, repo: string, path: string): Promise<void> {
+    await this.client.delete(COLLECTION, {
+      wait: true,
+      filter: {
+        must: [
+          { key: "org", match: { value: org } },
+          { key: "repo", match: { value: repo } },
+          { key: "path", match: { value: path } },
+        ],
+      },
+    });
+  }
+
+  async listFileHashes(org: string, repo: string): Promise<Map<string, string>> {
+    const byPath = new Map<string, string>();
+    let offset: string | number | undefined;
+    do {
+      const result = await this.client.scroll(COLLECTION, {
+        limit: 1000,
+        offset,
+        with_payload: ["path", "fileHash"],
+        filter: {
+          must: [
+            { key: "org", match: { value: org } },
+            { key: "repo", match: { value: repo } },
+          ],
+        },
+      });
+      for (const point of result.points) {
+        const payload = point.payload as { path?: string; fileHash?: string } | null;
+        if (payload?.path && payload.fileHash) {
+          byPath.set(payload.path, payload.fileHash);
+        }
+      }
+      offset = (result.next_page_offset as string | number | null) ?? undefined;
+    } while (offset !== undefined && offset !== null);
+    return byPath;
+  }
+
+  async search(
+    vector: number[],
+    filter: SearchFilter,
+    limit: number,
+    threshold: number
+  ): Promise<VectorMatch[]> {
+    const must: Record<string, unknown>[] = [{ key: "org", match: { value: filter.org } }];
+    if (filter.repo) must.push({ key: "repo", match: { value: filter.repo } });
+    if (filter.lang) must.push({ key: "lang", match: { value: filter.lang } });
+
+    const results = await this.client.search(COLLECTION, {
+      vector,
+      limit,
+      score_threshold: threshold,
+      filter: { must },
+      with_payload: true,
+    });
+
+    return results.map((r) => ({
+      score: r.score,
+      payload: r.payload as unknown as StoredChunk,
+    }));
+  }
+}

--- a/packages/pi-codebase-index/reference-backend/src/auth.ts
+++ b/packages/pi-codebase-index/reference-backend/src/auth.ts
@@ -1,0 +1,59 @@
+import jwt from "jsonwebtoken";
+import type { NextFunction, Request, Response } from "express";
+
+export interface AuthedUser {
+  id: string;
+  username: string;
+  org: string;
+}
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Express {
+    interface Request {
+      user?: AuthedUser;
+    }
+  }
+}
+
+const JWT_SECRET = process.env.JWT_SECRET || "";
+const ALLOWED_ORGS = (process.env.ALLOWED_ORGS || "").split(",").map((s) => s.trim()).filter(Boolean);
+
+export function requireAuth(req: Request, res: Response, next: NextFunction): void {
+  const header = req.headers.authorization;
+  if (!header?.startsWith("Bearer ")) {
+    res.status(401).json({ message: "Missing Authorization header" });
+    return;
+  }
+
+  if (!JWT_SECRET) {
+    res.status(500).json({ message: "JWT_SECRET not configured" });
+    return;
+  }
+
+  try {
+    const payload = jwt.verify(header.slice(7), JWT_SECRET) as {
+      sub?: string;
+      username?: string;
+      orgs?: string[];
+    };
+
+    const orgs = payload.orgs ?? [];
+    const allowedOrg =
+      ALLOWED_ORGS.length === 0 ? orgs[0] : orgs.find((o) => ALLOWED_ORGS.includes(o));
+
+    if (!allowedOrg) {
+      res.status(403).json({ message: "User not in an allowed organization" });
+      return;
+    }
+
+    req.user = {
+      id: payload.sub ?? "unknown",
+      username: payload.username ?? "unknown",
+      org: allowedOrg,
+    };
+    next();
+  } catch {
+    res.status(401).json({ message: "Invalid or expired token" });
+  }
+}

--- a/packages/pi-codebase-index/reference-backend/src/dev-auth.ts
+++ b/packages/pi-codebase-index/reference-backend/src/dev-auth.ts
@@ -1,0 +1,57 @@
+import jwt from "jsonwebtoken";
+import type { Express, Request, Response } from "express";
+
+const JWT_SECRET = process.env.JWT_SECRET || "";
+const TOKEN_TTL_SECONDS = 60 * 60 * 12;
+
+function mintTokens(username: string, org: string): {
+  access_token: string;
+  refresh_token: string;
+  expires_in: number;
+} {
+  const now = Math.floor(Date.now() / 1000);
+  const payload = {
+    sub: username,
+    username,
+    orgs: [org],
+    iat: now,
+    exp: now + TOKEN_TTL_SECONDS,
+  };
+  const access_token = jwt.sign(payload, JWT_SECRET);
+  return { access_token, refresh_token: access_token, expires_in: TOKEN_TTL_SECONDS };
+}
+
+export function registerDevAuth(app: Express): void {
+  app.get("/auth/:provider/start", (req: Request, res: Response) => {
+    const redirectUrl = String(req.query.redirect_url || "");
+    if (!redirectUrl) {
+      res.status(400).send("Missing redirect_url");
+      return;
+    }
+    const username = String(req.query.username || "dev-user");
+    const org = String(req.query.org || process.env.DEV_AUTH_ORG || "local");
+    const { access_token, refresh_token } = mintTokens(username, org);
+    const target = new URL(redirectUrl);
+    target.searchParams.set("token", access_token);
+    target.searchParams.set("refresh_token", refresh_token);
+    res.redirect(target.toString());
+  });
+
+  app.post("/auth/:provider/refresh", (req: Request, res: Response) => {
+    const refreshToken = req.body?.refresh_token as string | undefined;
+    if (!refreshToken) {
+      res.status(400).json({ message: "Missing refresh_token" });
+      return;
+    }
+    try {
+      const decoded = jwt.verify(refreshToken, JWT_SECRET, { ignoreExpiration: true }) as {
+        username?: string;
+        orgs?: string[];
+      };
+      const tokens = mintTokens(decoded.username ?? "dev-user", decoded.orgs?.[0] ?? "local");
+      res.json(tokens);
+    } catch {
+      res.status(401).json({ message: "Invalid refresh_token" });
+    }
+  });
+}

--- a/packages/pi-codebase-index/reference-backend/src/ports.ts
+++ b/packages/pi-codebase-index/reference-backend/src/ports.ts
@@ -1,0 +1,47 @@
+export interface Embedder {
+  dimension: number;
+  embed(texts: string[]): Promise<number[][]>;
+}
+
+export interface StoredChunk {
+  org: string;
+  repo: string;
+  path: string;
+  symbol: string;
+  lang: string;
+  gitSha: string | null;
+  lineStart: number | null;
+  lineEnd: number | null;
+  content: string;
+  fileHash: string | null;
+}
+
+export interface VectorPoint {
+  id: string;
+  vector: number[];
+  payload: StoredChunk;
+}
+
+export interface SearchFilter {
+  org: string;
+  repo?: string;
+  lang?: string;
+}
+
+export interface VectorMatch {
+  score: number;
+  payload: StoredChunk;
+}
+
+export interface VectorStore {
+  init(dimension: number): Promise<void>;
+  upsert(points: VectorPoint[]): Promise<void>;
+  deleteByPath(org: string, repo: string, path: string): Promise<void>;
+  listFileHashes(org: string, repo: string): Promise<Map<string, string>>;
+  search(
+    vector: number[],
+    filter: SearchFilter,
+    limit: number,
+    threshold: number
+  ): Promise<VectorMatch[]>;
+}

--- a/packages/pi-codebase-index/reference-backend/src/server.ts
+++ b/packages/pi-codebase-index/reference-backend/src/server.ts
@@ -1,0 +1,58 @@
+import express from "express";
+import { requireAuth } from "./auth.js";
+import { registerDevAuth } from "./dev-auth.js";
+import { OpenAIEmbedder } from "./adapters/openai-embedder.js";
+import { QdrantVectorStore } from "./adapters/qdrant-store.js";
+import { CodebaseService } from "./service.js";
+
+async function main(): Promise<void> {
+  const embedder = new OpenAIEmbedder();
+  const store = new QdrantVectorStore();
+  const service = new CodebaseService(store, embedder);
+  await service.init();
+
+  const app = express();
+  app.use(express.json({ limit: "32mb" }));
+
+  app.get("/health", (_req, res) => {
+    res.json({ ok: true });
+  });
+
+  if (process.env.ENABLE_DEV_AUTH === "true") {
+    registerDevAuth(app);
+  }
+
+  const api = express.Router();
+  api.use(requireAuth);
+
+  api.post("/sync", async (req, res) => {
+    const result = await service.sync(req.user!, req.body.repos ?? []);
+    res.json(result);
+  });
+
+  api.post("/index", async (req, res) => {
+    const result = await service.index(req.user!, req.body.chunks ?? [], req.body.remove);
+    res.json(result);
+  });
+
+  api.post("/search", async (req, res) => {
+    const result = await service.search(req.user!, req.body.query, {
+      repo: req.body.repo,
+      lang: req.body.lang,
+      limit: req.body.limit,
+    });
+    res.json(result);
+  });
+
+  app.use("/codebase-index", api);
+
+  const port = Number(process.env.PORT || 8080);
+  app.listen(port, () => {
+    console.log(`codebase-index reference backend listening on :${port}`);
+  });
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/pi-codebase-index/reference-backend/src/service.ts
+++ b/packages/pi-codebase-index/reference-backend/src/service.ts
@@ -1,0 +1,150 @@
+import type { AuthedUser } from "./auth.js";
+import type { Embedder, StoredChunk, VectorPoint, VectorStore } from "./ports.js";
+import { QdrantVectorStore } from "./adapters/qdrant-store.js";
+
+export interface RepoSyncInput {
+  name: string;
+  rootHash: string;
+  files?: { path: string; hash: string }[];
+}
+
+export interface ChunkInput {
+  repo: string;
+  path: string;
+  symbol: string;
+  lang: string;
+  gitSha?: string;
+  lineStart?: number;
+  lineEnd?: number;
+  content: string;
+  fileHash?: string;
+}
+
+export interface RepoPath {
+  repo: string;
+  path: string;
+}
+
+const SEARCH_THRESHOLD = 0.3;
+const CANDIDATE_MULTIPLIER = 4;
+const GAP_CUTOFF_RATIO = 0.7;
+const SNIPPET_MAX_LINES = 15;
+
+export class CodebaseService {
+  constructor(
+    private readonly store: VectorStore,
+    private readonly embedder: Embedder
+  ) {}
+
+  async init(): Promise<void> {
+    await this.store.init(this.embedder.dimension);
+  }
+
+  async sync(user: AuthedUser, repos: RepoSyncInput[]): Promise<{ changed: RepoPath[]; removed: RepoPath[] }> {
+    const changed: RepoPath[] = [];
+    const removed: RepoPath[] = [];
+
+    for (const repo of repos) {
+      const indexed = await this.store.listFileHashes(user.org, repo.name);
+      if (!repo.files?.length) continue;
+
+      const incoming = new Map(repo.files.map((f) => [f.path, f.hash]));
+      for (const [path, hash] of incoming) {
+        if (indexed.get(path) !== hash) {
+          changed.push({ repo: repo.name, path });
+        }
+      }
+      for (const path of indexed.keys()) {
+        if (!incoming.has(path)) {
+          await this.store.deleteByPath(user.org, repo.name, path);
+          removed.push({ repo: repo.name, path });
+        }
+      }
+    }
+
+    return { changed, removed };
+  }
+
+  async index(user: AuthedUser, chunks: ChunkInput[], remove?: RepoPath[]): Promise<{ indexed: number }> {
+    if (remove?.length) {
+      for (const item of remove) {
+        await this.store.deleteByPath(user.org, item.repo, item.path);
+      }
+    }
+    if (chunks.length === 0) return { indexed: 0 };
+
+    const touched = new Set(chunks.map((c) => `${c.repo}\u0000${c.path}`));
+    for (const key of touched) {
+      const [repo, path] = key.split("\u0000");
+      await this.store.deleteByPath(user.org, repo, path);
+    }
+
+    const vectors = await this.embedder.embed(chunks.map((c) => this.embeddingInput(c)));
+    const points: VectorPoint[] = chunks.map((chunk, i) => {
+      const payload: StoredChunk = {
+        org: user.org,
+        repo: chunk.repo,
+        path: chunk.path,
+        symbol: chunk.symbol,
+        lang: chunk.lang,
+        gitSha: chunk.gitSha ?? null,
+        lineStart: chunk.lineStart ?? null,
+        lineEnd: chunk.lineEnd ?? null,
+        content: chunk.content,
+        fileHash: chunk.fileHash ?? null,
+      };
+      return {
+        id: QdrantVectorStore.pointId(user.org, chunk.repo, chunk.path, chunk.symbol),
+        vector: vectors[i],
+        payload,
+      };
+    });
+
+    await this.store.upsert(points);
+    return { indexed: points.length };
+  }
+
+  async search(
+    user: AuthedUser,
+    query: string,
+    options: { repo?: string; lang?: string; limit?: number }
+  ) {
+    const limit = options.limit ?? 10;
+    const [vector] = await this.embedder.embed([query]);
+    const matches = await this.store.search(
+      vector,
+      { org: user.org, repo: options.repo, lang: options.lang },
+      limit * CANDIDATE_MULTIPLIER,
+      SEARCH_THRESHOLD
+    );
+
+    if (matches.length === 0) return { results: [] };
+
+    const sorted = [...matches].sort((a, b) => b.score - a.score);
+    const cutoff = sorted[0].score * GAP_CUTOFF_RATIO;
+    const kept = sorted.filter((m) => m.score >= cutoff).slice(0, limit);
+
+    return {
+      results: kept.map((m) => ({
+        repo: m.payload.repo,
+        path: m.payload.path,
+        symbol: m.payload.symbol,
+        lang: m.payload.lang,
+        snippet: this.snippet(m.payload.content),
+        score: m.score,
+        lineStart: m.payload.lineStart,
+        lineEnd: m.payload.lineEnd,
+      })),
+    };
+  }
+
+  private embeddingInput(chunk: ChunkInput): string {
+    return `[repo:${chunk.repo}] [file:${chunk.path}] [symbol:${chunk.symbol}] [lang:${chunk.lang}]\n${chunk.content}`;
+  }
+
+  private snippet(content: string): string {
+    const lines = content.split("\n");
+    if (lines.length <= SNIPPET_MAX_LINES) return content;
+    return `${lines.slice(0, SNIPPET_MAX_LINES).join("\n")}\n…`;
+  }
+}

--- a/packages/pi-codebase-index/reference-backend/tsconfig.json
+++ b/packages/pi-codebase-index/reference-backend/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "lib": ["ES2022"],
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/packages/pi-codebase-index/src/api.ts
+++ b/packages/pi-codebase-index/src/api.ts
@@ -1,0 +1,76 @@
+import { getCredentials } from "./auth.js";
+import { getConfig } from "./config.js";
+
+export interface RepoSync {
+  name: string;
+  rootHash: string;
+  files?: { path: string; hash: string }[];
+}
+
+export interface RepoPath {
+  repo: string;
+  path: string;
+}
+
+export interface Chunk {
+  repo: string;
+  path: string;
+  symbol: string;
+  lang: string;
+  gitSha?: string;
+  lineStart?: number;
+  lineEnd?: number;
+  content: string;
+  fileHash?: string;
+}
+
+export interface SearchResult {
+  repo: string;
+  path: string;
+  symbol: string;
+  lang: string;
+  snippet: string;
+  score: number;
+  lineStart: number | null;
+  lineEnd: number | null;
+}
+
+async function request<T>(path: string, method: string, body?: unknown): Promise<T> {
+  const creds = await getCredentials();
+  if (!creds) throw new Error("Not authenticated. Run /codebase-login first.");
+
+  const config = getConfig();
+  const response = await fetch(`${config.apiUrl}/codebase-index${path}`, {
+    method,
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${creds.token}`,
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+
+  if (!response.ok) {
+    throw new Error(`${method} ${path} failed: ${response.status} ${await response.text()}`);
+  }
+
+  return response.json() as Promise<T>;
+}
+
+export function sync(repos: RepoSync[]): Promise<{ changed: RepoPath[]; removed: RepoPath[] }> {
+  return request("/sync", "POST", { repos });
+}
+
+export function index(chunks: Chunk[], remove?: RepoPath[]): Promise<{ indexed: number }> {
+  return request("/index", "POST", { chunks, remove });
+}
+
+export async function search(
+  query: string,
+  options: { repo?: string; lang?: string; limit?: number } = {}
+): Promise<SearchResult[]> {
+  const data = await request<{ results: SearchResult[] }>("/search", "POST", {
+    query,
+    ...options,
+  });
+  return data.results;
+}

--- a/packages/pi-codebase-index/src/ast.ts
+++ b/packages/pi-codebase-index/src/ast.ts
@@ -1,0 +1,377 @@
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+
+export interface DefNode {
+  symbol: string;
+  lineStart: number;
+  lineEnd: number;
+  kind: string;
+}
+
+interface LangSpec {
+  pkg: string;
+  wasm: string;
+  defTypes: Set<string>;
+  containerTypes: Set<string>;
+}
+
+const LANG_SPECS: Record<string, LangSpec> = {
+  typescript: {
+    pkg: "tree-sitter-typescript",
+    wasm: "tree-sitter-typescript",
+    defTypes: new Set([
+      "function_declaration",
+      "class_declaration",
+      "method_definition",
+      "interface_declaration",
+      "type_alias_declaration",
+      "enum_declaration",
+      "abstract_class_declaration",
+    ]),
+    containerTypes: new Set(["class_body", "class_declaration", "abstract_class_declaration"]),
+  },
+  tsx: {
+    pkg: "tree-sitter-typescript",
+    wasm: "tree-sitter-tsx",
+    defTypes: new Set([
+      "function_declaration",
+      "class_declaration",
+      "method_definition",
+      "interface_declaration",
+      "type_alias_declaration",
+      "enum_declaration",
+      "abstract_class_declaration",
+    ]),
+    containerTypes: new Set(["class_body", "class_declaration", "abstract_class_declaration"]),
+  },
+  javascript: {
+    pkg: "tree-sitter-javascript",
+    wasm: "tree-sitter-javascript",
+    defTypes: new Set(["function_declaration", "class_declaration", "method_definition"]),
+    containerTypes: new Set(["class_body", "class_declaration"]),
+  },
+  python: {
+    pkg: "tree-sitter-python",
+    wasm: "tree-sitter-python",
+    defTypes: new Set(["function_definition", "class_definition"]),
+    containerTypes: new Set(["class_definition", "block"]),
+  },
+  go: {
+    pkg: "tree-sitter-go",
+    wasm: "tree-sitter-go",
+    defTypes: new Set(["function_declaration", "method_declaration", "type_declaration"]),
+    containerTypes: new Set(),
+  },
+  ruby: {
+    pkg: "tree-sitter-ruby",
+    wasm: "tree-sitter-ruby",
+    defTypes: new Set(["method", "class", "module", "singleton_method"]),
+    containerTypes: new Set(["class", "module", "body_statement"]),
+  },
+  rust: {
+    pkg: "tree-sitter-rust",
+    wasm: "tree-sitter-rust",
+    defTypes: new Set([
+      "function_item",
+      "struct_item",
+      "impl_item",
+      "enum_item",
+      "trait_item",
+      "mod_item",
+    ]),
+    containerTypes: new Set(["impl_item", "mod_item", "declaration_list"]),
+  },
+  java: {
+    pkg: "tree-sitter-java",
+    wasm: "tree-sitter-java",
+    defTypes: new Set([
+      "class_declaration",
+      "method_declaration",
+      "interface_declaration",
+      "constructor_declaration",
+      "enum_declaration",
+    ]),
+    containerTypes: new Set(["class_declaration", "class_body", "interface_body"]),
+  },
+  kotlin: {
+    pkg: "@tree-sitter-grammars/tree-sitter-kotlin",
+    wasm: "tree-sitter-kotlin",
+    defTypes: new Set(["function_declaration", "class_declaration", "object_declaration"]),
+    containerTypes: new Set(["class_declaration", "class_body", "object_declaration"]),
+  },
+  php: {
+    pkg: "tree-sitter-php",
+    wasm: "tree-sitter-php",
+    defTypes: new Set([
+      "function_definition",
+      "class_declaration",
+      "method_declaration",
+      "interface_declaration",
+      "trait_declaration",
+    ]),
+    containerTypes: new Set(["class_declaration", "declaration_list"]),
+  },
+  c: {
+    pkg: "tree-sitter-c",
+    wasm: "tree-sitter-c",
+    defTypes: new Set(["function_definition", "struct_specifier"]),
+    containerTypes: new Set(),
+  },
+  cpp: {
+    pkg: "tree-sitter-cpp",
+    wasm: "tree-sitter-cpp",
+    defTypes: new Set(["function_definition", "class_specifier", "struct_specifier"]),
+    containerTypes: new Set(["class_specifier", "field_declaration_list"]),
+  },
+  csharp: {
+    pkg: "tree-sitter-c-sharp",
+    wasm: "tree-sitter-c_sharp",
+    defTypes: new Set([
+      "class_declaration",
+      "method_declaration",
+      "struct_declaration",
+      "interface_declaration",
+      "namespace_declaration",
+    ]),
+    containerTypes: new Set(["class_declaration", "declaration_list", "namespace_declaration"]),
+  },
+  elixir: {
+    pkg: "tree-sitter-elixir",
+    wasm: "tree-sitter-elixir",
+    defTypes: new Set(["call"]),
+    containerTypes: new Set(["do_block", "call"]),
+  },
+};
+
+const ELIXIR_DEF_KEYWORDS = new Set([
+  "def",
+  "defp",
+  "defmodule",
+  "defmacro",
+  "defmacrop",
+  "defguard",
+  "defprotocol",
+  "defimpl",
+]);
+
+const LANG_BY_EXT: Record<string, string> = {
+  ".ts": "typescript",
+  ".mts": "typescript",
+  ".cts": "typescript",
+  ".tsx": "tsx",
+  ".js": "javascript",
+  ".jsx": "javascript",
+  ".mjs": "javascript",
+  ".cjs": "javascript",
+  ".py": "python",
+  ".go": "go",
+  ".rb": "ruby",
+  ".rs": "rust",
+  ".java": "java",
+  ".kt": "kotlin",
+  ".kts": "kotlin",
+  ".php": "php",
+  ".c": "c",
+  ".h": "c",
+  ".cc": "cpp",
+  ".cpp": "cpp",
+  ".hpp": "cpp",
+  ".cxx": "cpp",
+  ".cs": "csharp",
+  ".ex": "elixir",
+  ".exs": "elixir",
+};
+
+export function astLangOf(path: string): string | null {
+  const dot = path.lastIndexOf(".");
+  const ext = dot === -1 ? "" : path.slice(dot).toLowerCase();
+  return LANG_BY_EXT[ext] ?? null;
+}
+
+type TreeSitterModule = typeof import("web-tree-sitter");
+
+let parserModule: TreeSitterModule | null = null;
+let initPromise: Promise<TreeSitterModule> | null = null;
+const languageCache = new Map<string, unknown>();
+const failedLanguages = new Set<string>();
+
+function wasmPathFor(spec: LangSpec): string {
+  const entry = require.resolve(`${spec.pkg}/package.json`);
+  const base = entry.slice(0, entry.lastIndexOf("/"));
+  return `${base}/${spec.wasm}.wasm`;
+}
+
+async function getModule(): Promise<TreeSitterModule> {
+  if (parserModule) {
+    return parserModule;
+  }
+  if (!initPromise) {
+    initPromise = (async () => {
+      const mod = await import("web-tree-sitter");
+      await mod.Parser.init();
+      parserModule = mod;
+      return mod;
+    })();
+  }
+  return initPromise;
+}
+
+async function loadLanguage(lang: string): Promise<unknown | null> {
+  if (languageCache.has(lang)) {
+    return languageCache.get(lang) ?? null;
+  }
+  if (failedLanguages.has(lang)) {
+    return null;
+  }
+  const spec = LANG_SPECS[lang];
+  if (!spec) {
+    failedLanguages.add(lang);
+    return null;
+  }
+  try {
+    const mod = await getModule();
+    const wasmPath = wasmPathFor(spec);
+    const language = await mod.Language.load(wasmPath);
+    languageCache.set(lang, language);
+    return language;
+  } catch {
+    failedLanguages.add(lang);
+    return null;
+  }
+}
+
+interface TsNode {
+  type: string;
+  isNamed: boolean;
+  childCount: number;
+  startPosition: { row: number };
+  endPosition: { row: number };
+  text: string;
+  child(index: number): TsNode | null;
+  childForFieldName(name: string): TsNode | null;
+}
+
+function firstIdentifier(node: TsNode): string | null {
+  if (/identifier|name|alias/i.test(node.type) && node.childCount === 0) {
+    return node.text;
+  }
+  if (node.type === "alias") {
+    return node.text;
+  }
+  for (let i = 0; i < node.childCount; i += 1) {
+    const child = node.child(i);
+    if (!child) {
+      continue;
+    }
+    const found = firstIdentifier(child);
+    if (found) {
+      return found;
+    }
+  }
+  return null;
+}
+
+function nameOf(node: TsNode, lang: string): string | null {
+  if (lang === "elixir") {
+    return elixirName(node);
+  }
+  const named = node.childForFieldName("name");
+  if (named?.text) {
+    return named.text;
+  }
+  const declarator = node.childForFieldName("declarator");
+  if (declarator) {
+    const id = firstIdentifier(declarator);
+    if (id) {
+      return id;
+    }
+  }
+  return firstIdentifier(node);
+}
+
+function elixirKeyword(node: TsNode): string | null {
+  const target = node.childForFieldName("target") ?? node.child(0);
+  if (target && ELIXIR_DEF_KEYWORDS.has(target.text)) {
+    return target.text;
+  }
+  return null;
+}
+
+function elixirName(node: TsNode): string | null {
+  for (let i = 0; i < node.childCount; i += 1) {
+    const child = node.child(i);
+    if (!child) {
+      continue;
+    }
+    if (child.type === "arguments") {
+      const id = firstIdentifier(child);
+      if (id) {
+        return id;
+      }
+    }
+  }
+  return null;
+}
+
+export async function extractDefs(lang: string, source: string): Promise<DefNode[] | null> {
+  const language = await loadLanguage(lang);
+  if (!language) {
+    return null;
+  }
+  const spec = LANG_SPECS[lang];
+  const mod = parserModule;
+  if (!mod || !spec) {
+    return null;
+  }
+
+  let tree: { rootNode: TsNode; delete?: () => void };
+  try {
+    const parser = new mod.Parser();
+    // biome-ignore lint/suspicious/noExplicitAny: web-tree-sitter Language type is opaque here
+    parser.setLanguage(language as any);
+    tree = parser.parse(source) as unknown as { rootNode: TsNode; delete?: () => void };
+  } catch {
+    return null;
+  }
+
+  const defs: DefNode[] = [];
+
+  const visit = (node: TsNode, depth: number): void => {
+    for (let i = 0; i < node.childCount; i += 1) {
+      const child = node.child(i);
+      if (!child || !child.isNamed) {
+        continue;
+      }
+      const isDef = isDefinition(child, spec, lang);
+      if (isDef) {
+        const name = nameOf(child, lang);
+        defs.push({
+          symbol: name ?? `${child.type}@${child.startPosition.row + 1}`,
+          lineStart: child.startPosition.row + 1,
+          lineEnd: child.endPosition.row + 1,
+          kind: child.type,
+        });
+        if (spec.containerTypes.size > 0 && depth < 3) {
+          visit(child, depth + 1);
+        }
+        continue;
+      }
+      if (depth < 4) {
+        visit(child, depth + 1);
+      }
+    }
+  };
+
+  visit(tree.rootNode, 0);
+  tree.delete?.();
+
+  return defs;
+}
+
+function isDefinition(node: TsNode, spec: LangSpec, lang: string): boolean {
+  if (lang === "elixir") {
+    return node.type === "call" && elixirKeyword(node) !== null;
+  }
+  return spec.defTypes.has(node.type);
+}

--- a/packages/pi-codebase-index/src/auth.ts
+++ b/packages/pi-codebase-index/src/auth.ts
@@ -1,0 +1,94 @@
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { join, dirname } from "node:path";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { getConfig } from "./config.js";
+
+export interface CodebaseCredentials {
+  token: string;
+  refreshToken?: string;
+  username: string;
+  expiresAt: number;
+}
+
+const CONFIG_DIR = join(homedir(), ".config", "pi");
+const CREDENTIALS_FILE = join(CONFIG_DIR, "codebase-credentials.json");
+const EXPIRY_SKEW_MS = 60_000;
+
+async function readCredentials(): Promise<CodebaseCredentials | null> {
+  if (!existsSync(CREDENTIALS_FILE)) return null;
+
+  try {
+    const raw = await readFile(CREDENTIALS_FILE, "utf-8");
+    const creds = JSON.parse(raw) as CodebaseCredentials;
+    if (!creds.token) return null;
+    return creds;
+  } catch {
+    return null;
+  }
+}
+
+export async function getCredentials(): Promise<CodebaseCredentials | null> {
+  const creds = await readCredentials();
+  if (!creds) return null;
+
+  if (Date.now() < creds.expiresAt - EXPIRY_SKEW_MS) {
+    return creds;
+  }
+
+  if (creds.refreshToken) {
+    const refreshed = await tryRefresh(creds.refreshToken);
+    if (refreshed) return refreshed;
+  }
+
+  return null;
+}
+
+async function tryRefresh(refreshToken: string): Promise<CodebaseCredentials | null> {
+  try {
+    const config = getConfig();
+    const response = await fetch(
+      `${config.apiUrl}/auth/${config.authProvider}/refresh`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ refresh_token: refreshToken }),
+      }
+    );
+
+    if (!response.ok) return null;
+
+    const data = (await response.json()) as {
+      access_token: string;
+      refresh_token: string;
+      expires_in: number;
+    };
+
+    const payload = JSON.parse(
+      Buffer.from(data.access_token.split(".")[1], "base64url").toString()
+    );
+
+    const creds: CodebaseCredentials = {
+      token: data.access_token,
+      refreshToken: data.refresh_token,
+      username: payload.username,
+      expiresAt: Date.now() + data.expires_in * 1000,
+    };
+
+    await saveCredentials(creds);
+    return creds;
+  } catch {
+    return null;
+  }
+}
+
+export async function saveCredentials(creds: CodebaseCredentials): Promise<void> {
+  await mkdir(dirname(CREDENTIALS_FILE), { recursive: true });
+  await writeFile(CREDENTIALS_FILE, JSON.stringify(creds, null, 2));
+}
+
+export async function clearCredentials(): Promise<void> {
+  if (existsSync(CREDENTIALS_FILE)) {
+    await writeFile(CREDENTIALS_FILE, "{}");
+  }
+}

--- a/packages/pi-codebase-index/src/chunker.ts
+++ b/packages/pi-codebase-index/src/chunker.ts
@@ -1,25 +1,39 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { Chunk } from "./api.js";
+import { astLangOf, extractDefs } from "./ast.js";
+import type { DefNode } from "./ast.js";
 
 const MAX_LINES_PER_CHUNK = 200;
 const OVERLAP_LINES = 20;
+const MIN_PREAMBLE_LINES = 3;
 
 const LANG_BY_EXT: Record<string, string> = {
-  ".ts": "typescript", ".tsx": "typescript",
-  ".js": "javascript", ".jsx": "javascript", ".mjs": "javascript", ".cjs": "javascript",
-  ".ex": "elixir", ".exs": "elixir",
+  ".ts": "typescript",
+  ".tsx": "typescript",
+  ".js": "javascript",
+  ".jsx": "javascript",
+  ".mjs": "javascript",
+  ".cjs": "javascript",
+  ".ex": "elixir",
+  ".exs": "elixir",
   ".py": "python",
   ".rb": "ruby",
   ".go": "go",
   ".rs": "rust",
-  ".java": "java", ".kt": "kotlin",
+  ".java": "java",
+  ".kt": "kotlin",
   ".php": "php",
-  ".c": "c", ".h": "c", ".cc": "cpp", ".cpp": "cpp", ".hpp": "cpp",
+  ".c": "c",
+  ".h": "c",
+  ".cc": "cpp",
+  ".cpp": "cpp",
+  ".hpp": "cpp",
   ".cs": "csharp",
   ".swift": "swift",
   ".sql": "sql",
-  ".graphql": "graphql", ".gql": "graphql",
+  ".graphql": "graphql",
+  ".gql": "graphql",
 };
 
 function langOf(path: string): string {
@@ -28,22 +42,13 @@ function langOf(path: string): string {
   return LANG_BY_EXT[ext] ?? "text";
 }
 
-export async function chunkFile(
+function windowChunks(
   repo: string,
-  repoDir: string,
   relPath: string,
+  lang: string,
+  lines: string[],
   fileHash: string
-): Promise<Chunk[]> {
-  let content: string;
-  try {
-    content = await readFile(join(repoDir, relPath), "utf-8");
-  } catch {
-    return [];
-  }
-
-  const lang = langOf(relPath);
-  const lines = content.split("\n");
-
+): Chunk[] {
   if (lines.length <= MAX_LINES_PER_CHUNK) {
     return [
       {
@@ -53,7 +58,7 @@ export async function chunkFile(
         lang,
         lineStart: 1,
         lineEnd: lines.length,
-        content,
+        content: lines.join("\n"),
         fileHash,
       },
     ];
@@ -74,8 +79,178 @@ export async function chunkFile(
       content: lines.slice(start, end).join("\n"),
       fileHash,
     });
-    if (end === lines.length) break;
+    if (end === lines.length) {
+      break;
+    }
   }
 
   return chunks;
+}
+
+function splitDef(
+  repo: string,
+  relPath: string,
+  lang: string,
+  lines: string[],
+  fileHash: string,
+  def: DefNode
+): Chunk[] {
+  const total = def.lineEnd - def.lineStart + 1;
+  if (total <= MAX_LINES_PER_CHUNK) {
+    return [
+      {
+        repo,
+        path: relPath,
+        symbol: def.symbol,
+        lang,
+        lineStart: def.lineStart,
+        lineEnd: def.lineEnd,
+        content: lines.slice(def.lineStart - 1, def.lineEnd).join("\n"),
+        fileHash,
+      },
+    ];
+  }
+
+  const chunks: Chunk[] = [];
+  const step = MAX_LINES_PER_CHUNK - OVERLAP_LINES;
+  let part = 1;
+
+  for (let start = def.lineStart - 1; start < def.lineEnd; start += step) {
+    const end = Math.min(start + MAX_LINES_PER_CHUNK, def.lineEnd);
+    chunks.push({
+      repo,
+      path: relPath,
+      symbol: `${def.symbol}#part${part}`,
+      lang,
+      lineStart: start + 1,
+      lineEnd: end,
+      content: lines.slice(start, end).join("\n"),
+      fileHash,
+    });
+    part += 1;
+    if (end === def.lineEnd) {
+      break;
+    }
+  }
+
+  return chunks;
+}
+
+function selectDefs(defs: DefNode[]): DefNode[] {
+  const sorted = [...defs].sort((a, b) =>
+    a.lineStart === b.lineStart ? b.lineEnd - a.lineEnd : a.lineStart - b.lineStart
+  );
+
+  const contains = (outer: DefNode, inner: DefNode): boolean =>
+    outer !== inner &&
+    outer.lineStart <= inner.lineStart &&
+    outer.lineEnd >= inner.lineEnd &&
+    outer.lineEnd - outer.lineStart > inner.lineEnd - inner.lineStart;
+
+  const kept: DefNode[] = [];
+
+  for (const def of sorted) {
+    const children = sorted.filter((other) => contains(def, other));
+    const size = def.lineEnd - def.lineStart + 1;
+    const isExpandableContainer =
+      children.length > 1 || (children.length > 0 && size > MAX_LINES_PER_CHUNK);
+    if (isExpandableContainer) {
+      continue;
+    }
+    kept.push(def);
+  }
+
+  const result: DefNode[] = [];
+  let lastEnd = 0;
+  for (const def of kept) {
+    if (def.lineStart <= lastEnd) {
+      continue;
+    }
+    result.push(def);
+    lastEnd = def.lineEnd;
+  }
+  return result;
+}
+
+async function astChunks(
+  repo: string,
+  relPath: string,
+  astLang: string,
+  outputLang: string,
+  lines: string[],
+  fileHash: string
+): Promise<Chunk[] | null> {
+  const source = lines.join("\n");
+  const defs = await extractDefs(astLang, source);
+  if (!defs || defs.length === 0) {
+    return null;
+  }
+
+  const topLevel = selectDefs(defs);
+  if (topLevel.length === 0) {
+    return null;
+  }
+
+  const symbolCounts = new Map<string, number>();
+  for (const def of topLevel) {
+    symbolCounts.set(def.symbol, (symbolCounts.get(def.symbol) ?? 0) + 1);
+  }
+  for (const def of topLevel) {
+    if ((symbolCounts.get(def.symbol) ?? 0) > 1) {
+      def.symbol = `${def.symbol}@L${def.lineStart}`;
+    }
+  }
+
+  const chunks: Chunk[] = [];
+
+  const firstStart = topLevel[0].lineStart;
+  if (firstStart - 1 >= MIN_PREAMBLE_LINES) {
+    chunks.push({
+      repo,
+      path: relPath,
+      symbol: `${relPath}#preamble`,
+      lang: outputLang,
+      lineStart: 1,
+      lineEnd: firstStart - 1,
+      content: lines.slice(0, firstStart - 1).join("\n"),
+      fileHash,
+    });
+  }
+
+  for (const def of topLevel) {
+    chunks.push(...splitDef(repo, relPath, outputLang, lines, fileHash, def));
+  }
+
+  return chunks;
+}
+
+export async function chunkFile(
+  repo: string,
+  repoDir: string,
+  relPath: string,
+  fileHash: string
+): Promise<Chunk[]> {
+  let content: string;
+  try {
+    content = await readFile(join(repoDir, relPath), "utf-8");
+  } catch {
+    return [];
+  }
+
+  const lang = langOf(relPath);
+  const lines = content.split("\n");
+  const astLang = astLangOf(relPath);
+
+  if (astLang) {
+    try {
+      const ast = await astChunks(repo, relPath, astLang, lang, lines, fileHash);
+      if (ast && ast.length > 0) {
+        return ast;
+      }
+    } catch {
+      // falls through to window chunking
+    }
+  }
+
+  return windowChunks(repo, relPath, lang, lines, fileHash);
 }

--- a/packages/pi-codebase-index/src/chunker.ts
+++ b/packages/pi-codebase-index/src/chunker.ts
@@ -1,0 +1,81 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { Chunk } from "./api.js";
+
+const MAX_LINES_PER_CHUNK = 200;
+const OVERLAP_LINES = 20;
+
+const LANG_BY_EXT: Record<string, string> = {
+  ".ts": "typescript", ".tsx": "typescript",
+  ".js": "javascript", ".jsx": "javascript", ".mjs": "javascript", ".cjs": "javascript",
+  ".ex": "elixir", ".exs": "elixir",
+  ".py": "python",
+  ".rb": "ruby",
+  ".go": "go",
+  ".rs": "rust",
+  ".java": "java", ".kt": "kotlin",
+  ".php": "php",
+  ".c": "c", ".h": "c", ".cc": "cpp", ".cpp": "cpp", ".hpp": "cpp",
+  ".cs": "csharp",
+  ".swift": "swift",
+  ".sql": "sql",
+  ".graphql": "graphql", ".gql": "graphql",
+};
+
+function langOf(path: string): string {
+  const dot = path.lastIndexOf(".");
+  const ext = dot === -1 ? "" : path.slice(dot).toLowerCase();
+  return LANG_BY_EXT[ext] ?? "text";
+}
+
+export async function chunkFile(
+  repo: string,
+  repoDir: string,
+  relPath: string,
+  fileHash: string
+): Promise<Chunk[]> {
+  let content: string;
+  try {
+    content = await readFile(join(repoDir, relPath), "utf-8");
+  } catch {
+    return [];
+  }
+
+  const lang = langOf(relPath);
+  const lines = content.split("\n");
+
+  if (lines.length <= MAX_LINES_PER_CHUNK) {
+    return [
+      {
+        repo,
+        path: relPath,
+        symbol: relPath,
+        lang,
+        lineStart: 1,
+        lineEnd: lines.length,
+        content,
+        fileHash,
+      },
+    ];
+  }
+
+  const chunks: Chunk[] = [];
+  const step = MAX_LINES_PER_CHUNK - OVERLAP_LINES;
+
+  for (let start = 0; start < lines.length; start += step) {
+    const end = Math.min(start + MAX_LINES_PER_CHUNK, lines.length);
+    chunks.push({
+      repo,
+      path: relPath,
+      symbol: `${relPath}#L${start + 1}-${end}`,
+      lang,
+      lineStart: start + 1,
+      lineEnd: end,
+      content: lines.slice(start, end).join("\n"),
+      fileHash,
+    });
+    if (end === lines.length) break;
+  }
+
+  return chunks;
+}

--- a/packages/pi-codebase-index/src/chunker.ts
+++ b/packages/pi-codebase-index/src/chunker.ts
@@ -1,5 +1,5 @@
-import { readFile } from "node:fs/promises";
-import { join } from "node:path";
+import { lstat, readFile, realpath } from "node:fs/promises";
+import { isAbsolute, relative, resolve } from "node:path";
 import type { Chunk } from "./api.js";
 import { astLangOf, extractDefs } from "./ast.js";
 import type { DefNode } from "./ast.js";
@@ -203,22 +203,36 @@ async function astChunks(
 
   const chunks: Chunk[] = [];
 
-  const firstStart = topLevel[0].lineStart;
-  if (firstStart - 1 >= MIN_PREAMBLE_LINES) {
+  const emitGap = (start: number, end: number): void => {
+    if (end - start + 1 < MIN_PREAMBLE_LINES) {
+      return;
+    }
+    const slice = lines.slice(start - 1, end);
+    if (slice.every((line) => line.trim() === "")) {
+      return;
+    }
     chunks.push({
       repo,
       path: relPath,
-      symbol: `${relPath}#preamble`,
+      symbol: `${relPath}#L${start}-${end}`,
       lang: outputLang,
-      lineStart: 1,
-      lineEnd: firstStart - 1,
-      content: lines.slice(0, firstStart - 1).join("\n"),
+      lineStart: start,
+      lineEnd: end,
+      content: slice.join("\n"),
       fileHash,
     });
-  }
+  };
 
+  let cursor = 1;
   for (const def of topLevel) {
+    if (def.lineStart > cursor) {
+      emitGap(cursor, def.lineStart - 1);
+    }
     chunks.push(...splitDef(repo, relPath, outputLang, lines, fileHash, def));
+    cursor = Math.max(cursor, def.lineEnd + 1);
+  }
+  if (cursor <= lines.length) {
+    emitGap(cursor, lines.length);
   }
 
   return chunks;
@@ -232,7 +246,18 @@ export async function chunkFile(
 ): Promise<Chunk[]> {
   let content: string;
   try {
-    content = await readFile(join(repoDir, relPath), "utf-8");
+    const repoRoot = await realpath(repoDir);
+    const absPath = resolve(repoDir, relPath);
+    const stat = await lstat(absPath);
+    if (!stat.isFile() || stat.isSymbolicLink()) {
+      return [];
+    }
+    const realFilePath = await realpath(absPath);
+    const relToRoot = relative(repoRoot, realFilePath);
+    if (relToRoot.startsWith("..") || isAbsolute(relToRoot)) {
+      return [];
+    }
+    content = await readFile(realFilePath, "utf-8");
   } catch {
     return [];
   }

--- a/packages/pi-codebase-index/src/config.ts
+++ b/packages/pi-codebase-index/src/config.ts
@@ -1,0 +1,22 @@
+export interface PiCodebaseConfig {
+  apiUrl: string;
+  authProvider: string;
+}
+
+const EXAMPLE_URL = "https://your-backend.example.com/api";
+
+export function getConfig(): PiCodebaseConfig {
+  const apiUrl = process.env.PI_CODEBASE_API_URL;
+
+  if (!apiUrl) {
+    throw new Error(
+      "PI_CODEBASE_API_URL is not set. Point it at a backend that implements the " +
+        `Codebase Index Protocol (see PROTOCOL.md). Example: PI_CODEBASE_API_URL=${EXAMPLE_URL}`
+    );
+  }
+
+  return {
+    apiUrl,
+    authProvider: process.env.PI_CODEBASE_AUTH_PROVIDER || "github",
+  };
+}

--- a/packages/pi-codebase-index/src/index.ts
+++ b/packages/pi-codebase-index/src/index.ts
@@ -1,0 +1,224 @@
+import { exec } from "node:child_process";
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { clearCredentials, getCredentials, saveCredentials } from "./auth.js";
+import { getConfig } from "./config.js";
+import { registerCodebaseTools } from "./tools.js";
+import { search } from "./api.js";
+import { runSync } from "./sync.js";
+
+const LOGIN_TIMEOUT_MS = 60_000;
+const HIDDEN_STATE_ENTRY = "codebase-hidden-state";
+
+let hidden = false;
+let syncing = false;
+
+function openBrowser(url: string): void {
+  const cmd =
+    process.platform === "darwin"
+      ? `open "${url}"`
+      : process.platform === "win32"
+        ? `start "${url}"`
+        : `xdg-open "${url}"`;
+  exec(cmd);
+}
+
+function login(): Promise<{
+  token: string;
+  refreshToken: string | null;
+  username: string;
+  expiresIn: number;
+}> {
+  return new Promise((resolve, reject) => {
+    let boundPort = 0;
+
+    const server = createServer((req, res) => {
+      const url = new URL(req.url ?? "", `http://localhost:${boundPort || 0}`);
+      const token = url.searchParams.get("token");
+      const refreshToken = url.searchParams.get("refresh_token");
+
+      if (!token) {
+        res.writeHead(400);
+        res.end("Missing token");
+        return;
+      }
+
+      res.writeHead(200, { "Content-Type": "text/html" });
+      res.end("<html><body><h2>Login successful! You can close this tab.</h2></body></html>");
+      server.close();
+
+      try {
+        const payload = JSON.parse(Buffer.from(token.split(".")[1], "base64url").toString());
+        resolve({
+          token,
+          refreshToken,
+          username: payload.username,
+          expiresIn: (payload.exp - payload.iat) * 1000,
+        });
+      } catch (error) {
+        reject(error instanceof Error ? error : new Error("Invalid token payload"));
+      }
+    });
+
+    server.listen(0, () => {
+      const address = server.address() as AddressInfo | null;
+      if (!address) {
+        server.close();
+        reject(new Error("Failed to bind login server"));
+        return;
+      }
+      boundPort = address.port;
+      const config = getConfig();
+      const loginUrl = `${config.apiUrl}/auth/${config.authProvider}/start?redirect_url=http://localhost:${boundPort}`;
+      openBrowser(loginUrl);
+    });
+
+    server.on("error", reject);
+    setTimeout(() => {
+      server.close();
+      reject(new Error("Login timed out (60s)"));
+    }, LOGIN_TIMEOUT_MS);
+  });
+}
+
+function restoreHiddenState(entries: unknown[]): void {
+  for (const entry of entries) {
+    const typed = entry as { type?: string; customType?: string; data?: { hidden?: boolean } };
+    if (typed.type === "custom" && typed.customType === HIDDEN_STATE_ENTRY && typed.data) {
+      if (typeof typed.data.hidden === "boolean") {
+        hidden = typed.data.hidden;
+      }
+    }
+  }
+}
+
+async function triggerSync(pi: ExtensionAPI, cwd: string, setStatus: (text: string) => void): Promise<void> {
+  if (syncing) return;
+  const creds = await getCredentials();
+  if (!creds) return;
+
+  syncing = true;
+  const status = hidden ? () => {} : setStatus;
+  try {
+    await runSync(cwd, status);
+  } catch (error) {
+    if (!hidden) {
+      setStatus(`codebase: sync failed`);
+    }
+    void error;
+  } finally {
+    syncing = false;
+  }
+}
+
+export default function piCodebaseIndexExtension(pi: ExtensionAPI): void {
+  registerCodebaseTools(pi);
+
+  pi.on("session_start", async (_event, ctx) => {
+    restoreHiddenState(ctx.sessionManager.getEntries());
+
+    const creds = await getCredentials();
+    if (!hidden) {
+      ctx.ui.setStatus(
+        "codebase",
+        creds ? "codebase: starting sync…" : "codebase: not logged in"
+      );
+    }
+
+    if (creds) {
+      void triggerSync(pi, ctx.cwd, (text) => ctx.ui.setStatus("codebase", text));
+    }
+  });
+
+  pi.registerCommand("codebase-login", {
+    description: "Authenticate with the codebase index backend",
+    handler: async (_args, ctx) => {
+      try {
+        const result = await login();
+        await saveCredentials({
+          token: result.token,
+          refreshToken: result.refreshToken ?? undefined,
+          username: result.username,
+          expiresAt: Date.now() + result.expiresIn,
+        });
+        ctx.ui.setStatus("codebase", `codebase: ${result.username}`);
+        ctx.ui.notify(`Logged in as ${result.username}`, "info");
+        void triggerSync(pi, ctx.cwd, (text) => ctx.ui.setStatus("codebase", text));
+      } catch (error) {
+        ctx.ui.notify(
+          `Login failed: ${error instanceof Error ? error.message : String(error)}`,
+          "error"
+        );
+      }
+    },
+  });
+
+  pi.registerCommand("codebase-logout", {
+    description: "Clear codebase index credentials",
+    handler: async (_args, ctx) => {
+      await clearCredentials();
+      ctx.ui.setStatus("codebase", "codebase: logged out");
+      ctx.ui.notify("Logged out from codebase index", "info");
+    },
+  });
+
+  pi.registerCommand("codebase-search", {
+    description: "Search the codebase index: /codebase-search <query>",
+    handler: async (args, ctx) => {
+      const query = args?.trim();
+      if (!query) {
+        ctx.ui.notify("Usage: /codebase-search <query>", "warning");
+        return;
+      }
+      try {
+        const results = await search(query, { limit: 10 });
+        if (results.length === 0) {
+          ctx.ui.notify("No matching code found.", "info");
+          return;
+        }
+        const text = results
+          .map((r, i) => `${i + 1}. [${r.repo}] ${r.path}:${r.lineStart ?? "?"} — ${r.symbol}`)
+          .join("\n");
+        ctx.ui.notify(text, "info");
+      } catch (error) {
+        ctx.ui.notify(
+          `Search failed: ${error instanceof Error ? error.message : String(error)}`,
+          "error"
+        );
+      }
+    },
+  });
+
+  pi.registerCommand("codebase-reindex", {
+    description: "Force a fresh sync of the workspace into the codebase index",
+    handler: async (_args, ctx) => {
+      ctx.ui.notify("Re-syncing codebase index…", "info");
+      await triggerSync(pi, ctx.cwd, (text) => ctx.ui.setStatus("codebase", text));
+    },
+  });
+
+  pi.registerCommand("codebase-hide", {
+    description: "Hide the codebase index status widget",
+    handler: async (_args, ctx) => {
+      hidden = true;
+      pi.appendEntry(HIDDEN_STATE_ENTRY, { hidden: true });
+      ctx.ui.setStatus("codebase", "");
+      ctx.ui.notify("Codebase widget hidden (sync still runs).", "info");
+    },
+  });
+
+  pi.registerCommand("codebase-show", {
+    description: "Show the codebase index status widget",
+    handler: async (_args, ctx) => {
+      hidden = false;
+      pi.appendEntry(HIDDEN_STATE_ENTRY, { hidden: false });
+      const creds = await getCredentials();
+      ctx.ui.setStatus(
+        "codebase",
+        creds ? `codebase: ${creds.username}` : "codebase: not logged in"
+      );
+      ctx.ui.notify("Codebase widget shown.", "info");
+    },
+  });
+}

--- a/packages/pi-codebase-index/src/merkle.ts
+++ b/packages/pi-codebase-index/src/merkle.ts
@@ -1,0 +1,84 @@
+import { createHash } from "node:crypto";
+import { execFile } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { promisify } from "node:util";
+
+const exec = promisify(execFile);
+
+const MAX_FILE_BYTES = 256 * 1024;
+
+const INDEXABLE_EXTENSIONS = new Set([
+  ".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs",
+  ".ex", ".exs",
+  ".py",
+  ".rb",
+  ".go",
+  ".rs",
+  ".java", ".kt",
+  ".php",
+  ".c", ".h", ".cc", ".cpp", ".hpp",
+  ".cs",
+  ".swift",
+  ".sql",
+  ".graphql", ".gql",
+]);
+
+export interface RepoFile {
+  path: string;
+  hash: string;
+}
+
+export interface RepoSnapshot {
+  name: string;
+  rootHash: string;
+  files: RepoFile[];
+}
+
+function extOf(path: string): string {
+  const dot = path.lastIndexOf(".");
+  return dot === -1 ? "" : path.slice(dot).toLowerCase();
+}
+
+async function listTrackedFiles(repoDir: string): Promise<string[]> {
+  try {
+    const { stdout } = await exec("git", ["-C", repoDir, "ls-files"], {
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    return stdout.split("\n").filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+async function hashFile(absPath: string): Promise<string | null> {
+  try {
+    const content = await readFile(absPath);
+    if (content.byteLength > MAX_FILE_BYTES) return null;
+    return createHash("sha256").update(content).digest("hex");
+  } catch {
+    return null;
+  }
+}
+
+export async function snapshotRepo(repoDir: string, name: string): Promise<RepoSnapshot | null> {
+  const tracked = await listTrackedFiles(repoDir);
+  if (tracked.length === 0) return null;
+
+  const files: RepoFile[] = [];
+  for (const rel of tracked) {
+    if (!INDEXABLE_EXTENSIONS.has(extOf(rel))) continue;
+    const hash = await hashFile(join(repoDir, rel));
+    if (!hash) continue;
+    files.push({ path: rel, hash });
+  }
+
+  if (files.length === 0) return null;
+
+  files.sort((a, b) => (a.path < b.path ? -1 : 1));
+  const rootHash = createHash("sha256")
+    .update(files.map((f) => `${f.path}:${f.hash}`).join("\n"))
+    .digest("hex");
+
+  return { name, rootHash, files };
+}

--- a/packages/pi-codebase-index/src/sync.ts
+++ b/packages/pi-codebase-index/src/sync.ts
@@ -1,0 +1,120 @@
+import { readdir } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { index, sync } from "./api.js";
+import type { RepoPath } from "./api.js";
+import { chunkFile } from "./chunker.js";
+import { snapshotRepo } from "./merkle.js";
+import type { RepoSnapshot } from "./merkle.js";
+
+const INDEX_FLUSH_BATCH = 32;
+
+export type StatusFn = (text: string) => void;
+
+async function discoverRepos(workspaceDir: string): Promise<{ name: string; dir: string }[]> {
+  const repos: { name: string; dir: string }[] = [];
+
+  if (existsSync(join(workspaceDir, ".git"))) {
+    repos.push({ name: basename(workspaceDir), dir: workspaceDir });
+    return repos;
+  }
+
+  let entries: string[] = [];
+  try {
+    entries = await readdir(workspaceDir);
+  } catch {
+    return repos;
+  }
+
+  for (const entry of entries) {
+    if (entry.startsWith(".")) continue;
+    const dir = join(workspaceDir, entry);
+    if (existsSync(join(dir, ".git"))) {
+      repos.push({ name: entry, dir });
+    }
+  }
+
+  return repos;
+}
+
+function basename(p: string): string {
+  const parts = p.replace(/\/+$/, "").split("/");
+  return parts[parts.length - 1] || p;
+}
+
+export async function runSync(workspaceDir: string, setStatus: StatusFn): Promise<void> {
+  setStatus("codebase: checking sync…");
+
+  const repos = await discoverRepos(workspaceDir);
+  if (repos.length === 0) {
+    setStatus("codebase: no repos");
+    return;
+  }
+
+  const snapshots: (RepoSnapshot & { dir: string })[] = [];
+  for (const repo of repos) {
+    const snap = await snapshotRepo(repo.dir, repo.name);
+    if (snap) {
+      snapshots.push({ ...snap, dir: repo.dir });
+    }
+  }
+
+  if (snapshots.length === 0) {
+    setStatus("codebase: nothing to index");
+    return;
+  }
+
+  const { changed } = await sync(
+    snapshots.map((s) => ({ name: s.name, rootHash: s.rootHash, files: s.files }))
+  );
+
+  if (changed.length === 0) {
+    setStatus(`codebase: ✓ up to date (${snapshots.length} repos)`);
+    return;
+  }
+
+  await indexChanged(snapshots, changed, setStatus);
+}
+
+async function indexChanged(
+  snapshots: (RepoSnapshot & { dir: string })[],
+  changed: RepoPath[],
+  setStatus: StatusFn
+): Promise<void> {
+  const dirByRepo = new Map(snapshots.map((s) => [s.name, s.dir]));
+  const hashByKey = new Map<string, string>();
+  for (const snap of snapshots) {
+    for (const file of snap.files) {
+      hashByKey.set(`${snap.name}\u0000${file.path}`, file.hash);
+    }
+  }
+
+  const total = changed.length;
+  let done = 0;
+  let pending: Awaited<ReturnType<typeof chunkFile>> = [];
+
+  const flush = async () => {
+    if (pending.length === 0) return;
+    const batch = pending;
+    pending = [];
+    await index(batch);
+  };
+
+  for (const item of changed) {
+    const dir = dirByRepo.get(item.repo);
+    const fileHash = hashByKey.get(`${item.repo}\u0000${item.path}`);
+    if (dir && fileHash) {
+      const chunks = await chunkFile(item.repo, dir, item.path, fileHash);
+      pending.push(...chunks);
+    }
+    done += 1;
+    setStatus(`codebase: indexing ${done}/${total}…`);
+
+    if (pending.length >= INDEX_FLUSH_BATCH) {
+      await flush();
+    }
+  }
+
+  await flush();
+  setStatus(`codebase: ✓ indexed ${total} files`);
+}

--- a/packages/pi-codebase-index/src/tools.ts
+++ b/packages/pi-codebase-index/src/tools.ts
@@ -1,0 +1,68 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Type } from "@earendil-works/pi-ai";
+import { search } from "./api.js";
+
+export function registerCodebaseTools(pi: ExtensionAPI): void {
+  pi.registerTool({
+    name: "search_codebase",
+    label: "Search Codebase",
+    description:
+      "Semantic code search across the indexed repositories. Finds code by concept or intent " +
+      "even when you do not know the exact symbol name, and ranks results across all repos at once. " +
+      "Returns file path, symbol, a snippet, and line numbers so you can jump straight to the code.",
+    promptSnippet:
+      "search_codebase — semantic code search by concept/intent across all indexed repos.",
+    promptGuidelines: [
+      "Use search_codebase when the search is conceptual (\"where is subscription renewal handled\", \"how is a student linked to a class\") and you do not know the exact symbol name.",
+      "Prefer grep for an exact literal name you already know, and LSP tools for references/definitions of a known symbol.",
+      "search_codebase ranks across all repos at once — omit the repo filter unless you are sure which repo to scope to.",
+    ],
+    parameters: Type.Object({
+      query: Type.String({ description: "Natural-language description of the code you are looking for" }),
+      repo: Type.Optional(
+        Type.String({ description: "Restrict to a single repo by name. Omit to search all repos." })
+      ),
+      lang: Type.Optional(
+        Type.String({ description: "Restrict to a language (e.g. typescript, elixir, python)." })
+      ),
+      limit: Type.Optional(Type.Number({ description: "Max results (default 10)" })),
+    }),
+    async execute(_toolCallId, params) {
+      try {
+        const results = await search(params.query, {
+          repo: params.repo,
+          lang: params.lang,
+          limit: params.limit,
+        });
+
+        if (results.length === 0) {
+          return {
+            content: [{ type: "text", text: "No matching code found." }],
+            details: { count: 0 },
+          };
+        }
+
+        const text = results
+          .map((r, i) => {
+            const loc =
+              r.lineStart != null ? `${r.path}:${r.lineStart}` : r.path;
+            const header = `${i + 1}. [${r.repo}] ${loc} — ${r.symbol} (${(r.score * 100).toFixed(0)}%)`;
+            return `${header}\n\`\`\`${r.lang}\n${r.snippet}\n\`\`\``;
+          })
+          .join("\n\n");
+
+        return {
+          content: [{ type: "text", text }],
+          details: { count: results.length },
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          content: [{ type: "text", text: `search_codebase failed: ${message}` }],
+          details: { count: 0 },
+          isError: true,
+        };
+      }
+    },
+  });
+}

--- a/packages/pi-codebase-index/tsconfig.json
+++ b/packages/pi-codebase-index/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "lib": ["ES2022"],
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,6 +201,24 @@ importers:
         specifier: ^5.3.0
         version: 5.9.3
 
+  packages/pi-codebase-index:
+    devDependencies:
+      '@earendil-works/pi-ai':
+        specifier: latest
+        version: 0.80.2(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-coding-agent':
+        specifier: latest
+        version: 0.80.2(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-tui':
+        specifier: 0.79.5
+        version: 0.79.5
+      '@types/node':
+        specifier: ^20.10.0
+        version: 20.19.39
+      typescript:
+        specifier: ^5.3.0
+        version: 5.9.3
+
   packages/pi-memory:
     devDependencies:
       '@earendil-works/pi-ai':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,10 +23,10 @@ importers:
     devDependencies:
       '@earendil-works/pi-ai':
         specifier: latest
-        version: 0.79.6(ws@8.20.0)(zod@4.4.3)
+        version: 0.80.2(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-coding-agent':
         specifier: latest
-        version: 0.79.6(ws@8.20.0)(zod@4.4.3)
+        version: 0.80.2(ws@8.20.0)(zod@4.4.3)
       '@types/node':
         specifier: ^20.10.0
         version: 20.19.39
@@ -38,7 +38,7 @@ importers:
     devDependencies:
       '@earendil-works/pi-coding-agent':
         specifier: latest
-        version: 0.79.6(ws@8.20.0)(zod@4.4.3)
+        version: 0.80.2(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-tui':
         specifier: 0.79.5
         version: 0.79.5
@@ -53,10 +53,10 @@ importers:
     devDependencies:
       '@earendil-works/pi-ai':
         specifier: latest
-        version: 0.79.6(ws@8.20.0)(zod@4.4.3)
+        version: 0.80.2(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-coding-agent':
         specifier: latest
-        version: 0.79.6(ws@8.20.0)(zod@4.4.3)
+        version: 0.80.2(ws@8.20.0)(zod@4.4.3)
       '@types/node':
         specifier: ^20.10.0
         version: 20.19.39
@@ -90,10 +90,10 @@ importers:
     devDependencies:
       '@earendil-works/pi-ai':
         specifier: latest
-        version: 0.79.6(ws@8.20.0)(zod@4.4.3)
+        version: 0.80.2(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-coding-agent':
         specifier: latest
-        version: 0.79.6(ws@8.20.0)(zod@4.4.3)
+        version: 0.80.2(ws@8.20.0)(zod@4.4.3)
       '@types/node':
         specifier: ^20.10.0
         version: 20.19.39
@@ -108,7 +108,7 @@ importers:
     devDependencies:
       '@earendil-works/pi-coding-agent':
         specifier: latest
-        version: 0.79.0
+        version: 0.80.2(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-tui':
         specifier: 0.79.5
         version: 0.79.5
@@ -190,10 +190,10 @@ importers:
     devDependencies:
       '@earendil-works/pi-ai':
         specifier: latest
-        version: 0.78.1(ws@8.20.0)(zod@4.4.3)
+        version: 0.80.2(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-coding-agent':
         specifier: latest
-        version: 0.78.1(ws@8.20.0)(zod@4.4.3)
+        version: 0.80.2(ws@8.20.0)(zod@4.4.3)
       '@types/node':
         specifier: ^20.10.0
         version: 20.19.39
@@ -202,6 +202,49 @@ importers:
         version: 5.9.3
 
   packages/pi-codebase-index:
+    dependencies:
+      '@tree-sitter-grammars/tree-sitter-kotlin':
+        specifier: ^1.1.0
+        version: 1.1.0
+      tree-sitter-c:
+        specifier: ^0.24.1
+        version: 0.24.1
+      tree-sitter-c-sharp:
+        specifier: ^0.23.1
+        version: 0.23.5
+      tree-sitter-cpp:
+        specifier: ^0.23.4
+        version: 0.23.4
+      tree-sitter-elixir:
+        specifier: ^0.3.5
+        version: 0.3.5
+      tree-sitter-go:
+        specifier: ^0.25.0
+        version: 0.25.0
+      tree-sitter-java:
+        specifier: ^0.23.5
+        version: 0.23.5
+      tree-sitter-javascript:
+        specifier: ^0.25.0
+        version: 0.25.0
+      tree-sitter-php:
+        specifier: ^0.24.2
+        version: 0.24.2
+      tree-sitter-python:
+        specifier: ^0.25.0
+        version: 0.25.0
+      tree-sitter-ruby:
+        specifier: ^0.23.1
+        version: 0.23.1
+      tree-sitter-rust:
+        specifier: ^0.24.0
+        version: 0.24.0
+      tree-sitter-typescript:
+        specifier: ^0.23.2
+        version: 0.23.2
+      web-tree-sitter:
+        specifier: 0.25.6
+        version: 0.25.6
     devDependencies:
       '@earendil-works/pi-ai':
         specifier: latest
@@ -223,10 +266,10 @@ importers:
     devDependencies:
       '@earendil-works/pi-ai':
         specifier: latest
-        version: 0.79.6(ws@8.20.0)(zod@4.4.3)
+        version: 0.80.2(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-coding-agent':
         specifier: latest
-        version: 0.79.6(ws@8.20.0)(zod@4.4.3)
+        version: 0.80.2(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-tui':
         specifier: 0.79.5
         version: 0.79.5
@@ -241,13 +284,13 @@ importers:
     devDependencies:
       '@earendil-works/pi-agent-core':
         specifier: latest
-        version: 0.79.6(ws@8.20.0)(zod@4.4.3)
+        version: 0.80.2(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-ai':
         specifier: latest
-        version: 0.79.6(ws@8.20.0)(zod@4.4.3)
+        version: 0.80.2(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-coding-agent':
         specifier: latest
-        version: 0.79.6(ws@8.20.0)(zod@4.4.3)
+        version: 0.80.2(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-tui':
         specifier: 0.79.5
         version: 0.79.5
@@ -262,10 +305,10 @@ importers:
     devDependencies:
       '@earendil-works/pi-ai':
         specifier: latest
-        version: 0.79.6(ws@8.20.0)(zod@4.4.3)
+        version: 0.80.2(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-coding-agent':
         specifier: latest
-        version: 0.79.6(ws@8.20.0)(zod@4.4.3)
+        version: 0.80.2(ws@8.20.0)(zod@4.4.3)
       '@types/node':
         specifier: ^20.10.0
         version: 20.19.39
@@ -356,10 +399,10 @@ importers:
     devDependencies:
       '@earendil-works/pi-ai':
         specifier: latest
-        version: 0.74.0(ws@8.20.0)(zod@4.4.3)
+        version: 0.80.2(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-coding-agent':
         specifier: latest
-        version: 0.74.0(ws@8.20.0)(zod@4.4.3)
+        version: 0.80.2(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-tui':
         specifier: 0.79.5
         version: 0.79.5
@@ -386,7 +429,7 @@ importers:
     devDependencies:
       '@earendil-works/pi-coding-agent':
         specifier: latest
-        version: 0.79.6(ws@8.20.0)(zod@4.4.3)
+        version: 0.80.2(ws@8.20.0)(zod@4.4.3)
       '@types/node':
         specifier: ^20.10.0
         version: 20.19.39
@@ -398,10 +441,10 @@ importers:
     devDependencies:
       '@earendil-works/pi-ai':
         specifier: latest
-        version: 0.75.5(ws@8.20.0)(zod@4.4.3)
+        version: 0.80.2(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-coding-agent':
         specifier: latest
-        version: 0.75.5(ws@8.20.0)(zod@4.4.3)
+        version: 0.80.2(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-tui':
         specifier: 0.79.5
         version: 0.79.5
@@ -416,10 +459,10 @@ importers:
     devDependencies:
       '@earendil-works/pi-ai':
         specifier: latest
-        version: 0.79.6(ws@8.20.0)(zod@4.4.3)
+        version: 0.80.2(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-coding-agent':
         specifier: latest
-        version: 0.79.6(ws@8.20.0)(zod@4.4.3)
+        version: 0.80.2(ws@8.20.0)(zod@4.4.3)
       '@types/node':
         specifier: ^20.10.0
         version: 20.19.39
@@ -454,10 +497,6 @@ packages:
 
   '@aws-crypto/util@5.2.0':
     resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
-
-  '@aws-sdk/client-bedrock-runtime@3.1043.0':
-    resolution: {integrity: sha512-J22pIYr7ZND7F9oYvqALUeHBsA2ND8fHm7ZIu2SBkoYXuvTMdRIfbHwyas3cZkYp+W/zGaLC/5mAHcmQQuaSOw==}
-    engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-bedrock-runtime@3.1048.0':
     resolution: {integrity: sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==}
@@ -507,22 +546,6 @@ packages:
     resolution: {integrity: sha512-ECfsw7mf6G/sxNbKbGE3/h1xeIArY/yRI1IjDGYkLgDIankh+aDOtDRSr40LVlIHGL9+jEH1cVuxmbJ8NLL/1A==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-host-header@3.972.10':
-    resolution: {integrity: sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/middleware-logger@3.972.10':
-    resolution: {integrity: sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/middleware-recursion-detection@3.972.11':
-    resolution: {integrity: sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/middleware-user-agent@3.972.38':
-    resolution: {integrity: sha512-iz+B29TXcAZsJpwB+AwG/TTGA5l/VnmMZ2UxtiySOZjI6gCdmviXPwdgzcmuazMy16rXoPY4mYCGe7zdNKfx5A==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/middleware-websocket@3.972.22':
     resolution: {integrity: sha512-aumo6pYnvD1/eda3R0UDkRVecwxsuW4zTZLdjbHg7NqYMKmy7vK0bM3NGJzCD+Ys8iqCC7EeDU4LuWVIsXvL+A==}
     engines: {node: '>= 14.0.0'}
@@ -531,16 +554,8 @@ packages:
     resolution: {integrity: sha512-Js2VYaCM269feB0cs0cGmlIhdOgT9aMqzdBx68lCy6kVCYfzr0T36ovUFDvfUmatkuBeyBJhCwaLBh7P8meH5Q==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/region-config-resolver@3.972.13':
-    resolution: {integrity: sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/signature-v4-multi-region@3.996.29':
     resolution: {integrity: sha512-Few9FoQqOt/0KSvZYP+qdW0dfOhfQ9N+gl2UUDvCPW6mkPKHli9LMbKxWj+wZ5zKPaOoqxuR3Hhy3OTpndkfSw==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/token-providers@3.1043.0':
-    resolution: {integrity: sha512-Rlh9piVFV4WOMGgcHY0+O4TMDOSJGYxh7dvxWIhmhf6ASvRPMA2HZb6DSCan8nl5IFXjCYxYXWjpb5+Ii77MjQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/token-providers@3.1048.0':
@@ -555,25 +570,9 @@ packages:
     resolution: {integrity: sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/util-endpoints@3.996.8':
-    resolution: {integrity: sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/util-locate-window@3.965.5':
     resolution: {integrity: sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==}
     engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/util-user-agent-browser@3.972.10':
-    resolution: {integrity: sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==}
-
-  '@aws-sdk/util-user-agent-node@3.973.24':
-    resolution: {integrity: sha512-ZWwlkjcIp7cEL8ZfTpTAPNkwx25p7xol0xlKoWVVf22+nsjwmLcHYtTPjIV1cSpmB/b6DaK4cb1fSkvCXHgRdw==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      aws-crt: '>=1.0.0'
-    peerDependenciesMeta:
-      aws-crt:
-        optional: true
 
   '@aws-sdk/xml-builder@3.972.26':
     resolution: {integrity: sha512-cDbrqvDS73whl6YAPSPq0U6whzG6UWI9PuWh0wrUuGoZexhWEqhdunbukV7iBoaWnFV1AODutM5hOD6rtn439g==}
@@ -587,25 +586,6 @@ packages:
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
     engines: {node: '>=6.9.0'}
 
-  '@borewit/text-codec@0.2.2':
-    resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
-
-  '@earendil-works/pi-agent-core@0.74.0':
-    resolution: {integrity: sha512-6GMR7/wwjEJ1EsXLWEz03QOWin4AMrJ/AZoMpgm5DJ6GHsF6q6GOhQbj5Zip4dow3vo/TmBAVqM+vmGfrjGAFQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@earendil-works/pi-agent-core@0.75.5':
-    resolution: {integrity: sha512-LHygOgsW2pgXKb3IkXkOAeZPovHr9VF+EixgXVsDNuB4jmhEOXgshy/zksZ7slkUAx10OQ9W1Ed/2jsnhd1NqA==}
-    engines: {node: '>=22.19.0'}
-
-  '@earendil-works/pi-agent-core@0.78.1':
-    resolution: {integrity: sha512-oPwVRkkAvyKPWyM7E4k+EaTNmynbYn7ZLG/LBh9BUnMNb2gvpMp+VQ420R6JCJ20uogSqrHnWTyosSa/rU8lVw==}
-    engines: {node: '>=22.19.0'}
-
-  '@earendil-works/pi-agent-core@0.79.0':
-    resolution: {integrity: sha512-jQOtYjRGZ7+XC/olw9euLd2V03vkAPO8u0sSnQoLbyOQZz66dEBZrklTESk34Sf3AaeBSua28wjZR48ch1aXJQ==}
-    engines: {node: '>=22.19.0'}
-
   '@earendil-works/pi-agent-core@0.79.5':
     resolution: {integrity: sha512-yOxzx8SRJkGsZTJWfe9VACkAF4amwHUgvFShn8uoYR7/fnhF69Sz0n7TIh8qRH21fBDvo1RLex4NK/iXFQ3u2Q==}
     engines: {node: '>=22.19.0'}
@@ -617,21 +597,6 @@ packages:
   '@earendil-works/pi-agent-core@0.80.2':
     resolution: {integrity: sha512-BF9WPhixIFjT6Kp3Iz3H6ugkU+4AWotM8py96XE5pIK0arJbQKMWbR+dXSWWDEmR5yc/aFQODnuyowOEzMGO7Q==}
     engines: {node: '>=22.19.0'}
-
-  '@earendil-works/pi-ai@0.74.0':
-    resolution: {integrity: sha512-7M7qcrZY/KEkH4wFkX3eqzvmKru4O88wezNKoN0KD2m4aAOmp9tdW2xCmUgSTSWlKB7b2Xw9QtAgrzHtg6t6iw==}
-    engines: {node: '>=20.0.0'}
-    hasBin: true
-
-  '@earendil-works/pi-ai@0.75.5':
-    resolution: {integrity: sha512-zf1F5kXk1pqZeFShXOqq9ibUk8QdtRoLCDPAjO+hj44e3EUs9/GFO2qnhTC5+JA2uwVCx+WCNe1PiCjlBYWm5w==}
-    engines: {node: '>=22.19.0'}
-    hasBin: true
-
-  '@earendil-works/pi-ai@0.78.1':
-    resolution: {integrity: sha512-CM2pkTs1iupG/maw381lC9Q/Y/aQaMGK7GILc28ttImD0ci3LDwKroDsGkWbly5JIy3iqxdRxB9JlG7vvzCzTg==}
-    engines: {node: '>=22.19.0'}
-    hasBin: true
 
   '@earendil-works/pi-ai@0.79.5':
     resolution: {integrity: sha512-LwZfV8HNvT90A9n5foA/a6/JMh5n/1lh1rRzOn+68kiFitf/tz3HTBpeSNFnUL4KLIdwp1lczjl4U2EJX0egvQ==}
@@ -645,26 +610,6 @@ packages:
 
   '@earendil-works/pi-ai@0.80.2':
     resolution: {integrity: sha512-5GNKfdrRJ4uZ5Zd9iudoXggi/BbUcKnD/xfRHtdR+7q4vWqPvfx8auFuaT+ewGBVI8K4wj87eigFQ/iCSuy9RQ==}
-    engines: {node: '>=22.19.0'}
-    hasBin: true
-
-  '@earendil-works/pi-coding-agent@0.74.0':
-    resolution: {integrity: sha512-Q5GikbB5vRBrsrrf/uvet53rPSQ1sn5I5mO+l7sIobdXYpS04/X2oOc2UHFm90fNdkl3yU+ANTZL0zOtHbnqRw==}
-    engines: {node: '>=20.6.0'}
-    hasBin: true
-
-  '@earendil-works/pi-coding-agent@0.75.5':
-    resolution: {integrity: sha512-O3CCQDYy28D4uwtP6zZkdEwzHN6X22v49Sb0+SZTC7x37V/YfmogrWPiaFoWeoc2hmdKhSATI7ZAK5bQbJG5NA==}
-    engines: {node: '>=22.19.0'}
-    hasBin: true
-
-  '@earendil-works/pi-coding-agent@0.78.1':
-    resolution: {integrity: sha512-Syjf6Ib8UoY5t9ZdKjp0BRrQZuFkFBc8j2KEU9zG/ZnmYPcAxYeioofdv2Q3MEXnHEX2U8sKQptkSnJIdMsd0g==}
-    engines: {node: '>=22.19.0'}
-    hasBin: true
-
-  '@earendil-works/pi-coding-agent@0.79.0':
-    resolution: {integrity: sha512-pZoXk65vFR3dAzzmPNWEX61aHnT6+BaVhTyFDQAs1DyumaMeWpvzRV9ZrGxqlbVLwhrq+0LnXbaqDAFkhe2+MQ==}
     engines: {node: '>=22.19.0'}
     hasBin: true
 
@@ -900,49 +845,15 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@mariozechner/clipboard-darwin-arm64@0.3.2':
-    resolution: {integrity: sha512-uBf6K7Je1ihsgvmWxA8UCGCeI+nbRVRXoarZdLjl6slz94Zs1tNKFZqx7aCI5O1i3e0B6ja82zZ06BWrl0MCVw==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@mariozechner/clipboard-darwin-arm64@0.3.6':
-    resolution: {integrity: sha512-HjaisYCAbHi/1+N1yDAQHc8ZXGffufIUT5NSOSVR3f3AuMDusxTtnbK8tZ7JFDkShua1oNGZoNwQHsc8MPtE0Q==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@mariozechner/clipboard-darwin-arm64@0.3.9':
     resolution: {integrity: sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@mariozechner/clipboard-darwin-universal@0.3.2':
-    resolution: {integrity: sha512-mxSheKTW2U9LsBdXy0SdmdCAE5HqNS9QUmpNHLnfJ+SsbFKALjEZc5oRrVMXxGQSirDvYf5bjmRyT0QYYonnlg==}
-    engines: {node: '>= 10'}
-    os: [darwin]
-
-  '@mariozechner/clipboard-darwin-universal@0.3.6':
-    resolution: {integrity: sha512-8BWtPjOtJOJoykml3w0fx0zRrfWP31mXrJwfoA7xzNprkZw1uolCNfgmjDiVBseoKjp16EGITz7bN+61qn8dWA==}
-    engines: {node: '>= 10'}
-    os: [darwin]
-
   '@mariozechner/clipboard-darwin-universal@0.3.9':
     resolution: {integrity: sha512-BGGR4iA9Z2shAjI65eI5xtyb3LYNlDW9X3gxKxDbqtbnREohsrqznov6zpKoIrsRWpzlYVEdKphS7ksJ0/ndSQ==}
     engines: {node: '>= 10'}
-    os: [darwin]
-
-  '@mariozechner/clipboard-darwin-x64@0.3.2':
-    resolution: {integrity: sha512-U1BcVEoidvwIp95+HJswSW+xr28EQiHR7rZjH6pn8Sja5yO4Yoe3yCN0Zm8Lo72BbSOK/fTSq0je7CJpaPCspg==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@mariozechner/clipboard-darwin-x64@0.3.6':
-    resolution: {integrity: sha512-p9syiZD1kU4I+1ya7f7g+zD1GiUvR8fdlRlNmgsZNWlyjtc8rlV2EjTLd/35x1LsdBq020GVvtzp0ZmPgBI09Q==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
     os: [darwin]
 
   '@mariozechner/clipboard-darwin-x64@0.3.9':
@@ -951,32 +862,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@mariozechner/clipboard-linux-arm64-gnu@0.3.2':
-    resolution: {integrity: sha512-BsinwG3yWTIjdgNCxsFlip7LkfwPk+ruw/aFCXHUg/fb5XC/Ksp+YMQ7u0LUtiKzIv/7LMXgZInJQH6gxbAaqQ==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@mariozechner/clipboard-linux-arm64-gnu@0.3.6':
-    resolution: {integrity: sha512-5JFf5rGofrm+V29HNF+wLthXphHdQpMbKDUYJ5tML6/Z5DLlLOV/9Ak4kDPtYyZ+Dzf+kAusE0VsFg4+tfP1IA==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-
   '@mariozechner/clipboard-linux-arm64-gnu@0.3.9':
     resolution: {integrity: sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@mariozechner/clipboard-linux-arm64-musl@0.3.2':
-    resolution: {integrity: sha512-0/Gi5Xq2V6goXBop19ePoHvXsmJD9SzFlO3S+d6+T2b+BlPcpOu3Oa0wTjl+cZrLAAEzA86aPNBI+VVAFDFPKw==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@mariozechner/clipboard-linux-arm64-musl@0.3.6':
-    resolution: {integrity: sha512-JlVjxxw0GbGC0djXYWRIqyteO3J1KZ/QG3udlEFaOD5TLOM1FnmXXAPDQBqr+aBVr720ef9K00dirYnJ0LDCtw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -987,50 +874,14 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@mariozechner/clipboard-linux-riscv64-gnu@0.3.2':
-    resolution: {integrity: sha512-2AFFiXB24qf0zOZsxI1GJGb9wQGlOJyN6UwoXqmKS3dpQi/l6ix30IzDDA4c4ZcCcx4D+9HLYXhC1w7Sov8pXA==}
-    engines: {node: '>= 10'}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@mariozechner/clipboard-linux-riscv64-gnu@0.3.6':
-    resolution: {integrity: sha512-4t8BUi5zZ+L77otFQVnVSlaTyAX4TVk9EqQm4syMrEQp96trFEHEwwNHcNEBGzYv5+K7mxay50TthYkz47OWzQ==}
-    engines: {node: '>= 10'}
-    cpu: [riscv64]
-    os: [linux]
-
   '@mariozechner/clipboard-linux-riscv64-gnu@0.3.9':
     resolution: {integrity: sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
 
-  '@mariozechner/clipboard-linux-x64-gnu@0.3.2':
-    resolution: {integrity: sha512-v6fVnsn7WMGg73Dab8QMwyFce7tzGfgEixKgzLP8f1GJqkJZi5zO4k4FOHzSgUufgLil63gnxvMpjWkgfeQN7A==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-
-  '@mariozechner/clipboard-linux-x64-gnu@0.3.6':
-    resolution: {integrity: sha512-trtPwcNLW37irwQCJLtCxLw757jjJZk3TSnY/MU9bhtWtA3K9b/eLW0e4RGhUXDoFRds9opNWWaUDuFLa8dm0w==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-
   '@mariozechner/clipboard-linux-x64-gnu@0.3.9':
     resolution: {integrity: sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-
-  '@mariozechner/clipboard-linux-x64-musl@0.3.2':
-    resolution: {integrity: sha512-xVUtnoMQ8v2JVyfJLKKXACA6avdnchdbBkTsZs8BgJQo29qwCp5NIHAUO8gbJ40iaEGToW5RlmVk2M9V0HsHEw==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-
-  '@mariozechner/clipboard-linux-x64-musl@0.3.6':
-    resolution: {integrity: sha512-WfnzIvOCCWQiN0MmltCEo6cLceUDbYe+I7xyFZjaps5A+2Op/M2CY7Rey+C4ucQhrvmpoHmTSFgY9ODWk7snoA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -1041,34 +892,10 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@mariozechner/clipboard-win32-arm64-msvc@0.3.2':
-    resolution: {integrity: sha512-AEgg95TNi8TGgak2wSXZkXKCvAUTjWoU1Pqb0ON7JHrX78p616XUFNTJohtIon3e0w6k0pYPZeCuqRCza/Tqeg==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@mariozechner/clipboard-win32-arm64-msvc@0.3.6':
-    resolution: {integrity: sha512-+8+1aHYsBPUjmW3otmWlg+Hijt0iJvoBBs5e0mxFeUd4gDaKMB8Bn6x7c6KVtscg7E5j5NFXnwQqNSIAO4p8zQ==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [win32]
-
   '@mariozechner/clipboard-win32-arm64-msvc@0.3.9':
     resolution: {integrity: sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
-    os: [win32]
-
-  '@mariozechner/clipboard-win32-x64-msvc@0.3.2':
-    resolution: {integrity: sha512-tGRuYpZwDOD7HBrCpyRuhGnHHSCknELvqwKKUG4JSfSB7JIU7LKRh6zx6fMUOQd8uISK35TjFg5UcNih+vJhFA==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [win32]
-
-  '@mariozechner/clipboard-win32-x64-msvc@0.3.6':
-    resolution: {integrity: sha512-S4xfPmERC8ZkiLHe3vekZCjdDwNEETCuvCgQK2kP6/TnvmUkq1y2Pk+DjM4t8uh9KMX9bH4zs5ePcKa8GTXmfg==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
     os: [win32]
 
   '@mariozechner/clipboard-win32-x64-msvc@0.3.9':
@@ -1076,14 +903,6 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
-
-  '@mariozechner/clipboard@0.3.5':
-    resolution: {integrity: sha512-D3F+UrU9CR7roJt0zDLp6Oc+4/KlLDIrN4frH+6V90SJNW2KKUec1oCQIPaaDjCqeOsQyX9dyqYbImIQIM45PA==}
-    engines: {node: '>= 10'}
-
-  '@mariozechner/clipboard@0.3.6':
-    resolution: {integrity: sha512-MXdtr+6+ntlIVHdrZYuZNQydu6o8yZswFJ2Ln81j2O/Y9B/LDHvEaIm95xWNPkjGTWriSOeLnQJRFs6dYb60bg==}
-    engines: {node: '>= 10'}
 
   '@mariozechner/clipboard@0.3.9':
     resolution: {integrity: sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA==}
@@ -1160,10 +979,6 @@ packages:
     resolution: {integrity: sha512-jejr34a8B4L5AS713wOAx1LAqNkW16HVMDEa6sYBvFDc/llUBl8hXaiI4BwF+Al+Sug19Vn2O7iokTVIhVvZ1Q==}
     engines: {node: '>= 18', npm: '>= 8.6.0'}
 
-  '@smithy/config-resolver@4.4.17':
-    resolution: {integrity: sha512-TzDZcAnhTyAHbXVxWZo7/tEcrIeFq20IBk8So3OLOetWpR8EwY/yEqBMBFaJMeyEiREDq4NfEl+qO3OAUD+vbQ==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/core@3.24.4':
     resolution: {integrity: sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw==}
     engines: {node: '>=18.0.0'}
@@ -1172,183 +987,41 @@ packages:
     resolution: {integrity: sha512-vKW0MEFRU4Y3MkVZUkpJm+g9qyPGLCXhc0YLggUdSdBB4g7IaSSsCE75P9rBXyWHrXY1UYSQUl8/DwsTR7QciA==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/eventstream-codec@4.2.14':
-    resolution: {integrity: sha512-erZq0nOIpzfeZdCyzZjdJb4nVSKLUmSkaQUVkRGQTXs30gyUGeKnrYEg+Xe1W5gE3aReS7IgsvANwVPxSzY6Pw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/eventstream-serde-browser@4.2.14':
-    resolution: {integrity: sha512-8IelTCtTctWRbb+0Dcy+C0aICh1qa0qWXqgjcXDmMuCvPJRnv26hiDZoAau2ILOniki65mCPKqOQs/BaWvO4CQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/eventstream-serde-config-resolver@4.3.14':
-    resolution: {integrity: sha512-sqHiHpYRYo3FJlaIxD1J8PhbcmJAm7IuM16mVnwSkCToD7g00IBZzKuiLNMGmftULmEUX6/UAz8/NN5uMP8bVA==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/eventstream-serde-node@4.2.14':
-    resolution: {integrity: sha512-Ht/8BuGlKfFTy0H3+8eEu0vdpwGztCnaLLXtpXNdQqiR7Hj4vFScU3T436vRAjATglOIPjJXronY+1WxxNLSiw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/eventstream-serde-universal@4.2.14':
-    resolution: {integrity: sha512-lWyt4T2XQZUZgK3tQ3Wn0w3XBvZsK/vjTuJl6bXbnGZBHH0ZUSONTYiK9TgjTTzU54xQr3DRFwpjmhp0oLm3gg==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/fetch-http-handler@5.4.4':
     resolution: {integrity: sha512-qM7AUKI4G6d7lNgaZD3lA1tWSolh5r6gcixfTZAPstVURfjIbvreVTPz+994M0yC3HbX4YYhDRgr31Xy3XwWOQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/hash-node@4.2.14':
-    resolution: {integrity: sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/invalid-dependency@4.2.14':
-    resolution: {integrity: sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/is-array-buffer@2.2.0':
     resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
     engines: {node: '>=14.0.0'}
 
-  '@smithy/is-array-buffer@4.2.2':
-    resolution: {integrity: sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/middleware-content-length@4.2.14':
-    resolution: {integrity: sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/middleware-endpoint@4.4.32':
-    resolution: {integrity: sha512-ZZkgyjnJppiZbIm6Qbx92pbXYi1uzenIvGhBSCDlc7NwuAkiqSgS75j1czAD25ZLs2FjMjYy1q7gyRVWG6JA0Q==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/middleware-retry@4.5.7':
-    resolution: {integrity: sha512-bRt6ZImqVSeTk39Nm81K20ObIiAZ3WefY7G6+iz/0tZjs4dgRRjvRX2sgsH+zi6iDCRR/aQvQofLKxxz4rPBZg==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/middleware-serde@4.2.20':
-    resolution: {integrity: sha512-Lx9JMO9vArPtiChE3wbEZ5akMIDQpWQtlu90lhACQmNOXcGXRbaDywMHDzuDZ2OkZzP+9wQfZi3YJT9F67zTQQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/middleware-stack@4.2.14':
-    resolution: {integrity: sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/node-config-provider@4.3.14':
-    resolution: {integrity: sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/node-http-handler@4.7.3':
     resolution: {integrity: sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/property-provider@4.2.14':
-    resolution: {integrity: sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/protocol-http@5.3.14':
-    resolution: {integrity: sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/querystring-parser@4.2.14':
-    resolution: {integrity: sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/service-error-classification@4.3.1':
-    resolution: {integrity: sha512-aUQuDGh760ts/8MU+APjIZhlLPKhIIfqyzZaJikLEIMrdxFvxuLYD0WxWzaYWpmLbQlXDe9p7EWM3HsBe0K6Gw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/shared-ini-file-loader@4.4.9':
-    resolution: {integrity: sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/signature-v4@5.4.4':
     resolution: {integrity: sha512-e5UtkMvsatzBfbeBZjEOt0k0Z3BEsjTFL/n6fdO5vtBLe67tdy0dX7xw2DU7uZ3acwoHyeCqpU2Fzb7pxwHb6Q==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/smithy-client@4.12.13':
-    resolution: {integrity: sha512-y/Pcj1V9+qG98gyu1gvftHB7rDpdh+7kIBIggs55yGm3JdtBV8GT8IFF3a1qxZ79QnaJHX9GXzvBG6tAd+czJA==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/types@4.14.2':
     resolution: {integrity: sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/url-parser@4.2.14':
-    resolution: {integrity: sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-base64@4.3.2':
-    resolution: {integrity: sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-body-length-browser@4.2.2':
-    resolution: {integrity: sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-body-length-node@4.2.3':
-    resolution: {integrity: sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-buffer-from@2.2.0':
     resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
     engines: {node: '>=14.0.0'}
 
-  '@smithy/util-buffer-from@4.2.2':
-    resolution: {integrity: sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-config-provider@4.2.2':
-    resolution: {integrity: sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-defaults-mode-browser@4.3.49':
-    resolution: {integrity: sha512-a5bNrdiONYB/qE2BuKegvUMd/+ZDwdg4vsNuuSzYE8qs2EYAdK9CynL+Rzn29PbPiUqoz/cbpRbcLzD5lEevHw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-defaults-mode-node@4.2.54':
-    resolution: {integrity: sha512-g1cvrJvOnzeJgEdf7AE4luI7gp6L8weE0y9a9wQUSGtjb8QRHDbCJYuE4Sy0SD9N8RrnNPFsPltAz/OSoBR9Zw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-endpoints@3.4.2':
-    resolution: {integrity: sha512-a55Tr+3OKld4TTtnT+RhKOQHyPxm3j/xL4OR83WBUhLJaKDS9dnJ7arRMOp3t31dcLhApwG9bgvrRXBHlLdIkg==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-hex-encoding@4.2.2':
-    resolution: {integrity: sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-middleware@4.2.14':
-    resolution: {integrity: sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-retry@4.3.8':
-    resolution: {integrity: sha512-LUIxbTBi+OpvXpg91poGA6BdyoleMDLnfXjVDqyi2RvZmTveY5loE/FgYUBCR5LU2BThW2SoZRh8dTIIy38IPw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-stream@4.5.25':
-    resolution: {integrity: sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/util-utf8@2.3.0':
     resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
     engines: {node: '>=14.0.0'}
 
-  '@smithy/util-utf8@4.2.2':
-    resolution: {integrity: sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/uuid@1.1.2':
-    resolution: {integrity: sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==}
-    engines: {node: '>=18.0.0'}
-
-  '@tokenizer/inflate@0.4.1':
-    resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
-    engines: {node: '>=18'}
-
-  '@tokenizer/token@0.3.0':
-    resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
-
-  '@tootallnate/quickjs-emscripten@0.23.0':
-    resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
+  '@tree-sitter-grammars/tree-sitter-kotlin@1.1.0':
+    resolution: {integrity: sha512-vlVXaxEE8t2kpJgfZpa8XVvxcnKw9AYtRTgy7KWjsDmAsadk06RxAT80IXOgGQnmM9i/orQn1nD84gPNUHu6DQ==}
+    peerDependencies:
+      tree-sitter: ^0.22.4
+    peerDependenciesMeta:
+      tree-sitter:
+        optional: true
 
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
@@ -1367,9 +1040,6 @@ packages:
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
-
-  '@types/yauzl@2.10.3':
-    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
 
   '@typescript-eslint/eslint-plugin@8.59.3':
     resolution: {integrity: sha512-PwFvSKsXGShKGW6n5bZOhGHEcCZXM8HofLK9fNsEwZXzFRjoY+XT1Vsf1zgyXdwTr0ZYz1/2tkZ0DBTT9jZjhw==}
@@ -1451,25 +1121,6 @@ packages:
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
-  ansi-regex@5.0.1:
-    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
-    engines: {node: '>=8'}
-
-  ansi-regex@6.2.2:
-    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
-    engines: {node: '>=12'}
-
-  ansi-styles@4.3.0:
-    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
-    engines: {node: '>=8'}
-
-  any-promise@1.3.0:
-    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
-
-  ast-types@0.13.4:
-    resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
-    engines: {node: '>=4'}
-
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
@@ -1483,10 +1134,6 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  basic-ftp@5.3.1:
-    resolution: {integrity: sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==}
-    engines: {node: '>=10.0.0'}
-
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
@@ -1497,9 +1144,6 @@ packages:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
     engines: {node: 18 || 20 || >=22}
 
-  buffer-crc32@0.2.13:
-    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
-
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
@@ -1507,28 +1151,9 @@ packages:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
 
-  chalk@4.1.2:
-    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
-    engines: {node: '>=10'}
-
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
-
-  cli-highlight@2.1.11:
-    resolution: {integrity: sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==}
-    engines: {node: '>=8.0.0', npm: '>=5.0.0'}
-    hasBin: true
-
-  cliui@7.0.4:
-    resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
-
-  color-convert@2.0.1:
-    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
-    engines: {node: '>=7.0.0'}
-
-  color-name@1.1.4:
-    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
@@ -1542,10 +1167,6 @@ packages:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
 
-  data-uri-to-buffer@6.0.2:
-    resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
-    engines: {node: '>= 14'}
-
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -1557,10 +1178,6 @@ packages:
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
-
-  degenerator@5.0.1:
-    resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
-    engines: {node: '>= 14'}
 
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -1581,12 +1198,6 @@ packages:
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
-  emoji-regex@8.0.0:
-    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
-
-  end-of-stream@1.4.5:
-    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
-
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
     engines: {node: '>= 0.4'}
@@ -1603,18 +1214,9 @@ packages:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
-  escalade@3.2.0:
-    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
-    engines: {node: '>=6'}
-
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
-
-  escodegen@2.1.0:
-    resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
-    engines: {node: '>=6.0'}
-    hasBin: true
 
   eslint-scope@9.1.2:
     resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
@@ -1642,11 +1244,6 @@ packages:
     resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  esprima@4.0.1:
-    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
-    engines: {node: '>=4'}
-    hasBin: true
-
   esquery@1.7.0:
     resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
     engines: {node: '>=0.10'}
@@ -1672,11 +1269,6 @@ packages:
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
-  extract-zip@2.0.1:
-    resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
-    engines: {node: '>= 10.17.0'}
-    hasBin: true
-
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -1692,9 +1284,6 @@ packages:
   fast-xml-parser@5.7.3:
     resolution: {integrity: sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==}
     hasBin: true
-
-  fd-slicer@1.1.0:
-    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1712,10 +1301,6 @@ packages:
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
-
-  file-type@21.3.4:
-    resolution: {integrity: sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==}
-    engines: {node: '>=20'}
 
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
@@ -1756,10 +1341,6 @@ packages:
     resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
     engines: {node: '>=18'}
 
-  get-caller-file@2.0.5:
-    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
-    engines: {node: 6.* || 8.* || >= 10.*}
-
   get-east-asian-width@1.6.0:
     resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
     engines: {node: '>=18'}
@@ -1771,14 +1352,6 @@ packages:
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
-
-  get-stream@5.2.0:
-    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
-    engines: {node: '>=8'}
-
-  get-uri@6.0.5:
-    resolution: {integrity: sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==}
-    engines: {node: '>= 14'}
 
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
@@ -1802,10 +1375,6 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
-
-  has-flag@4.0.0:
-    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
-    engines: {node: '>=8'}
 
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
@@ -1838,9 +1407,6 @@ packages:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
 
-  ieee754@1.2.1:
-    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
-
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -1853,20 +1419,12 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
-  ip-address@10.2.0:
-    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
-    engines: {node: '>= 12'}
-
   is-electron@2.2.2:
     resolution: {integrity: sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
-
-  is-fullwidth-code-point@3.0.0:
-    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
-    engines: {node: '>=8'}
 
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
@@ -1923,15 +1481,6 @@ packages:
     resolution: {integrity: sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==}
     engines: {node: 20 || >=22}
 
-  lru-cache@7.18.3:
-    resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
-    engines: {node: '>=12'}
-
-  marked@15.0.12:
-    resolution: {integrity: sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==}
-    engines: {node: '>= 18'}
-    hasBin: true
-
   marked@18.0.5:
     resolution: {integrity: sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==}
     engines: {node: '>= 20'}
@@ -1960,15 +1509,15 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  mz@2.7.0:
-    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
-
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
-  netmask@2.1.1:
-    resolution: {integrity: sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==}
-    engines: {node: '>= 0.4.0'}
+  node-addon-api@7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+
+  node-addon-api@8.9.0:
+    resolution: {integrity: sha512-ekZMeaaIzSQTSpr7X2X3iJM7lTzgnx8ahAG9pJfT/7+14mlEM8ZYQ9cgCDvSSRbReFK0oHli3WrZdCiRsgAT9Q==}
+    engines: {node: ^18 || ^20 || >= 21}
 
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
@@ -1979,12 +1528,14 @@ packages:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  object-assign@4.1.1:
-    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
-    engines: {node: '>=0.10.0'}
+  node-gyp-build@4.8.4:
+    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
+    hasBin: true
 
-  once@1.4.0:
-    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+  npm-check-updates@17.1.18:
+    resolution: {integrity: sha512-bkUy2g4v1i+3FeUf5fXMLbxmV95eG4/sS7lYE32GrUeVgQRfQEk39gpskksFunyaxQgTIdrvYbnuNbO/pSUSqw==}
+    engines: {node: ^18.18.0 || >=20.0.0, npm: '>=8.12.1'}
+    hasBin: true
 
   openai@6.26.0:
     resolution: {integrity: sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==}
@@ -2026,25 +1577,8 @@ packages:
     resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
     engines: {node: '>=8'}
 
-  pac-proxy-agent@7.2.0:
-    resolution: {integrity: sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==}
-    engines: {node: '>= 14'}
-
-  pac-resolver@7.0.1:
-    resolution: {integrity: sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==}
-    engines: {node: '>= 14'}
-
   parse-diff@0.11.1:
     resolution: {integrity: sha512-Oq4j8LAOPOcssanQkIjxosjATBIEJhCxMCxPhMu+Ci4wdNmAEdx0O+a7gzbR2PyKXgKPvRLIN5g224+dJAsKHA==}
-
-  parse5-htmlparser2-tree-adapter@6.0.1:
-    resolution: {integrity: sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==}
-
-  parse5@5.1.1:
-    resolution: {integrity: sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==}
-
-  parse5@6.0.1:
-    resolution: {integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==}
 
   partial-json@0.1.7:
     resolution: {integrity: sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==}
@@ -2065,9 +1599,6 @@ packages:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
 
-  pend@1.2.0:
-    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
-
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
@@ -2083,27 +1614,13 @@ packages:
     resolution: {integrity: sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==}
     engines: {node: '>=12.0.0'}
 
-  proxy-agent@6.5.0:
-    resolution: {integrity: sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==}
-    engines: {node: '>= 14'}
-
-  proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
-
   proxy-from-env@2.1.0:
     resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
     engines: {node: '>=10'}
 
-  pump@3.0.4:
-    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
-
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
-
-  require-directory@2.1.1:
-    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
-    engines: {node: '>=0.10.0'}
 
   retry@0.12.0:
     resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
@@ -2141,59 +1658,121 @@ packages:
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
-  smart-buffer@4.2.0:
-    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
-    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
-
-  socks-proxy-agent@8.0.5:
-    resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
-    engines: {node: '>= 14'}
-
-  socks@2.8.8:
-    resolution: {integrity: sha512-NlGELfPrgX2f1TAAcz0WawlLn+0r3FyhhCRpFFK2CemXenPYvzMWWZINv3eDNo9ucdwme7oCHRY0Jnbs4aIkog==}
-    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
-
-  source-map@0.6.1:
-    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
-    engines: {node: '>=0.10.0'}
-
-  string-width@4.2.3:
-    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
-    engines: {node: '>=8'}
-
-  strip-ansi@6.0.1:
-    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
-    engines: {node: '>=8'}
-
-  strip-ansi@7.2.0:
-    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
-    engines: {node: '>=12'}
-
   strnum@2.2.3:
     resolution: {integrity: sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==}
-
-  strtok3@10.3.5:
-    resolution: {integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==}
-    engines: {node: '>=18'}
-
-  supports-color@7.2.0:
-    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
-    engines: {node: '>=8'}
-
-  thenify-all@1.6.0:
-    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
-    engines: {node: '>=0.8'}
-
-  thenify@3.3.1:
-    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
-  token-types@6.1.2:
-    resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
-    engines: {node: '>=14.16'}
+  tree-sitter-c-sharp@0.23.5:
+    resolution: {integrity: sha512-xJGOeXPMmld0nES5+080N/06yY6LQi+KWGWV4LfZaZe6srJPtUtfhIbRSN7EZN6IaauzW28v6W4QHFwmeUW6HQ==}
+    peerDependencies:
+      tree-sitter: ^0.25.0
+    peerDependenciesMeta:
+      tree-sitter:
+        optional: true
+
+  tree-sitter-c@0.23.6:
+    resolution: {integrity: sha512-0dxXKznVyUA0s6PjNolJNs2yF87O5aL538A/eR6njA5oqX3C3vH4vnx3QdOKwuUdpKEcFdHuiDpRKLLCA/tjvQ==}
+    peerDependencies:
+      tree-sitter: ^0.22.1
+    peerDependenciesMeta:
+      tree-sitter:
+        optional: true
+
+  tree-sitter-c@0.24.1:
+    resolution: {integrity: sha512-lkYwWN3SRecpvaeqmFKkuPNR3ZbtnvHU+4XAEEkJdrp3JfSp2pBrhXOtvfsENUneye76g889Y0ddF2DM0gEDpA==}
+    peerDependencies:
+      tree-sitter: ^0.22.4
+    peerDependenciesMeta:
+      tree-sitter:
+        optional: true
+
+  tree-sitter-cpp@0.23.4:
+    resolution: {integrity: sha512-qR5qUDyhZ5jJ6V8/umiBxokRbe89bCGmcq/dk94wI4kN86qfdV8k0GHIUEKaqWgcu42wKal5E97LKpLeVW8sKw==}
+    peerDependencies:
+      tree-sitter: ^0.21.1
+    peerDependenciesMeta:
+      tree-sitter:
+        optional: true
+
+  tree-sitter-elixir@0.3.5:
+    resolution: {integrity: sha512-xozQMvYK0aSolcQZAx2d84Xe/YMWFuRPYFlLVxO01bM2GITh5jyiIp0TqPCQa8754UzRAI7A83hZmfiYub5TZQ==}
+    peerDependencies:
+      tree-sitter: ^0.21.0
+
+  tree-sitter-go@0.25.0:
+    resolution: {integrity: sha512-APBc/Dq3xz/e35Xpkhb1blu5UgW+2E3RyGWawZSCNcbGwa7jhSQPS8KsUupuzBla8PCo8+lz9W/JDJjmfRa2tw==}
+    peerDependencies:
+      tree-sitter: ^0.25.0
+    peerDependenciesMeta:
+      tree-sitter:
+        optional: true
+
+  tree-sitter-java@0.23.5:
+    resolution: {integrity: sha512-Yju7oQ0Xx7GcUT01mUglPP+bYfvqjNCGdxqigTnew9nLGoII42PNVP3bHrYeMxswiCRM0yubWmN5qk+zsg0zMA==}
+    peerDependencies:
+      tree-sitter: ^0.21.1
+    peerDependenciesMeta:
+      tree-sitter:
+        optional: true
+
+  tree-sitter-javascript@0.23.1:
+    resolution: {integrity: sha512-/bnhbrTD9frUYHQTiYnPcxyHORIw157ERBa6dqzaKxvR/x3PC4Yzd+D1pZIMS6zNg2v3a8BZ0oK7jHqsQo9fWA==}
+    peerDependencies:
+      tree-sitter: ^0.21.1
+    peerDependenciesMeta:
+      tree-sitter:
+        optional: true
+
+  tree-sitter-javascript@0.25.0:
+    resolution: {integrity: sha512-1fCbmzAskZkxcZzN41sFZ2br2iqTYP3tKls1b/HKGNPQUVOpsUxpmGxdN/wMqAk3jYZnYBR1dd/y/0avMeU7dw==}
+    peerDependencies:
+      tree-sitter: ^0.25.0
+    peerDependenciesMeta:
+      tree-sitter:
+        optional: true
+
+  tree-sitter-php@0.24.2:
+    resolution: {integrity: sha512-zwgAePc/HozNaWOOfwRAA+3p8yhuehRw8Fb7vn5qd2XjiIc93uJPryDTMYTSjBRjVIUg/KY6pM3rRzs8dSwKfw==}
+    peerDependencies:
+      tree-sitter: ^0.22.4
+    peerDependenciesMeta:
+      tree-sitter:
+        optional: true
+
+  tree-sitter-python@0.25.0:
+    resolution: {integrity: sha512-eCmJx6zQa35GxaCtQD+wXHOhYqBxEL+bp71W/s3fcDMu06MrtzkVXR437dRrCrbrDbyLuUDJpAgycs7ncngLXw==}
+    peerDependencies:
+      tree-sitter: ^0.25.0
+    peerDependenciesMeta:
+      tree-sitter:
+        optional: true
+
+  tree-sitter-ruby@0.23.1:
+    resolution: {integrity: sha512-d9/RXgWjR6HanN7wTYhS5bpBQLz1VkH048Vm3CodPGyJVnamXMGb8oEhDypVCBq4QnHui9sTXuJBBP3WtCw5RA==}
+    peerDependencies:
+      tree-sitter: ^0.21.1
+    peerDependenciesMeta:
+      tree-sitter:
+        optional: true
+
+  tree-sitter-rust@0.24.0:
+    resolution: {integrity: sha512-NWemUDf629Tfc90Y0Z55zuwPCAHkLxWnMf2RznYu4iBkkrQl2o/CHGB7Cr52TyN5F1DAx8FmUnDtCy9iUkXZEQ==}
+    peerDependencies:
+      tree-sitter: ^0.22.1
+    peerDependenciesMeta:
+      tree-sitter:
+        optional: true
+
+  tree-sitter-typescript@0.23.2:
+    resolution: {integrity: sha512-e04JUUKxTT53/x3Uq1zIL45DoYKVfHH4CZqwgZhPg5qYROl5nQjV+85ruFzFGZxu+QeFVbRTPDRnqL9UbU4VeA==}
+    peerDependencies:
+      tree-sitter: ^0.21.0
+    peerDependenciesMeta:
+      tree-sitter:
+        optional: true
 
   ts-algebra@2.0.0:
     resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
@@ -2229,16 +1808,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  uint8array-extras@1.5.0:
-    resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
-    engines: {node: '>=18'}
-
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
-
-  undici@7.25.0:
-    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
-    engines: {node: '>=20.18.1'}
 
   undici@8.3.0:
     resolution: {integrity: sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==}
@@ -2251,13 +1822,12 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
-  uuid@14.0.0:
-    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
-    hasBin: true
-
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
+
+  web-tree-sitter@0.25.6:
+    resolution: {integrity: sha512-WG+/YGbxw8r+rLlzzhV+OvgiOJCWdIpOucG3qBf3RCBFMkGDb1CanUi2BxCxjnkpzU3/hLWPT8VO5EKsMk9Fxg==}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -2267,13 +1837,6 @@ packages:
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
-
-  wrap-ansi@7.0.0:
-    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
-    engines: {node: '>=10'}
-
-  wrappy@1.0.2:
-    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   ws@8.20.0:
     resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
@@ -2287,30 +1850,10 @@ packages:
       utf-8-validate:
         optional: true
 
-  y18n@5.0.8:
-    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
-    engines: {node: '>=10'}
-
-  yaml@2.8.4:
-    resolution: {integrity: sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==}
-    engines: {node: '>= 14.6'}
-    hasBin: true
-
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
     hasBin: true
-
-  yargs-parser@20.2.9:
-    resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
-    engines: {node: '>=10'}
-
-  yargs@16.2.0:
-    resolution: {integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==}
-    engines: {node: '>=10'}
-
-  yauzl@2.10.0:
-    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -2363,58 +1906,6 @@ snapshots:
       '@aws-sdk/types': 3.973.9
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
-
-  '@aws-sdk/client-bedrock-runtime@3.1043.0':
-    dependencies:
-      '@aws-crypto/sha256-browser': 5.2.0
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.14
-      '@aws-sdk/credential-provider-node': 3.972.45
-      '@aws-sdk/eventstream-handler-node': 3.972.17
-      '@aws-sdk/middleware-eventstream': 3.972.13
-      '@aws-sdk/middleware-host-header': 3.972.10
-      '@aws-sdk/middleware-logger': 3.972.10
-      '@aws-sdk/middleware-recursion-detection': 3.972.11
-      '@aws-sdk/middleware-user-agent': 3.972.38
-      '@aws-sdk/middleware-websocket': 3.972.22
-      '@aws-sdk/region-config-resolver': 3.972.13
-      '@aws-sdk/token-providers': 3.1043.0
-      '@aws-sdk/types': 3.973.9
-      '@aws-sdk/util-endpoints': 3.996.8
-      '@aws-sdk/util-user-agent-browser': 3.972.10
-      '@aws-sdk/util-user-agent-node': 3.973.24
-      '@smithy/config-resolver': 4.4.17
-      '@smithy/core': 3.24.4
-      '@smithy/eventstream-serde-browser': 4.2.14
-      '@smithy/eventstream-serde-config-resolver': 4.3.14
-      '@smithy/eventstream-serde-node': 4.2.14
-      '@smithy/fetch-http-handler': 5.4.4
-      '@smithy/hash-node': 4.2.14
-      '@smithy/invalid-dependency': 4.2.14
-      '@smithy/middleware-content-length': 4.2.14
-      '@smithy/middleware-endpoint': 4.4.32
-      '@smithy/middleware-retry': 4.5.7
-      '@smithy/middleware-serde': 4.2.20
-      '@smithy/middleware-stack': 4.2.14
-      '@smithy/node-config-provider': 4.3.14
-      '@smithy/node-http-handler': 4.7.3
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/smithy-client': 4.12.13
-      '@smithy/types': 4.14.2
-      '@smithy/url-parser': 4.2.14
-      '@smithy/util-base64': 4.3.2
-      '@smithy/util-body-length-browser': 4.2.2
-      '@smithy/util-body-length-node': 4.2.3
-      '@smithy/util-defaults-mode-browser': 4.3.49
-      '@smithy/util-defaults-mode-node': 4.2.54
-      '@smithy/util-endpoints': 3.4.2
-      '@smithy/util-middleware': 4.2.14
-      '@smithy/util-retry': 4.3.8
-      '@smithy/util-stream': 4.5.25
-      '@smithy/util-utf8': 4.2.2
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
 
   '@aws-sdk/client-bedrock-runtime@3.1048.0':
     dependencies:
@@ -2542,38 +2033,6 @@ snapshots:
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-host-header@3.972.10':
-    dependencies:
-      '@aws-sdk/types': 3.973.9
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/types': 4.14.2
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-logger@3.972.10':
-    dependencies:
-      '@aws-sdk/types': 3.973.9
-      '@smithy/types': 4.14.2
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-recursion-detection@3.972.11':
-    dependencies:
-      '@aws-sdk/types': 3.973.9
-      '@aws/lambda-invoke-store': 0.2.4
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/types': 4.14.2
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-user-agent@3.972.38':
-    dependencies:
-      '@aws-sdk/core': 3.974.14
-      '@aws-sdk/types': 3.973.9
-      '@aws-sdk/util-endpoints': 3.996.8
-      '@smithy/core': 3.24.4
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/types': 4.14.2
-      '@smithy/util-retry': 4.3.8
-      tslib: 2.8.1
-
   '@aws-sdk/middleware-websocket@3.972.22':
     dependencies:
       '@aws-sdk/core': 3.974.14
@@ -2597,28 +2056,10 @@ snapshots:
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
-  '@aws-sdk/region-config-resolver@3.972.13':
-    dependencies:
-      '@aws-sdk/types': 3.973.9
-      '@smithy/config-resolver': 4.4.17
-      '@smithy/node-config-provider': 4.3.14
-      '@smithy/types': 4.14.2
-      tslib: 2.8.1
-
   '@aws-sdk/signature-v4-multi-region@3.996.29':
     dependencies:
       '@aws-sdk/types': 3.973.9
       '@smithy/signature-v4': 5.4.4
-      '@smithy/types': 4.14.2
-      tslib: 2.8.1
-
-  '@aws-sdk/token-providers@3.1043.0':
-    dependencies:
-      '@aws-sdk/core': 3.974.14
-      '@aws-sdk/nested-clients': 3.997.12
-      '@aws-sdk/types': 3.973.9
-      '@smithy/property-provider': 4.2.14
-      '@smithy/shared-ini-file-loader': 4.4.9
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
@@ -2645,32 +2086,8 @@ snapshots:
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
-  '@aws-sdk/util-endpoints@3.996.8':
-    dependencies:
-      '@aws-sdk/types': 3.973.9
-      '@smithy/types': 4.14.2
-      '@smithy/url-parser': 4.2.14
-      '@smithy/util-endpoints': 3.4.2
-      tslib: 2.8.1
-
   '@aws-sdk/util-locate-window@3.965.5':
     dependencies:
-      tslib: 2.8.1
-
-  '@aws-sdk/util-user-agent-browser@3.972.10':
-    dependencies:
-      '@aws-sdk/types': 3.973.9
-      '@smithy/types': 4.14.2
-      bowser: 2.14.1
-      tslib: 2.8.1
-
-  '@aws-sdk/util-user-agent-node@3.973.24':
-    dependencies:
-      '@aws-sdk/middleware-user-agent': 3.972.38
-      '@aws-sdk/types': 3.973.9
-      '@smithy/node-config-provider': 4.3.14
-      '@smithy/types': 4.14.2
-      '@smithy/util-config-provider': 4.2.2
       tslib: 2.8.1
 
   '@aws-sdk/xml-builder@3.972.26':
@@ -2682,63 +2099,6 @@ snapshots:
   '@aws/lambda-invoke-store@0.2.4': {}
 
   '@babel/runtime@7.29.2': {}
-
-  '@borewit/text-codec@0.2.2': {}
-
-  '@earendil-works/pi-agent-core@0.74.0(ws@8.20.0)(zod@4.4.3)':
-    dependencies:
-      '@earendil-works/pi-ai': 0.74.0(ws@8.20.0)(zod@4.4.3)
-      typebox: 1.1.38
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - aws-crt
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
-  '@earendil-works/pi-agent-core@0.75.5(ws@8.20.0)(zod@4.4.3)':
-    dependencies:
-      '@earendil-works/pi-ai': 0.75.5(ws@8.20.0)(zod@4.4.3)
-      ignore: 7.0.5
-      typebox: 1.1.38
-      yaml: 2.9.0
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
-  '@earendil-works/pi-agent-core@0.78.1(ws@8.20.0)(zod@4.4.3)':
-    dependencies:
-      '@earendil-works/pi-ai': 0.78.1(ws@8.20.0)(zod@4.4.3)
-      ignore: 7.0.5
-      typebox: 1.1.38
-      yaml: 2.9.0
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
-  '@earendil-works/pi-agent-core@0.79.0':
-    dependencies:
-      '@earendil-works/pi-ai': 0.79.6(ws@8.20.0)(zod@4.4.3)
-      ignore: 7.0.5
-      typebox: 1.1.38
-      yaml: 2.9.0
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
 
   '@earendil-works/pi-agent-core@0.79.5':
     dependencies:
@@ -2774,68 +2134,6 @@ snapshots:
       ignore: 7.0.5
       typebox: 1.1.38
       yaml: 2.9.0
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
-  '@earendil-works/pi-ai@0.74.0(ws@8.20.0)(zod@4.4.3)':
-    dependencies:
-      '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
-      '@aws-sdk/client-bedrock-runtime': 3.1043.0
-      '@google/genai': 1.52.0
-      '@mistralai/mistralai': 2.2.1
-      chalk: 5.6.2
-      openai: 6.26.0(ws@8.20.0)(zod@4.4.3)
-      partial-json: 0.1.7
-      proxy-agent: 6.5.0
-      typebox: 1.1.38
-      undici: 7.25.0
-      zod-to-json-schema: 3.25.2(zod@4.4.3)
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - aws-crt
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
-  '@earendil-works/pi-ai@0.75.5(ws@8.20.0)(zod@4.4.3)':
-    dependencies:
-      '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
-      '@aws-sdk/client-bedrock-runtime': 3.1048.0
-      '@google/genai': 1.52.0
-      '@mistralai/mistralai': 2.2.1
-      '@smithy/node-http-handler': 4.7.3
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
-      openai: 6.26.0(ws@8.20.0)(zod@4.4.3)
-      partial-json: 0.1.7
-      typebox: 1.1.38
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
-  '@earendil-works/pi-ai@0.78.1(ws@8.20.0)(zod@4.4.3)':
-    dependencies:
-      '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
-      '@aws-sdk/client-bedrock-runtime': 3.1048.0
-      '@google/genai': 1.52.0
-      '@mistralai/mistralai': 2.2.1
-      '@smithy/node-http-handler': 4.7.3
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
-      openai: 6.26.0(ws@8.20.0)(zod@4.4.3)
-      partial-json: 0.1.7
-      typebox: 1.1.38
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - bufferutil
@@ -2897,127 +2195,6 @@ snapshots:
       openai: 6.26.0(ws@8.20.0)(zod@4.4.3)
       partial-json: 0.1.7
       typebox: 1.1.38
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
-  '@earendil-works/pi-coding-agent@0.74.0(ws@8.20.0)(zod@4.4.3)':
-    dependencies:
-      '@earendil-works/pi-agent-core': 0.74.0(ws@8.20.0)(zod@4.4.3)
-      '@earendil-works/pi-ai': 0.74.0(ws@8.20.0)(zod@4.4.3)
-      '@earendil-works/pi-tui': 0.79.5
-      '@silvia-odwyer/photon-node': 0.3.4
-      chalk: 5.6.2
-      cli-highlight: 2.1.11
-      diff: 8.0.4
-      extract-zip: 2.0.1
-      file-type: 21.3.4
-      glob: 13.0.6
-      hosted-git-info: 9.0.3
-      ignore: 7.0.5
-      jiti: 2.7.0
-      marked: 15.0.12
-      minimatch: 10.2.5
-      proper-lockfile: 4.1.2
-      strip-ansi: 7.2.0
-      typebox: 1.1.38
-      undici: 7.25.0
-      uuid: 14.0.0
-      yaml: 2.8.4
-    optionalDependencies:
-      '@mariozechner/clipboard': 0.3.5
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - aws-crt
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
-  '@earendil-works/pi-coding-agent@0.75.5(ws@8.20.0)(zod@4.4.3)':
-    dependencies:
-      '@earendil-works/pi-agent-core': 0.75.5(ws@8.20.0)(zod@4.4.3)
-      '@earendil-works/pi-ai': 0.75.5(ws@8.20.0)(zod@4.4.3)
-      '@earendil-works/pi-tui': 0.79.5
-      '@silvia-odwyer/photon-node': 0.3.4
-      chalk: 5.6.2
-      cross-spawn: 7.0.6
-      diff: 8.0.4
-      glob: 13.0.6
-      highlight.js: 10.7.3
-      hosted-git-info: 9.0.3
-      ignore: 7.0.5
-      jiti: 2.7.0
-      minimatch: 10.2.5
-      proper-lockfile: 4.1.2
-      typebox: 1.1.38
-      undici: 8.3.0
-      yaml: 2.9.0
-    optionalDependencies:
-      '@mariozechner/clipboard': 0.3.6
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
-  '@earendil-works/pi-coding-agent@0.78.1(ws@8.20.0)(zod@4.4.3)':
-    dependencies:
-      '@earendil-works/pi-agent-core': 0.78.1(ws@8.20.0)(zod@4.4.3)
-      '@earendil-works/pi-ai': 0.78.1(ws@8.20.0)(zod@4.4.3)
-      '@earendil-works/pi-tui': 0.79.5
-      '@silvia-odwyer/photon-node': 0.3.4
-      chalk: 5.6.2
-      cross-spawn: 7.0.6
-      diff: 8.0.4
-      glob: 13.0.6
-      highlight.js: 10.7.3
-      hosted-git-info: 9.0.3
-      ignore: 7.0.5
-      jiti: 2.7.0
-      minimatch: 10.2.5
-      proper-lockfile: 4.1.2
-      typebox: 1.1.38
-      undici: 8.3.0
-      yaml: 2.9.0
-    optionalDependencies:
-      '@mariozechner/clipboard': 0.3.9
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
-  '@earendil-works/pi-coding-agent@0.79.0':
-    dependencies:
-      '@earendil-works/pi-agent-core': 0.79.0
-      '@earendil-works/pi-ai': 0.79.6(ws@8.20.0)(zod@4.4.3)
-      '@earendil-works/pi-tui': 0.79.5
-      '@silvia-odwyer/photon-node': 0.3.4
-      chalk: 5.6.2
-      cross-spawn: 7.0.6
-      diff: 8.0.4
-      glob: 13.0.6
-      highlight.js: 10.7.3
-      hosted-git-info: 9.0.3
-      ignore: 7.0.5
-      jiti: 2.7.0
-      minimatch: 10.2.5
-      proper-lockfile: 4.1.2
-      typebox: 1.1.38
-      undici: 8.3.0
-      yaml: 2.9.0
-    optionalDependencies:
-      '@mariozechner/clipboard': 0.3.9
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - bufferutil
@@ -3312,122 +2489,34 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
-  '@mariozechner/clipboard-darwin-arm64@0.3.2':
-    optional: true
-
-  '@mariozechner/clipboard-darwin-arm64@0.3.6':
-    optional: true
-
   '@mariozechner/clipboard-darwin-arm64@0.3.9':
-    optional: true
-
-  '@mariozechner/clipboard-darwin-universal@0.3.2':
-    optional: true
-
-  '@mariozechner/clipboard-darwin-universal@0.3.6':
     optional: true
 
   '@mariozechner/clipboard-darwin-universal@0.3.9':
     optional: true
 
-  '@mariozechner/clipboard-darwin-x64@0.3.2':
-    optional: true
-
-  '@mariozechner/clipboard-darwin-x64@0.3.6':
-    optional: true
-
   '@mariozechner/clipboard-darwin-x64@0.3.9':
-    optional: true
-
-  '@mariozechner/clipboard-linux-arm64-gnu@0.3.2':
-    optional: true
-
-  '@mariozechner/clipboard-linux-arm64-gnu@0.3.6':
     optional: true
 
   '@mariozechner/clipboard-linux-arm64-gnu@0.3.9':
     optional: true
 
-  '@mariozechner/clipboard-linux-arm64-musl@0.3.2':
-    optional: true
-
-  '@mariozechner/clipboard-linux-arm64-musl@0.3.6':
-    optional: true
-
   '@mariozechner/clipboard-linux-arm64-musl@0.3.9':
-    optional: true
-
-  '@mariozechner/clipboard-linux-riscv64-gnu@0.3.2':
-    optional: true
-
-  '@mariozechner/clipboard-linux-riscv64-gnu@0.3.6':
     optional: true
 
   '@mariozechner/clipboard-linux-riscv64-gnu@0.3.9':
     optional: true
 
-  '@mariozechner/clipboard-linux-x64-gnu@0.3.2':
-    optional: true
-
-  '@mariozechner/clipboard-linux-x64-gnu@0.3.6':
-    optional: true
-
   '@mariozechner/clipboard-linux-x64-gnu@0.3.9':
-    optional: true
-
-  '@mariozechner/clipboard-linux-x64-musl@0.3.2':
-    optional: true
-
-  '@mariozechner/clipboard-linux-x64-musl@0.3.6':
     optional: true
 
   '@mariozechner/clipboard-linux-x64-musl@0.3.9':
     optional: true
 
-  '@mariozechner/clipboard-win32-arm64-msvc@0.3.2':
-    optional: true
-
-  '@mariozechner/clipboard-win32-arm64-msvc@0.3.6':
-    optional: true
-
   '@mariozechner/clipboard-win32-arm64-msvc@0.3.9':
     optional: true
 
-  '@mariozechner/clipboard-win32-x64-msvc@0.3.2':
-    optional: true
-
-  '@mariozechner/clipboard-win32-x64-msvc@0.3.6':
-    optional: true
-
   '@mariozechner/clipboard-win32-x64-msvc@0.3.9':
-    optional: true
-
-  '@mariozechner/clipboard@0.3.5':
-    optionalDependencies:
-      '@mariozechner/clipboard-darwin-arm64': 0.3.2
-      '@mariozechner/clipboard-darwin-universal': 0.3.2
-      '@mariozechner/clipboard-darwin-x64': 0.3.2
-      '@mariozechner/clipboard-linux-arm64-gnu': 0.3.2
-      '@mariozechner/clipboard-linux-arm64-musl': 0.3.2
-      '@mariozechner/clipboard-linux-riscv64-gnu': 0.3.2
-      '@mariozechner/clipboard-linux-x64-gnu': 0.3.2
-      '@mariozechner/clipboard-linux-x64-musl': 0.3.2
-      '@mariozechner/clipboard-win32-arm64-msvc': 0.3.2
-      '@mariozechner/clipboard-win32-x64-msvc': 0.3.2
-    optional: true
-
-  '@mariozechner/clipboard@0.3.6':
-    optionalDependencies:
-      '@mariozechner/clipboard-darwin-arm64': 0.3.6
-      '@mariozechner/clipboard-darwin-universal': 0.3.6
-      '@mariozechner/clipboard-darwin-x64': 0.3.6
-      '@mariozechner/clipboard-linux-arm64-gnu': 0.3.6
-      '@mariozechner/clipboard-linux-arm64-musl': 0.3.6
-      '@mariozechner/clipboard-linux-riscv64-gnu': 0.3.6
-      '@mariozechner/clipboard-linux-x64-gnu': 0.3.6
-      '@mariozechner/clipboard-linux-x64-musl': 0.3.6
-      '@mariozechner/clipboard-win32-arm64-msvc': 0.3.6
-      '@mariozechner/clipboard-win32-x64-msvc': 0.3.6
     optional: true
 
   '@mariozechner/clipboard@0.3.9':
@@ -3534,15 +2623,6 @@ snapshots:
       - debug
       - supports-color
 
-  '@smithy/config-resolver@4.4.17':
-    dependencies:
-      '@smithy/node-config-provider': 4.3.14
-      '@smithy/types': 4.14.2
-      '@smithy/util-config-provider': 4.2.2
-      '@smithy/util-endpoints': 3.4.2
-      '@smithy/util-middleware': 4.2.14
-      tslib: 2.8.1
-
   '@smithy/core@3.24.4':
     dependencies:
       '@aws-crypto/crc32': 5.2.0
@@ -3555,51 +2635,9 @@ snapshots:
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
-  '@smithy/eventstream-codec@4.2.14':
-    dependencies:
-      '@aws-crypto/crc32': 5.2.0
-      '@smithy/types': 4.14.2
-      '@smithy/util-hex-encoding': 4.2.2
-      tslib: 2.8.1
-
-  '@smithy/eventstream-serde-browser@4.2.14':
-    dependencies:
-      '@smithy/eventstream-serde-universal': 4.2.14
-      '@smithy/types': 4.14.2
-      tslib: 2.8.1
-
-  '@smithy/eventstream-serde-config-resolver@4.3.14':
-    dependencies:
-      '@smithy/types': 4.14.2
-      tslib: 2.8.1
-
-  '@smithy/eventstream-serde-node@4.2.14':
-    dependencies:
-      '@smithy/eventstream-serde-universal': 4.2.14
-      '@smithy/types': 4.14.2
-      tslib: 2.8.1
-
-  '@smithy/eventstream-serde-universal@4.2.14':
-    dependencies:
-      '@smithy/eventstream-codec': 4.2.14
-      '@smithy/types': 4.14.2
-      tslib: 2.8.1
-
   '@smithy/fetch-http-handler@5.4.4':
     dependencies:
       '@smithy/core': 3.24.4
-      '@smithy/types': 4.14.2
-      tslib: 2.8.1
-
-  '@smithy/hash-node@4.2.14':
-    dependencies:
-      '@smithy/types': 4.14.2
-      '@smithy/util-buffer-from': 4.2.2
-      '@smithy/util-utf8': 4.2.2
-      tslib: 2.8.1
-
-  '@smithy/invalid-dependency@4.2.14':
-    dependencies:
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
@@ -3607,86 +2645,9 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@smithy/is-array-buffer@4.2.2':
-    dependencies:
-      tslib: 2.8.1
-
-  '@smithy/middleware-content-length@4.2.14':
-    dependencies:
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/types': 4.14.2
-      tslib: 2.8.1
-
-  '@smithy/middleware-endpoint@4.4.32':
-    dependencies:
-      '@smithy/core': 3.24.4
-      '@smithy/middleware-serde': 4.2.20
-      '@smithy/node-config-provider': 4.3.14
-      '@smithy/shared-ini-file-loader': 4.4.9
-      '@smithy/types': 4.14.2
-      '@smithy/url-parser': 4.2.14
-      '@smithy/util-middleware': 4.2.14
-      tslib: 2.8.1
-
-  '@smithy/middleware-retry@4.5.7':
-    dependencies:
-      '@smithy/core': 3.24.4
-      '@smithy/node-config-provider': 4.3.14
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/service-error-classification': 4.3.1
-      '@smithy/smithy-client': 4.12.13
-      '@smithy/types': 4.14.2
-      '@smithy/util-middleware': 4.2.14
-      '@smithy/util-retry': 4.3.8
-      '@smithy/uuid': 1.1.2
-      tslib: 2.8.1
-
-  '@smithy/middleware-serde@4.2.20':
-    dependencies:
-      '@smithy/core': 3.24.4
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/types': 4.14.2
-      tslib: 2.8.1
-
-  '@smithy/middleware-stack@4.2.14':
-    dependencies:
-      '@smithy/types': 4.14.2
-      tslib: 2.8.1
-
-  '@smithy/node-config-provider@4.3.14':
-    dependencies:
-      '@smithy/property-provider': 4.2.14
-      '@smithy/shared-ini-file-loader': 4.4.9
-      '@smithy/types': 4.14.2
-      tslib: 2.8.1
-
   '@smithy/node-http-handler@4.7.3':
     dependencies:
       '@smithy/core': 3.24.4
-      '@smithy/types': 4.14.2
-      tslib: 2.8.1
-
-  '@smithy/property-provider@4.2.14':
-    dependencies:
-      '@smithy/types': 4.14.2
-      tslib: 2.8.1
-
-  '@smithy/protocol-http@5.3.14':
-    dependencies:
-      '@smithy/types': 4.14.2
-      tslib: 2.8.1
-
-  '@smithy/querystring-parser@4.2.14':
-    dependencies:
-      '@smithy/types': 4.14.2
-      tslib: 2.8.1
-
-  '@smithy/service-error-classification@4.3.1':
-    dependencies:
-      '@smithy/types': 4.14.2
-
-  '@smithy/shared-ini-file-loader@4.4.9':
-    dependencies:
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
@@ -3696,37 +2657,7 @@ snapshots:
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
-  '@smithy/smithy-client@4.12.13':
-    dependencies:
-      '@smithy/core': 3.24.4
-      '@smithy/middleware-endpoint': 4.4.32
-      '@smithy/middleware-stack': 4.2.14
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/types': 4.14.2
-      '@smithy/util-stream': 4.5.25
-      tslib: 2.8.1
-
   '@smithy/types@4.14.2':
-    dependencies:
-      tslib: 2.8.1
-
-  '@smithy/url-parser@4.2.14':
-    dependencies:
-      '@smithy/querystring-parser': 4.2.14
-      '@smithy/types': 4.14.2
-      tslib: 2.8.1
-
-  '@smithy/util-base64@4.3.2':
-    dependencies:
-      '@smithy/util-buffer-from': 4.2.2
-      '@smithy/util-utf8': 4.2.2
-      tslib: 2.8.1
-
-  '@smithy/util-body-length-browser@4.2.2':
-    dependencies:
-      tslib: 2.8.1
-
-  '@smithy/util-body-length-node@4.2.3':
     dependencies:
       tslib: 2.8.1
 
@@ -3735,88 +2666,16 @@ snapshots:
       '@smithy/is-array-buffer': 2.2.0
       tslib: 2.8.1
 
-  '@smithy/util-buffer-from@4.2.2':
-    dependencies:
-      '@smithy/is-array-buffer': 4.2.2
-      tslib: 2.8.1
-
-  '@smithy/util-config-provider@4.2.2':
-    dependencies:
-      tslib: 2.8.1
-
-  '@smithy/util-defaults-mode-browser@4.3.49':
-    dependencies:
-      '@smithy/property-provider': 4.2.14
-      '@smithy/smithy-client': 4.12.13
-      '@smithy/types': 4.14.2
-      tslib: 2.8.1
-
-  '@smithy/util-defaults-mode-node@4.2.54':
-    dependencies:
-      '@smithy/config-resolver': 4.4.17
-      '@smithy/credential-provider-imds': 4.3.4
-      '@smithy/node-config-provider': 4.3.14
-      '@smithy/property-provider': 4.2.14
-      '@smithy/smithy-client': 4.12.13
-      '@smithy/types': 4.14.2
-      tslib: 2.8.1
-
-  '@smithy/util-endpoints@3.4.2':
-    dependencies:
-      '@smithy/node-config-provider': 4.3.14
-      '@smithy/types': 4.14.2
-      tslib: 2.8.1
-
-  '@smithy/util-hex-encoding@4.2.2':
-    dependencies:
-      tslib: 2.8.1
-
-  '@smithy/util-middleware@4.2.14':
-    dependencies:
-      '@smithy/types': 4.14.2
-      tslib: 2.8.1
-
-  '@smithy/util-retry@4.3.8':
-    dependencies:
-      '@smithy/service-error-classification': 4.3.1
-      '@smithy/types': 4.14.2
-      tslib: 2.8.1
-
-  '@smithy/util-stream@4.5.25':
-    dependencies:
-      '@smithy/fetch-http-handler': 5.4.4
-      '@smithy/node-http-handler': 4.7.3
-      '@smithy/types': 4.14.2
-      '@smithy/util-base64': 4.3.2
-      '@smithy/util-buffer-from': 4.2.2
-      '@smithy/util-hex-encoding': 4.2.2
-      '@smithy/util-utf8': 4.2.2
-      tslib: 2.8.1
-
   '@smithy/util-utf8@2.3.0':
     dependencies:
       '@smithy/util-buffer-from': 2.2.0
       tslib: 2.8.1
 
-  '@smithy/util-utf8@4.2.2':
+  '@tree-sitter-grammars/tree-sitter-kotlin@1.1.0':
     dependencies:
-      '@smithy/util-buffer-from': 4.2.2
-      tslib: 2.8.1
-
-  '@smithy/uuid@1.1.2':
-    dependencies:
-      tslib: 2.8.1
-
-  '@tokenizer/inflate@0.4.1':
-    dependencies:
-      debug: 4.4.3
-      token-types: 6.1.2
-    transitivePeerDependencies:
-      - supports-color
-
-  '@tokenizer/token@0.3.0': {}
-
-  '@tootallnate/quickjs-emscripten@0.23.0': {}
+      node-addon-api: 8.9.0
+      node-gyp-build: 4.8.4
+      npm-check-updates: 17.1.18
 
   '@types/esrecurse@4.3.1': {}
 
@@ -3833,11 +2692,6 @@ snapshots:
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 20.19.39
-
-  '@types/yauzl@2.10.3':
-    dependencies:
-      '@types/node': 20.19.39
-    optional: true
 
   '@typescript-eslint/eslint-plugin@8.59.3(@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.4.0(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
@@ -3951,20 +2805,6 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
-  ansi-regex@5.0.1: {}
-
-  ansi-regex@6.2.2: {}
-
-  ansi-styles@4.3.0:
-    dependencies:
-      color-convert: 2.0.1
-
-  any-promise@1.3.0: {}
-
-  ast-types@0.13.4:
-    dependencies:
-      tslib: 2.8.1
-
   asynckit@0.4.0: {}
 
   axios@1.18.1:
@@ -3981,8 +2821,6 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  basic-ftp@5.3.1: {}
-
   bignumber.js@9.3.1: {}
 
   bowser@2.14.1: {}
@@ -3991,8 +2829,6 @@ snapshots:
     dependencies:
       balanced-match: 4.0.4
 
-  buffer-crc32@0.2.13: {}
-
   buffer-equal-constant-time@1.0.1: {}
 
   call-bind-apply-helpers@1.0.2:
@@ -4000,33 +2836,7 @@ snapshots:
       es-errors: 1.3.0
       function-bind: 1.1.2
 
-  chalk@4.1.2:
-    dependencies:
-      ansi-styles: 4.3.0
-      supports-color: 7.2.0
-
   chalk@5.6.2: {}
-
-  cli-highlight@2.1.11:
-    dependencies:
-      chalk: 4.1.2
-      highlight.js: 10.7.3
-      mz: 2.7.0
-      parse5: 5.1.1
-      parse5-htmlparser2-tree-adapter: 6.0.1
-      yargs: 16.2.0
-
-  cliui@7.0.4:
-    dependencies:
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      wrap-ansi: 7.0.0
-
-  color-convert@2.0.1:
-    dependencies:
-      color-name: 1.1.4
-
-  color-name@1.1.4: {}
 
   combined-stream@1.0.8:
     dependencies:
@@ -4040,19 +2850,11 @@ snapshots:
 
   data-uri-to-buffer@4.0.1: {}
 
-  data-uri-to-buffer@6.0.2: {}
-
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
 
   deep-is@0.1.4: {}
-
-  degenerator@5.0.1:
-    dependencies:
-      ast-types: 0.13.4
-      escodegen: 2.1.0
-      esprima: 4.0.1
 
   delayed-stream@1.0.0: {}
 
@@ -4070,12 +2872,6 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
-  emoji-regex@8.0.0: {}
-
-  end-of-stream@1.4.5:
-    dependencies:
-      once: 1.4.0
-
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
@@ -4091,17 +2887,7 @@ snapshots:
       has-tostringtag: 1.0.2
       hasown: 2.0.4
 
-  escalade@3.2.0: {}
-
   escape-string-regexp@4.0.0: {}
-
-  escodegen@2.1.0:
-    dependencies:
-      esprima: 4.0.1
-      estraverse: 5.3.0
-      esutils: 2.0.3
-    optionalDependencies:
-      source-map: 0.6.1
 
   eslint-scope@9.1.2:
     dependencies:
@@ -4157,8 +2943,6 @@ snapshots:
       acorn-jsx: 5.3.2(acorn@8.16.0)
       eslint-visitor-keys: 5.0.1
 
-  esprima@4.0.1: {}
-
   esquery@1.7.0:
     dependencies:
       estraverse: 5.3.0
@@ -4177,16 +2961,6 @@ snapshots:
 
   extend@3.0.2: {}
 
-  extract-zip@2.0.1:
-    dependencies:
-      debug: 4.4.3
-      get-stream: 5.2.0
-      yauzl: 2.10.0
-    optionalDependencies:
-      '@types/yauzl': 2.10.3
-    transitivePeerDependencies:
-      - supports-color
-
   fast-deep-equal@3.1.3: {}
 
   fast-json-stable-stringify@2.1.0: {}
@@ -4204,10 +2978,6 @@ snapshots:
       path-expression-matcher: 1.5.0
       strnum: 2.2.3
 
-  fd-slicer@1.1.0:
-    dependencies:
-      pend: 1.2.0
-
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
@@ -4220,15 +2990,6 @@ snapshots:
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
-
-  file-type@21.3.4:
-    dependencies:
-      '@tokenizer/inflate': 0.4.1
-      strtok3: 10.3.5
-      token-types: 6.1.2
-      uint8array-extras: 1.5.0
-    transitivePeerDependencies:
-      - supports-color
 
   find-up@5.0.0:
     dependencies:
@@ -4274,8 +3035,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  get-caller-file@2.0.5: {}
-
   get-east-asian-width@1.6.0: {}
 
   get-intrinsic@1.3.0:
@@ -4295,18 +3054,6 @@ snapshots:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.2
-
-  get-stream@5.2.0:
-    dependencies:
-      pump: 3.0.4
-
-  get-uri@6.0.5:
-    dependencies:
-      basic-ftp: 5.3.1
-      data-uri-to-buffer: 6.0.2
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
 
   glob-parent@6.0.2:
     dependencies:
@@ -4334,8 +3081,6 @@ snapshots:
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
-
-  has-flag@4.0.0: {}
 
   has-symbols@1.1.0: {}
 
@@ -4374,21 +3119,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ieee754@1.2.1: {}
-
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
 
   imurmurhash@0.1.4: {}
 
-  ip-address@10.2.0: {}
-
   is-electron@2.2.2: {}
 
   is-extglob@2.1.1: {}
-
-  is-fullwidth-code-point@3.0.0: {}
 
   is-glob@4.0.3:
     dependencies:
@@ -4443,10 +3182,6 @@ snapshots:
 
   lru-cache@11.3.6: {}
 
-  lru-cache@7.18.3: {}
-
-  marked@15.0.12: {}
-
   marked@18.0.5: {}
 
   math-intrinsics@1.1.0: {}
@@ -4465,15 +3200,11 @@ snapshots:
 
   ms@2.1.3: {}
 
-  mz@2.7.0:
-    dependencies:
-      any-promise: 1.3.0
-      object-assign: 4.1.1
-      thenify-all: 1.6.0
-
   natural-compare@1.4.0: {}
 
-  netmask@2.1.1: {}
+  node-addon-api@7.1.1: {}
+
+  node-addon-api@8.9.0: {}
 
   node-domexception@1.0.0: {}
 
@@ -4483,11 +3214,9 @@ snapshots:
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
 
-  object-assign@4.1.1: {}
+  node-gyp-build@4.8.4: {}
 
-  once@1.4.0:
-    dependencies:
-      wrappy: 1.0.2
+  npm-check-updates@17.1.18: {}
 
   openai@6.26.0(ws@8.20.0)(zod@4.4.3):
     optionalDependencies:
@@ -4527,33 +3256,7 @@ snapshots:
     dependencies:
       p-finally: 1.0.0
 
-  pac-proxy-agent@7.2.0:
-    dependencies:
-      '@tootallnate/quickjs-emscripten': 0.23.0
-      agent-base: 7.1.4
-      debug: 4.4.3
-      get-uri: 6.0.5
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
-      pac-resolver: 7.0.1
-      socks-proxy-agent: 8.0.5
-    transitivePeerDependencies:
-      - supports-color
-
-  pac-resolver@7.0.1:
-    dependencies:
-      degenerator: 5.0.1
-      netmask: 2.1.1
-
   parse-diff@0.11.1: {}
-
-  parse5-htmlparser2-tree-adapter@6.0.1:
-    dependencies:
-      parse5: 6.0.1
-
-  parse5@5.1.1: {}
-
-  parse5@6.0.1: {}
 
   partial-json@0.1.7: {}
 
@@ -4567,8 +3270,6 @@ snapshots:
     dependencies:
       lru-cache: 11.3.6
       minipass: 7.1.3
-
-  pend@1.2.0: {}
 
   picomatch@4.0.4: {}
 
@@ -4595,31 +3296,9 @@ snapshots:
       '@types/node': 20.19.39
       long: 5.3.2
 
-  proxy-agent@6.5.0:
-    dependencies:
-      agent-base: 7.1.4
-      debug: 4.4.3
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
-      lru-cache: 7.18.3
-      pac-proxy-agent: 7.2.0
-      proxy-from-env: 1.1.0
-      socks-proxy-agent: 8.0.5
-    transitivePeerDependencies:
-      - supports-color
-
-  proxy-from-env@1.1.0: {}
-
   proxy-from-env@2.1.0: {}
 
-  pump@3.0.4:
-    dependencies:
-      end-of-stream: 1.4.5
-      once: 1.4.0
-
   punycode@2.3.1: {}
-
-  require-directory@2.1.1: {}
 
   retry@0.12.0: {}
 
@@ -4670,66 +3349,84 @@ snapshots:
 
   signal-exit@3.0.7: {}
 
-  smart-buffer@4.2.0: {}
-
-  socks-proxy-agent@8.0.5:
-    dependencies:
-      agent-base: 7.1.4
-      debug: 4.4.3
-      socks: 2.8.8
-    transitivePeerDependencies:
-      - supports-color
-
-  socks@2.8.8:
-    dependencies:
-      ip-address: 10.2.0
-      smart-buffer: 4.2.0
-
-  source-map@0.6.1:
-    optional: true
-
-  string-width@4.2.3:
-    dependencies:
-      emoji-regex: 8.0.0
-      is-fullwidth-code-point: 3.0.0
-      strip-ansi: 6.0.1
-
-  strip-ansi@6.0.1:
-    dependencies:
-      ansi-regex: 5.0.1
-
-  strip-ansi@7.2.0:
-    dependencies:
-      ansi-regex: 6.2.2
-
   strnum@2.2.3: {}
-
-  strtok3@10.3.5:
-    dependencies:
-      '@tokenizer/token': 0.3.0
-
-  supports-color@7.2.0:
-    dependencies:
-      has-flag: 4.0.0
-
-  thenify-all@1.6.0:
-    dependencies:
-      thenify: 3.3.1
-
-  thenify@3.3.1:
-    dependencies:
-      any-promise: 1.3.0
 
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
-  token-types@6.1.2:
+  tree-sitter-c-sharp@0.23.5:
     dependencies:
-      '@borewit/text-codec': 0.2.2
-      '@tokenizer/token': 0.3.0
-      ieee754: 1.2.1
+      node-addon-api: 8.9.0
+      node-gyp-build: 4.8.4
+
+  tree-sitter-c@0.23.6:
+    dependencies:
+      node-addon-api: 8.9.0
+      node-gyp-build: 4.8.4
+
+  tree-sitter-c@0.24.1:
+    dependencies:
+      node-addon-api: 8.9.0
+      node-gyp-build: 4.8.4
+
+  tree-sitter-cpp@0.23.4:
+    dependencies:
+      node-addon-api: 8.9.0
+      node-gyp-build: 4.8.4
+      tree-sitter-c: 0.23.6
+
+  tree-sitter-elixir@0.3.5:
+    dependencies:
+      node-addon-api: 7.1.1
+      node-gyp-build: 4.8.4
+
+  tree-sitter-go@0.25.0:
+    dependencies:
+      node-addon-api: 8.9.0
+      node-gyp-build: 4.8.4
+
+  tree-sitter-java@0.23.5:
+    dependencies:
+      node-addon-api: 8.9.0
+      node-gyp-build: 4.8.4
+
+  tree-sitter-javascript@0.23.1:
+    dependencies:
+      node-addon-api: 8.9.0
+      node-gyp-build: 4.8.4
+
+  tree-sitter-javascript@0.25.0:
+    dependencies:
+      node-addon-api: 8.9.0
+      node-gyp-build: 4.8.4
+
+  tree-sitter-php@0.24.2:
+    dependencies:
+      node-addon-api: 8.9.0
+      node-gyp-build: 4.8.4
+
+  tree-sitter-python@0.25.0:
+    dependencies:
+      node-addon-api: 8.9.0
+      node-gyp-build: 4.8.4
+
+  tree-sitter-ruby@0.23.1:
+    dependencies:
+      node-addon-api: 8.9.0
+      node-gyp-build: 4.8.4
+
+  tree-sitter-rust@0.24.0:
+    dependencies:
+      node-addon-api: 8.9.0
+      node-gyp-build: 4.8.4
+
+  tree-sitter-typescript@0.23.2:
+    dependencies:
+      node-addon-api: 8.9.0
+      node-gyp-build: 4.8.4
+      tree-sitter-javascript: 0.23.1
 
   ts-algebra@2.0.0: {}
 
@@ -4760,11 +3457,7 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  uint8array-extras@1.5.0: {}
-
   undici-types@6.21.0: {}
-
-  undici@7.25.0: {}
 
   undici@8.3.0: {}
 
@@ -4774,9 +3467,9 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  uuid@14.0.0: {}
-
   web-streams-polyfill@3.3.3: {}
+
+  web-tree-sitter@0.25.6: {}
 
   which@2.0.2:
     dependencies:
@@ -4784,38 +3477,9 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
-  wrap-ansi@7.0.0:
-    dependencies:
-      ansi-styles: 4.3.0
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-
-  wrappy@1.0.2: {}
-
   ws@8.20.0: {}
 
-  y18n@5.0.8: {}
-
-  yaml@2.8.4: {}
-
   yaml@2.9.0: {}
-
-  yargs-parser@20.2.9: {}
-
-  yargs@16.2.0:
-    dependencies:
-      cliui: 7.0.4
-      escalade: 3.2.0
-      get-caller-file: 2.0.5
-      require-directory: 2.1.1
-      string-width: 4.2.3
-      y18n: 5.0.8
-      yargs-parser: 20.2.9
-
-  yauzl@2.10.0:
-    dependencies:
-      buffer-crc32: 0.2.13
-      fd-slicer: 1.1.0
 
   yocto-queue@0.1.0: {}
 


### PR DESCRIPTION
## Summary

New Pi extension that gives the agent **semantic code search** across repositories via a `search_codebase` tool. Ask for code by concept ("where is subscription renewal handled") and get ranked results across every repo, even without knowing the exact symbol name.

How it works:
- On `session_start` it scans the git repos in the workspace and computes a content hash per file (a Merkle root per repo).
- It sends those hashes to the backend `/sync`, which returns only the files that changed since the last index. A newly added repo returns all its files, so new repos index automatically.
- Changed files are chunked and sent to `/index` in the background, with a status widget showing progress (`/codebase-hide` to silence, `/codebase-show` to restore).
- The `search_codebase` tool hits `/search` and returns ranked snippets with file paths and line numbers.

Auth: credentials persist in `~/.config/pi/codebase-credentials.json` and the access token auto-refreshes, so `/codebase-login` is a one-time step (same pattern as `pi-memory`).

## Vendor-neutral by design

The extension talks to a backend over a small HTTP contract — `PROTOCOL.md` + `openapi.yaml`. It has **no built-in backend URL** and fails loudly until `PI_CODEBASE_API_URL` is set, so the package carries no single company's infrastructure. A runnable `reference-backend/` ships with swappable `VectorStore` / `Embedder` interfaces (Qdrant + OpenAI adapters by default), so any team can self-host by `npm start` or by implementing the contract on their own stack.

The Árvore backend that implements this contract lives in `api-arvore` (companion PR).

## Commands

`/codebase-login`, `/codebase-logout`, `/codebase-search <query>`, `/codebase-reindex`, `/codebase-hide`, `/codebase-show`.

## What was tested

- `tsc --noEmit` clean on the client package and on the reference backend.
- `tsc` build of the client produces `dist/` cleanly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a codebase search extension with login/logout, search, hide/show, and reindex commands.
  * Added semantic indexing and search backed by a vector server, including repo/language filters and ranked result snippets.
  * Added a reference backend with `/health` plus authenticated `/sync`, `/index`, and `/search` endpoints, including a local dev auth flow.

* **Documentation**
  * Added a vendor-neutral protocol contract and an OpenAPI spec for backend compatibility.
  * Added README/setup guides for both the extension and reference backend.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->