### PR TITLE
pi-memory: status widget + resilience (v0.6.0)

### DIFF
--- a/packages/pi-memory/README.md
+++ b/packages/pi-memory/README.md
@@ -28,7 +28,7 @@ Memory is a single org-wide pool (cross-user). Two tiers: `raw` (episodic chat, 
 
 ## Status widget
 
-A persistent widget above the editor shows what the memory extension is doing in real time: `buscando memórias` (searching), `injetando contexto` (injecting retrieved context), `salvando memória` (saving), `capturando sessão` (background flush), `não logado`, `incognito`, or `falha` with the error message. Run `/hide-memory` to toggle it off (and again to bring it back).
+A persistent widget above the editor shows what the memory extension is doing in real time: `buscando memórias` (searching), `injetando contexto` (injecting retrieved context), `salvando memória` (saving), `capturando sessão` (background flush), `não logado`, `incognito`, or `falha` with the error message. During active states an animated braille spinner plays in place of the icon. Run `/hide-memory` to toggle it off (and again to bring it back).
 
 ## Resilience
 

--- a/packages/pi-memory/README.md
+++ b/packages/pi-memory/README.md
@@ -23,6 +23,18 @@ Memory is a single org-wide pool (cross-user). Two tiers: `raw` (episodic chat, 
 | `/memory-promote <id>` | Promote a raw memory to curated |
 | `/memory-curate <category>\|<title>\|<content>` | Create a curated memory directly |
 | `/memory-forget` | Delete the current session from memory (retroactive incognito) |
+| `/memory-feedback <on\|off>` | Toggle relevance feedback prompts |
+| `/hide-memory` | Hide/show the memory status widget |
+
+## Status widget
+
+A persistent widget above the editor shows what the memory extension is doing in real time: `buscando memórias` (searching), `injetando contexto` (injecting retrieved context), `salvando memória` (saving), `capturando sessão` (background flush), `não logado`, `incognito`, or `falha` with the error message. Run `/hide-memory` to toggle it off (and again to bring it back).
+
+## Resilience
+
+- Requests retry with exponential backoff on `429`/`5xx`/network errors (Cloudflare in front of `api-arvore` occasionally returns transient `403`/`504`).
+- Expired/invalid sessions (`401`/`403`) surface as a visible `não logado` state prompting `/memory-login`, instead of failing silently.
+| `/memory-forget` | Delete the current session from memory (retroactive incognito) |
 
 ## Config
 

--- a/packages/pi-memory/package.json
+++ b/packages/pi-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-memory",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "PI extension for cloud-based memory with RAG (Qdrant + GitHub OAuth)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/pi-memory/package.json
+++ b/packages/pi-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-memory",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "description": "PI extension for cloud-based memory with RAG (Qdrant + GitHub OAuth)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/pi-memory/src/api.ts
+++ b/packages/pi-memory/src/api.ts
@@ -31,25 +31,75 @@ export interface Candidate {
   session_id: string | null;
 }
 
+const MAX_RETRIES = 3;
+const BASE_BACKOFF_MS = 500;
+
+export class MemoryAuthError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "MemoryAuthError";
+  }
+}
+
+function isRetryableStatus(status: number): boolean {
+  return status === 429 || (status >= 500 && status <= 599);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 async function request<T>(path: string, method: string, body?: unknown): Promise<T> {
   const creds = await getCredentials();
-  if (!creds) throw new Error("Not authenticated. Run /memory-login first.");
-
-  const config = getConfig();
-  const response = await fetch(`${config.apiUrl}/pi-memory${path}`, {
-    method,
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${creds.token}`,
-    },
-    body: body ? JSON.stringify(body) : undefined,
-  });
-
-  if (!response.ok) {
-    throw new Error(`${method} ${path} failed: ${response.status} ${await response.text()}`);
+  if (!creds) {
+    throw new MemoryAuthError("Not authenticated. Run /memory-login first.");
   }
 
-  return response.json() as Promise<T>;
+  const config = getConfig();
+  let lastError: Error = new Error(`${method} ${path} failed`);
+
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    let response: Response;
+    try {
+      response = await fetch(`${config.apiUrl}/pi-memory${path}`, {
+        method,
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${creds.token}`,
+        },
+        body: body ? JSON.stringify(body) : undefined,
+      });
+    } catch (networkError) {
+      lastError = networkError instanceof Error ? networkError : new Error(String(networkError));
+      if (attempt < MAX_RETRIES) {
+        await sleep(BASE_BACKOFF_MS * 2 ** attempt);
+        continue;
+      }
+      throw lastError;
+    }
+
+    if (response.ok) {
+      return response.json() as Promise<T>;
+    }
+
+    if (response.status === 401 || response.status === 403) {
+      throw new MemoryAuthError(
+        `Sessão de memória expirada ou sem acesso (${response.status}). Rode /memory-login.`,
+      );
+    }
+
+    const text = await response.text();
+    lastError = new Error(`${method} ${path} failed: ${response.status} ${text}`);
+
+    if (isRetryableStatus(response.status) && attempt < MAX_RETRIES) {
+      await sleep(BASE_BACKOFF_MS * 2 ** attempt);
+      continue;
+    }
+
+    throw lastError;
+  }
+
+  throw lastError;
 }
 
 export function ingest(sessionId: string, messages: IngestMessage[], final: boolean): Promise<IngestResult> {

--- a/packages/pi-memory/src/index.ts
+++ b/packages/pi-memory/src/index.ts
@@ -1,4 +1,4 @@
-import { exec } from "node:child_process";
+import { execFile } from "node:child_process";
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
 import { randomUUID } from "node:crypto";
@@ -11,10 +11,20 @@ import {
   deleteSession,
   ingest,
   listCandidates,
+  MemoryAuthError,
   promote,
   search,
 } from "./api.js";
 import type { IngestMessage, SearchResult } from "./api.js";
+import {
+  clearError,
+  getMemorySnapshot,
+  setActivity,
+  setError,
+  setHidden,
+  setUsername,
+} from "./state.js";
+import { disposeMemoryWidget, updateMemoryWidget } from "./widget.js";
 import {
   feedbackEnabled,
   incrementTurn,
@@ -39,13 +49,13 @@ let flushTimer: ReturnType<typeof setTimeout> | null = null;
 let lastSearchResults: SearchResult[] = [];
 
 function openBrowser(url: string): void {
-  const cmd =
-    process.platform === "darwin"
-      ? `open "${url}"`
-      : process.platform === "win32"
-        ? `start "${url}"`
-        : `xdg-open "${url}"`;
-  exec(cmd);
+  if (process.platform === "darwin") {
+    execFile("open", [url]);
+  } else if (process.platform === "win32") {
+    execFile("cmd", ["/c", "start", "", url]);
+  } else {
+    execFile("xdg-open", [url]);
+  }
 }
 
 interface RawMessage {
@@ -162,6 +172,8 @@ export default function piMemoryExtension(pi: ExtensionAPI): void {
     }
     const creds = await getCredentials();
     if (!creds) {
+      setUsername(null);
+      setActivity("logged-out");
       return;
     }
 
@@ -171,13 +183,22 @@ export default function piMemoryExtension(pi: ExtensionAPI): void {
       return;
     }
 
+    setUsername(creds.username);
+    setActivity("flushing", `${fresh.length} mensagem(ns)`);
     try {
       const result = await ingest(sessionId, fresh, final);
-      lastFlushedTurn = Math.max(...fresh.map((m) => m.turn_index));
+      lastFlushedTurn = fresh.reduce((max, m) => Math.max(max, m.turn_index), lastFlushedTurn);
+      setActivity("idle", `+${result.decisions.add}`);
       setStatus("memory", `memory: ${creds.username} (+${result.decisions.add})`);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      void message;
+      if (error instanceof MemoryAuthError) {
+        setUsername(null);
+        setActivity("logged-out");
+      } else {
+        setError(message);
+      }
+      setStatus("memory", `memory: falha ao capturar`);
     }
   }
 
@@ -188,34 +209,51 @@ export default function piMemoryExtension(pi: ExtensionAPI): void {
     restoreFeedbackState(pi, ctx.sessionManager.getEntries());
 
     const creds = await getCredentials();
+    if (creds) {
+      setUsername(creds.username);
+      setActivity(incognito ? "incognito" : "idle");
+    } else {
+      setUsername(null);
+      setActivity("logged-out");
+    }
     ctx.ui.setStatus("memory", creds ? `memory: ${creds.username}` : "memory: not logged in");
+    updateMemoryWidget(ctx);
   });
 
   pi.on("before_agent_start", async (event, ctx) => {
+    updateMemoryWidget(ctx);
     if (incognito) {
+      setActivity("incognito");
       return;
     }
     const creds = await getCredentials();
     ctx.ui.setStatus("memory", creds ? `memory: ${creds.username}` : "memory: not logged in");
     if (!creds) {
+      setUsername(null);
+      setActivity("logged-out");
       return;
     }
+    setUsername(creds.username);
 
     try {
       const prompt = event.prompt?.trim();
       if (!prompt || prompt.length < MIN_TEXT_LENGTH) {
+        setActivity("idle");
         return;
       }
 
       const entries = ctx.sessionManager.getEntries();
       const priorMessages = collectMessages(entries);
       if (priorMessages.length < MIN_PRIOR_MESSAGES_FOR_INJECTION) {
+        setActivity("idle");
         return;
       }
 
       const query = buildSearchQuery(entries, prompt);
+      setActivity("searching");
       const results = await search(query, { limit: SEARCH_LIMIT, threshold: SEARCH_THRESHOLD });
       if (results.length === 0) {
+        setActivity("idle");
         return;
       }
 
@@ -249,14 +287,22 @@ export default function piMemoryExtension(pi: ExtensionAPI): void {
         used += line.length;
       }
       if (items.length === 0) {
+        setActivity("idle");
         return;
       }
 
       lastSearchResults = results;
+      setActivity("injecting", `${items.length} snippet(s)`);
 
       const memoryBlock = `${header}${items.join("")}`;
       return { systemPrompt: `${event.systemPrompt}\n\n${memoryBlock}` };
-    } catch {
+    } catch (error) {
+      if (error instanceof MemoryAuthError) {
+        setUsername(null);
+        setActivity("logged-out");
+      } else {
+        setError(error instanceof Error ? error.message : String(error));
+      }
       return;
     }
   });
@@ -281,6 +327,7 @@ export default function piMemoryExtension(pi: ExtensionAPI): void {
       clearTimeout(flushTimer);
     }
     await flush(ctx.sessionManager.getEntries(), true, (k, t) => ctx.ui.setStatus(k, t));
+    disposeMemoryWidget(ctx);
   });
 
   pi.registerCommand("memory-login", {
@@ -296,6 +343,10 @@ export default function piMemoryExtension(pi: ExtensionAPI): void {
           expiresAt: Date.now() + result.expiresIn,
         });
         ctx.ui.setStatus("memory", `memory: ${result.username}`);
+        setUsername(result.username);
+        clearError();
+        setActivity(incognito ? "incognito" : "idle");
+        updateMemoryWidget(ctx);
         ctx.ui.notify(`Logged in as ${result.username}`, "info");
       } catch (error) {
         ctx.ui.notify(`Login failed: ${error instanceof Error ? error.message : String(error)}`, "error");
@@ -308,6 +359,9 @@ export default function piMemoryExtension(pi: ExtensionAPI): void {
     handler: async (_args, ctx) => {
       await clearCredentials();
       ctx.ui.setStatus("memory", "memory: logged out");
+      setUsername(null);
+      setActivity("logged-out");
+      updateMemoryWidget(ctx);
       ctx.ui.notify("Logged out from Pi Memory", "info");
     },
   });
@@ -317,8 +371,25 @@ export default function piMemoryExtension(pi: ExtensionAPI): void {
     handler: (_args, ctx) => {
       incognito = !incognito;
       const status = incognito ? "ON" : "OFF";
+      setActivity(incognito ? "incognito" : "idle");
       ctx.ui.setStatus("memory", `memory: incognito ${status}`);
       ctx.ui.notify(`Incognito mode: ${status}`, "info");
+      updateMemoryWidget(ctx);
+      return Promise.resolve();
+    },
+  });
+
+  pi.registerCommand("hide-memory", {
+    description: "Toggle the Pi Memory status widget (hide/show)",
+    handler: (_args, ctx) => {
+      const snapshot = getMemorySnapshot();
+      const nextHidden = !snapshot.hidden;
+      setHidden(nextHidden);
+      updateMemoryWidget(ctx);
+      ctx.ui.notify(
+        nextHidden ? "Pi Memory widget hidden (/hide-memory to show)." : "Pi Memory widget visible.",
+        "info",
+      );
       return Promise.resolve();
     },
   });

--- a/packages/pi-memory/src/state.ts
+++ b/packages/pi-memory/src/state.ts
@@ -1,0 +1,77 @@
+export type MemoryActivity =
+  | "idle"
+  | "searching"
+  | "injecting"
+  | "saving"
+  | "flushing"
+  | "error"
+  | "logged-out"
+  | "incognito";
+
+export interface MemorySnapshot {
+  activity: MemoryActivity;
+  username: string | null;
+  detail: string | null;
+  lastError: string | null;
+  hidden: boolean;
+}
+
+type Listener = () => void;
+
+const snapshot: MemorySnapshot = {
+  activity: "logged-out",
+  username: null,
+  detail: null,
+  lastError: null,
+  hidden: false,
+};
+
+const listeners = new Set<Listener>();
+
+export function getMemorySnapshot(): MemorySnapshot {
+  return snapshot;
+}
+
+export function subscribe(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+function emit(): void {
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+export function setActivity(activity: MemoryActivity, detail: string | null = null): void {
+  snapshot.activity = activity;
+  snapshot.detail = detail;
+  if (activity !== "error") {
+    snapshot.lastError = null;
+  }
+  emit();
+}
+
+export function setError(message: string): void {
+  snapshot.activity = "error";
+  snapshot.lastError = message;
+  emit();
+}
+
+export function setUsername(username: string | null): void {
+  snapshot.username = username;
+  emit();
+}
+
+export function setHidden(hidden: boolean): void {
+  snapshot.hidden = hidden;
+  emit();
+}
+
+export function clearError(): void {
+  if (snapshot.activity === "error") {
+    snapshot.activity = "idle";
+  }
+  snapshot.lastError = null;
+  emit();
+}

--- a/packages/pi-memory/src/state.ts
+++ b/packages/pi-memory/src/state.ts
@@ -8,6 +8,18 @@ export type MemoryActivity =
   | "logged-out"
   | "incognito";
 
+const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+const SPINNER_INTERVAL_MS = 90;
+
+export function isActiveActivity(activity: MemoryActivity): boolean {
+  return (
+    activity === "searching" ||
+    activity === "injecting" ||
+    activity === "saving" ||
+    activity === "flushing"
+  );
+}
+
 export interface MemorySnapshot {
   activity: MemoryActivity;
   username: string | null;
@@ -27,9 +39,15 @@ const snapshot: MemorySnapshot = {
 };
 
 const listeners = new Set<Listener>();
+let spinnerFrame = 0;
+let spinnerTimer: ReturnType<typeof setInterval> | null = null;
 
 export function getMemorySnapshot(): MemorySnapshot {
   return snapshot;
+}
+
+export function getSpinnerFrame(): string {
+  return SPINNER_FRAMES[spinnerFrame % SPINNER_FRAMES.length];
 }
 
 export function subscribe(listener: Listener): () => void {
@@ -43,18 +61,53 @@ function emit(): void {
   }
 }
 
+function startSpinner(): void {
+  if (spinnerTimer) {
+    return;
+  }
+  spinnerTimer = setInterval(() => {
+    spinnerFrame = (spinnerFrame + 1) % SPINNER_FRAMES.length;
+    emit();
+  }, SPINNER_INTERVAL_MS);
+  if (typeof spinnerTimer.unref === "function") {
+    spinnerTimer.unref();
+  }
+}
+
+function stopSpinner(): void {
+  if (spinnerTimer) {
+    clearInterval(spinnerTimer);
+    spinnerTimer = null;
+  }
+  spinnerFrame = 0;
+}
+
+function syncSpinner(): void {
+  if (!snapshot.hidden && isActiveActivity(snapshot.activity)) {
+    startSpinner();
+  } else {
+    stopSpinner();
+  }
+}
+
+export function stopSpinnerTimer(): void {
+  stopSpinner();
+}
+
 export function setActivity(activity: MemoryActivity, detail: string | null = null): void {
   snapshot.activity = activity;
   snapshot.detail = detail;
   if (activity !== "error") {
     snapshot.lastError = null;
   }
+  syncSpinner();
   emit();
 }
 
 export function setError(message: string): void {
   snapshot.activity = "error";
   snapshot.lastError = message;
+  syncSpinner();
   emit();
 }
 
@@ -65,6 +118,7 @@ export function setUsername(username: string | null): void {
 
 export function setHidden(hidden: boolean): void {
   snapshot.hidden = hidden;
+  syncSpinner();
   emit();
 }
 
@@ -73,5 +127,6 @@ export function clearError(): void {
     snapshot.activity = "idle";
   }
   snapshot.lastError = null;
+  syncSpinner();
   emit();
 }

--- a/packages/pi-memory/src/tools.ts
+++ b/packages/pi-memory/src/tools.ts
@@ -1,6 +1,7 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "@earendil-works/pi-ai";
-import { createCurated, search } from "./api.js";
+import { createCurated, MemoryAuthError, search } from "./api.js";
+import { setActivity, setError, setUsername } from "./state.js";
 
 const CATEGORIES = ["decisions", "conventions", "incidents", "domain", "gotchas"];
 
@@ -27,6 +28,7 @@ export function registerMemoryTools(pi: ExtensionAPI): void {
       limit: Type.Optional(Type.Number({ description: "Max results (default 10)" })),
     }),
     async execute(_toolCallId, params) {
+      setActivity("searching", params.query.slice(0, 60));
       try {
         const results = await search(params.query, {
           tier: params.tier,
@@ -34,6 +36,7 @@ export function registerMemoryTools(pi: ExtensionAPI): void {
           limit: params.limit,
         });
 
+        setActivity("idle", `${results.length} resultado(s)`);
         if (results.length === 0) {
           return {
             content: [{ type: "text", text: "No relevant memories found." }],
@@ -51,6 +54,12 @@ export function registerMemoryTools(pi: ExtensionAPI): void {
         return { content: [{ type: "text", text }], details: { count: results.length } };
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
+        if (error instanceof MemoryAuthError) {
+          setUsername(null);
+          setActivity("logged-out");
+        } else {
+          setError(message);
+        }
         return {
           content: [{ type: "text", text: `memory_search failed: ${message}` }],
           details: { count: 0 },
@@ -72,6 +81,7 @@ export function registerMemoryTools(pi: ExtensionAPI): void {
       tags: Type.Optional(Type.Array(Type.String(), { description: "Tags" })),
     }),
     async execute(_toolCallId, params) {
+      setActivity("saving", params.title.slice(0, 60));
       try {
         const category = CATEGORIES.includes(params.category) ? params.category : "domain";
         const result = await createCurated({
@@ -80,12 +90,19 @@ export function registerMemoryTools(pi: ExtensionAPI): void {
           content: params.content,
           tags: params.tags,
         });
+        setActivity("idle", `salvo: ${params.title.slice(0, 40)}`);
         return {
           content: [{ type: "text", text: `Saved curated memory (${result.id}).` }],
           details: { id: result.id },
         };
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
+        if (error instanceof MemoryAuthError) {
+          setUsername(null);
+          setActivity("logged-out");
+        } else {
+          setError(message);
+        }
         return {
           content: [{ type: "text", text: `memory_save failed: ${message}` }],
           details: { id: "" },

--- a/packages/pi-memory/src/widget.ts
+++ b/packages/pi-memory/src/widget.ts
@@ -1,0 +1,116 @@
+import { getMemorySnapshot, subscribe, type MemoryActivity } from "./state.js";
+
+const WIDGET_KEY = "pi-memory";
+
+interface ActivityStyle {
+  icon: string;
+  label: string;
+  color: string;
+}
+
+function styleFor(activity: MemoryActivity): ActivityStyle {
+  switch (activity) {
+    case "searching":
+      return { icon: "🔍", label: "buscando memórias", color: "accent" };
+    case "injecting":
+      return { icon: "🧠", label: "injetando contexto", color: "accent" };
+    case "saving":
+      return { icon: "💾", label: "salvando memória", color: "accent" };
+    case "flushing":
+      return { icon: "⏫", label: "capturando sessão", color: "dim" };
+    case "error":
+      return { icon: "⚠️", label: "falha", color: "error" };
+    case "logged-out":
+      return { icon: "🔒", label: "não logado (/memory-login)", color: "warning" };
+    case "incognito":
+      return { icon: "🕶️", label: "incognito", color: "muted" };
+    case "idle":
+    default:
+      return { icon: "🌱", label: "pronto", color: "dim" };
+  }
+}
+
+let widgetRegistered = false;
+let uiCtx: any = null;
+let unsubscribe: (() => void) | null = null;
+
+function truncate(line: string, width: number): string {
+  if (line.length <= width) return line;
+  if (width <= 1) return line.slice(0, Math.max(0, width));
+  return `${line.slice(0, width - 1)}…`;
+}
+
+export function updateMemoryWidget(ctx: any): void {
+  if (ctx !== uiCtx) {
+    if (widgetRegistered && uiCtx) {
+      try {
+        uiCtx.ui.setWidget(WIDGET_KEY, undefined);
+      } catch {}
+    }
+    widgetRegistered = false;
+    uiCtx = ctx;
+  }
+
+  if (!unsubscribe) {
+    unsubscribe = subscribe(() => {
+      if (uiCtx?.ui?.requestRender) {
+        try {
+          uiCtx.ui.requestRender();
+        } catch {}
+      }
+    });
+  }
+
+  const snapshot = getMemorySnapshot();
+  if (snapshot.hidden) {
+    if (widgetRegistered) {
+      try {
+        ctx.ui.setWidget(WIDGET_KEY, undefined);
+      } catch {}
+      widgetRegistered = false;
+    }
+    return;
+  }
+
+  if (widgetRegistered) {
+    return;
+  }
+
+  ctx.ui.setWidget(
+    WIDGET_KEY,
+    (_tui: any, theme: any) => ({
+      render(width: number): string[] {
+        const snap = getMemorySnapshot();
+        const style = styleFor(snap.activity);
+        const user = snap.username ? ` (${snap.username})` : "";
+        const head = `${style.icon} memory${user}: ${style.label}`;
+        const lines = [theme.fg(style.color, truncate(head, width))];
+        if (snap.activity === "error" && snap.lastError) {
+          lines.push(theme.fg("error", truncate(`   ${snap.lastError}`, width)));
+        } else if (snap.detail) {
+          lines.push(theme.fg("dim", truncate(`   ${snap.detail}`, width)));
+        }
+        return lines;
+      },
+      invalidate(): void {
+        widgetRegistered = false;
+      },
+    }),
+    { placement: "aboveEditor" },
+  );
+  widgetRegistered = true;
+}
+
+export function disposeMemoryWidget(ctx: any): void {
+  if (unsubscribe) {
+    unsubscribe();
+    unsubscribe = null;
+  }
+  if (widgetRegistered) {
+    try {
+      ctx.ui.setWidget(WIDGET_KEY, undefined);
+    } catch {}
+    widgetRegistered = false;
+  }
+  uiCtx = null;
+}

--- a/packages/pi-memory/src/widget.ts
+++ b/packages/pi-memory/src/widget.ts
@@ -1,4 +1,11 @@
-import { getMemorySnapshot, subscribe, type MemoryActivity } from "./state.js";
+import {
+  getMemorySnapshot,
+  getSpinnerFrame,
+  isActiveActivity,
+  stopSpinnerTimer,
+  subscribe,
+  type MemoryActivity,
+} from "./state.js";
 
 const WIDGET_KEY = "pi-memory";
 
@@ -82,8 +89,9 @@ export function updateMemoryWidget(ctx: any): void {
       render(width: number): string[] {
         const snap = getMemorySnapshot();
         const style = styleFor(snap.activity);
+        const icon = isActiveActivity(snap.activity) ? getSpinnerFrame() : style.icon;
         const user = snap.username ? ` (${snap.username})` : "";
-        const head = `${style.icon} memory${user}: ${style.label}`;
+        const head = `${icon} memory${user}: ${style.label}`;
         const lines = [theme.fg(style.color, truncate(head, width))];
         if (snap.activity === "error" && snap.lastError) {
           lines.push(theme.fg("error", truncate(`   ${snap.lastError}`, width)));
@@ -102,6 +110,7 @@ export function updateMemoryWidget(ctx: any): void {
 }
 
 export function disposeMemoryWidget(ctx: any): void {
+  stopSpinnerTimer();
   if (unsubscribe) {
     unsubscribe();
     unsubscribe = null;


### PR DESCRIPTION
## Resumo

Torna a extension `@arvoretech/pi-memory` **visível** e **resiliente**. Hoje toda a atividade de memória (busca, injeção de contexto, captura de sessão) acontece em silêncio e qualquer falha é engolida — então ninguém percebe quando a captura para de funcionar. Este PR resolve isso com um widget de status em tempo real e várias correções de robustez.

## Widget de status (+ `/hide-memory`)

Widget persistente acima do editor (mesmo padrão do `pi-worktree`) que reflete o estado atual:

- 🔍 `buscando memórias` · 🧠 `injetando contexto` · 💾 `salvando memória` · ⏫ `capturando sessão`
- 🔒 `não logado` · 🕶️ `incognito` · ⚠️ `falha` (com a mensagem de erro)

Comando **`/hide-memory`** esconde/reexibe o widget para quem não quer poluição visual.

## Resiliência

- **Retry com backoff exponencial** em `429`/`5xx`/erros de rede no `request()` — o Cloudflare na frente do api-arvore retorna `403`/`504` intermitentes em ingestão (documentado em memória).
- **401/403 viram `MemoryAuthError`** e aparecem como estado `não logado` visível (sugere `/memory-login`), em vez de falhar silencioso. O refresh proativo por `expiresAt` já existia; isto cobre o caso reativo (revogação/rotação antes do expiry).
- **`flush` não engole mais o erro** invisivelmente: roteia para o estado do widget (mantendo fora do input do pi, preservando a intenção do commit `84b25fe`).

## Hardening

- `openBrowser` usa `execFile` em vez de `exec` com interpolação de string (elimina a classe de command injection).
- `flush` calcula `lastFlushedTurn` via `reduce` em vez de `Math.max(...spread)` (evita `RangeError` em sessões longas).

## Teste

- `tsc --noEmit` (lint) e `tsc` (build) passam — `EXIT=0`.
- `state.ts`/`widget.ts` novos compilam no `dist`.
- Versão: `0.5.2` → `0.6.0`.
