### PR TITLE
fix(pi-memory): limpa saída de erro quando gateway retorna HTML

### DIFF
--- a/packages/pi-memory/package.json
+++ b/packages/pi-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-memory",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "PI extension for cloud-based memory with RAG (Qdrant + GitHub OAuth)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/pi-memory/src/api.ts
+++ b/packages/pi-memory/src/api.ts
@@ -45,6 +45,30 @@ function isRetryableStatus(status: number): boolean {
   return status === 429 || (status >= 500 && status <= 599);
 }
 
+async function formatErrorBody(response: Response): Promise<string> {
+  const status = response.status;
+  const contentType = response.headers.get("content-type") ?? "";
+  const raw = await response.text().catch(() => "");
+
+  if (contentType.includes("application/json")) {
+    try {
+      const parsed = JSON.parse(raw) as { message?: unknown };
+      if (typeof parsed.message === "string") {
+        return `${status} ${parsed.message}`;
+      }
+    } catch {
+      // falls through to generic handling
+    }
+  }
+
+  if (contentType.includes("text/html") || raw.trimStart().startsWith("<")) {
+    return `${status} gateway error (HTML response, likely timeout)`;
+  }
+
+  const snippet = raw.replace(/\s+/g, " ").trim().slice(0, 200);
+  return snippet ? `${status} ${snippet}` : `${status}`;
+}
+
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -88,8 +112,7 @@ async function request<T>(path: string, method: string, body?: unknown): Promise
       );
     }
 
-    const text = await response.text();
-    lastError = new Error(`${method} ${path} failed: ${response.status} ${text}`);
+    lastError = new Error(`${method} ${path} failed: ${await formatErrorBody(response)}`);
 
     if (isRetryableStatus(response.status) && attempt < MAX_RETRIES) {
       await sleep(BASE_BACKOFF_MS * 2 ** attempt);


### PR DESCRIPTION
## Contexto

Quando o `/ingest` recebia um **504/502 do Cloudflare** (timeout de gateway), o cliente da extensão jogava a **página HTML de erro inteira** dentro da mensagem de `Error` (`failed: 504 <!DOCTYPE html><!--[if lt IE 7]>...`), poluindo o terminal com centenas de linhas de markup/CSS.

## Mudança

- **`packages/pi-memory/src/api.ts`**: nova `formatErrorBody()` substitui o dump cru do corpo:
  - corpo JSON → extrai `message` (`<status> <mensagem>`)
  - HTML / respostas de gateway (504/502/503) → mensagem curta `<status> gateway error (HTML response, likely timeout)`
  - outros → snippet de até 200 chars, sem quebras de linha

## Resultado

O terminal nunca mais recebe a página de erro inteira do Cloudflare; o erro vira uma linha legível. Não muda o fluxo de retry/backoff nem o tratamento de 401/403 já existentes.

## Notas

Correção complementar ao backend: o 504 em si (latência do `/ingest`) está sendo tratado no api-arvore (paralelização das decisões de LLM). Este PR apenas garante que, quando ocorrer qualquer erro de gateway, a saída no terminal seja limpa.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when HTTP requests fail, making them more informative and easier to understand.
  * Added clearer handling for JSON, HTML, and plain-text responses, including a specific message for gateway-style HTML errors.
  * Error details are now shortened and cleaned up to show the most relevant part of the response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->