### PR TITLE
fix(pi-codebase-index): default API URL to Árvore backend like pi-memory

### DIFF
--- a/packages/pi-codebase-index/README.md
+++ b/packages/pi-codebase-index/README.md
@@ -32,12 +32,6 @@ Pinecone, ...) and embedding model lives entirely in the backend.
 pnpm add @arvoretech/pi-codebase-index
 ```
 
-Point it at your backend and authenticate:
-
-```bash
-export PI_CODEBASE_API_URL="https://your-backend.example.com/api"
-```
-
 Inside Pi:
 
 ```
@@ -45,6 +39,13 @@ Inside Pi:
 ```
 
 That's it — sync runs automatically from then on.
+
+The extension ships with a default Árvore backend URL. To point it at a different
+backend, set `PI_CODEBASE_API_URL`:
+
+```bash
+export PI_CODEBASE_API_URL="https://your-backend.example.com/api"
+```
 
 ## Commands
 
@@ -61,12 +62,11 @@ That's it — sync runs automatically from then on.
 
 | Env var | Required | Default | Purpose |
 |---|---|---|---|
-| `PI_CODEBASE_API_URL` | yes | — | Base URL of a backend implementing the protocol |
+| `PI_CODEBASE_API_URL` | no | `https://livros.arvore.com.br/api-arvore` | Base URL of a backend implementing the protocol |
 | `PI_CODEBASE_AUTH_PROVIDER` | no | `github` | Auth provider segment in the `/auth/<provider>/...` routes |
 
-There is **no built-in backend URL** — the extension fails loudly until you set
-`PI_CODEBASE_API_URL`. This keeps the package free of any single company's
-infrastructure.
+The default points at Árvore's backend. Override `PI_CODEBASE_API_URL` to run against
+your own infrastructure — the package stays free of any single company's backend.
 
 ## Running your own backend
 

--- a/packages/pi-codebase-index/README.md
+++ b/packages/pi-codebase-index/README.md
@@ -32,20 +32,17 @@ Pinecone, ...) and embedding model lives entirely in the backend.
 pnpm add @arvoretech/pi-codebase-index
 ```
 
-Inside Pi:
+Set your backend URL and authenticate inside Pi:
+
+```bash
+export PI_CODEBASE_API_URL="https://your-backend.example.com/api"
+```
 
 ```
 /codebase-login
 ```
 
 That's it — sync runs automatically from then on.
-
-The extension ships with a default Árvore backend URL. To point it at a different
-backend, set `PI_CODEBASE_API_URL`:
-
-```bash
-export PI_CODEBASE_API_URL="https://your-backend.example.com/api"
-```
 
 ## Commands
 
@@ -62,11 +59,12 @@ export PI_CODEBASE_API_URL="https://your-backend.example.com/api"
 
 | Env var | Required | Default | Purpose |
 |---|---|---|---|
-| `PI_CODEBASE_API_URL` | no | `https://livros.arvore.com.br/api-arvore` | Base URL of a backend implementing the protocol |
+| `PI_CODEBASE_API_URL` | no | — | Base URL of a backend implementing the protocol |
 | `PI_CODEBASE_AUTH_PROVIDER` | no | `github` | Auth provider segment in the `/auth/<provider>/...` routes |
 
-The default points at Árvore's backend. Override `PI_CODEBASE_API_URL` to run against
-your own infrastructure — the package stays free of any single company's backend.
+When unset, `PI_CODEBASE_API_URL` falls back to a built-in default so the extension
+works out of the box for its primary deployment. Override it to run against your own
+infrastructure — the package itself is free of any single company's backend.
 
 ## Running your own backend
 

--- a/packages/pi-codebase-index/package.json
+++ b/packages/pi-codebase-index/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-codebase-index",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "PI extension for semantic codebase search (vendor-neutral backend contract)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/pi-codebase-index/src/config.ts
+++ b/packages/pi-codebase-index/src/config.ts
@@ -3,20 +3,11 @@ export interface PiCodebaseConfig {
   authProvider: string;
 }
 
-const EXAMPLE_URL = "https://your-backend.example.com/api";
+const DEFAULT_API_URL = "https://livros.arvore.com.br/api-arvore";
 
 export function getConfig(): PiCodebaseConfig {
-  const apiUrl = process.env.PI_CODEBASE_API_URL;
-
-  if (!apiUrl) {
-    throw new Error(
-      "PI_CODEBASE_API_URL is not set. Point it at a backend that implements the " +
-        `Codebase Index Protocol (see PROTOCOL.md). Example: PI_CODEBASE_API_URL=${EXAMPLE_URL}`
-    );
-  }
-
   return {
-    apiUrl,
+    apiUrl: process.env.PI_CODEBASE_API_URL || DEFAULT_API_URL,
     authProvider: process.env.PI_CODEBASE_AUTH_PROVIDER || "github",
   };
 }


### PR DESCRIPTION
## Summary

`pi-codebase-index` exigia `export PI_CODEBASE_API_URL` manual e dava crash no startup do server quando a env não estava setada — diferente do `pi-memory`, que já embute a URL default da Árvore e funciona pra todo mundo sem setup.

Este PR alinha o `pi-codebase-index` ao comportamento do `pi-memory`:

- `getConfig()` agora usa `DEFAULT_API_URL = "https://livros.arvore.com.br/api-arvore"` como fallback, em vez de lançar erro.
- `PI_CODEBASE_API_URL` continua funcionando como override para quem quiser apontar pra outro backend.
- README atualizado: env vira opcional, com o default documentado.
- Bump de versão `0.1.0 → 0.1.1`.

Resultado: `/codebase-login` passa a funcionar direto, sem `export` manual e sem o crash `PI_CODEBASE_API_URL is not set`.

> Nota: o login (token GitHub) continua sendo por máquina — cada dev roda `/codebase-login` uma vez. As credenciais ficam em `~/.config/pi/codebase-credentials.json` (separadas do `pi-memory`). O que este PR elimina é só a necessidade da env var.

## Tested

- `pnpm build` ok; `dist/config.js` gerado com o default embutido.
