### PR TITLE
fix(pi-codebase-index): index nested repos under a git workspace root

### DIFF
--- a/packages/pi-codebase-index/package.json
+++ b/packages/pi-codebase-index/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-codebase-index",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "PI extension for semantic codebase search (vendor-neutral backend contract)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/pi-codebase-index/src/sync.ts
+++ b/packages/pi-codebase-index/src/sync.ts
@@ -16,7 +16,6 @@ async function discoverRepos(workspaceDir: string): Promise<{ name: string; dir:
 
   if (existsSync(join(workspaceDir, ".git"))) {
     repos.push({ name: basename(workspaceDir), dir: workspaceDir });
-    return repos;
   }
 
   let entries: string[] = [];


### PR DESCRIPTION
## Summary

`runSync` discovered **0 of the 19 nested repos** in the `arvore-hub` workspace, leaving the Qdrant index empty even though `/codebase-reindex` reported activity.

### Root cause
`discoverRepos` early-returned as soon as it found a `.git` at the workspace root:

```ts
if (existsSync(join(workspaceDir, ".git"))) {
  repos.push({ name: basename(workspaceDir), dir: workspaceDir });
  return repos; // <- skipped every child repo
}
```

`arvore-hub` is itself a git repo **and** contains 19 nested per-project git repos (api-arvore, frontend-arvore-nextjs, …, all gitignored). The early return meant only arvore-hub's own 5 indexable files were ever considered; the real repos were never scanned.

### Fix
Drop the early return so the child scan always runs. The workspace root is still indexed when it is a repo, and each nested `.git` directory is discovered too.

Verified against the live workspace: discovery goes from **1 → 20 repos**.

### Backend
Confirmed healthy out of band — probing `/sync`, `/index` and `/search` directly returned correct results and a probe chunk was indexed + retrieved at score 1, then cleaned up. The bug was purely client-side discovery.

## Test
- `tsc` clean
- Simulated `discoverRepos` against the real workspace: 20 repos found (arvore-hub + 19 children)

Bumps the package to `0.1.2` (needs republish to reach installs).