### PR TITLE
fix(pi-codebase-index): retry index batches with exponential backoff

### DIFF
--- a/packages/pi-codebase-index/package.json
+++ b/packages/pi-codebase-index/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-codebase-index",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "PI extension for semantic codebase search (vendor-neutral backend contract)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/pi-codebase-index/src/sync.ts
+++ b/packages/pi-codebase-index/src/sync.ts
@@ -96,7 +96,15 @@ async function indexChanged(
     if (pending.length === 0) return;
     const batch = pending;
     pending = [];
-    await index(batch);
+    for (let attempt = 0; attempt < 4; attempt++) {
+      try {
+        await index(batch);
+        return;
+      } catch {
+        if (attempt === 3) break;
+        await new Promise((r) => setTimeout(r, 500 * 2 ** attempt));
+      }
+    }
   };
 
   for (const item of changed) {


### PR DESCRIPTION
## Summary

During full workspace sync (~19k files), the `/index` endpoint sporadically returns 403 (WAF rate-limit) and 500 errors. The current `flush()` call had no retry logic — each failed batch was silently dropped, leaving gaps in the Qdrant index.

## Fix

Added retry with exponential backoff (up to 4 attempts: 0ms, 500ms, 1s, 2s) inside `flush()`. Failed batches are retried before being abandoned.

## Version

Bumps to `0.1.3` — needs republish after merge.