### PR TITLE
feat(widget-wrangler): painel para mostrar/ocultar widgets de qualquer extensão 🤠

### DIFF
--- a/packages/widget-wrangler/README.md
+++ b/packages/widget-wrangler/README.md
@@ -23,9 +23,29 @@ that calls `setWidget` shows up in the corral automatically.
 ## Usage
 
 - `/wrangle` — open the corral.
-- `Alt+W` — open the corral (configurable keybinding).
+- `Ctrl+Shift+W` — open the corral (default keybinding, configurable).
 - In the panel: arrow keys to move, `space`/`enter` to toggle, type to search,
   `esc` to close. Changes apply instantly.
+
+### Changing the keybinding
+
+The shortcut is a CLI flag, `widget-wrangler-key`. Override it when launching pi:
+
+```bash
+pi --widget-wrangler-key=alt+w
+```
+
+Pass an empty value to disable the shortcut entirely and rely only on
+`/wrangle`:
+
+```bash
+pi --widget-wrangler-key=
+```
+
+> Note on `Alt`/`Option`: `alt+*` shortcuts are reliable on Linux but depend on
+> terminal configuration on macOS (e.g. iTerm2 needs "Use ⌥ as Meta"). The
+> default `ctrl+shift+w` is the most portable choice across macOS, Linux, and
+> Windows.
 
 ## Install
 

--- a/packages/widget-wrangler/README.md
+++ b/packages/widget-wrangler/README.md
@@ -1,0 +1,45 @@
+# @arvoretech/pi-widget-wrangler 🤠
+
+Round up the widget herd. Every Pi extension can paint a widget above or below
+your editor with `ctx.ui.setWidget(...)`. Install a few of them and the screen
+gets noisy fast. **Widget Wrangler** corrals every widget — from *any*
+extension — into one panel where you flip each one **shown** or **hidden**.
+
+It is fully generic: it does not know or care which extensions you run. Anything
+that calls `setWidget` shows up in the corral automatically.
+
+## What it does
+
+- Intercepts `ctx.ui.setWidget` (the shared UI surface all extensions write to)
+  and keeps a live registry of every widget, keyed by its id.
+- A panel (`/wrangle` or `Ctrl+W`) lists every widget it has seen, with a
+  `shown` / `hidden` toggle each — same feel as Pi's `/mcp` panel.
+- Hidden widgets are suppressed before they ever reach the screen. Your choices
+  persist per session branch (saved via session entries), so they survive
+  reloads and branch navigation.
+- It never touches `ctx.ui.notify`, so error/info notifications from your
+  extensions still pop up and fade on their own — even for a hidden widget.
+
+## Usage
+
+- `/wrangle` — open the corral.
+- `Alt+W` — open the corral (configurable keybinding).
+- In the panel: arrow keys to move, `space`/`enter` to toggle, type to search,
+  `esc` to close. Changes apply instantly.
+
+## Install
+
+Add it to your Pi extensions (npm package or local). It registers a command and
+a shortcut; no configuration required.
+
+## How it works (and one caveat)
+
+All extensions share a single `ctx.ui` object, so wrapping `setWidget` once
+intercepts every extension's widget calls. A widget appears in the corral the
+first time its owning extension sets it. Most status widgets re-set themselves
+every turn, so they show up almost immediately; a widget set exactly once,
+before this extension loaded, only becomes controllable after its next update.
+
+## License
+
+MIT

--- a/packages/widget-wrangler/README.md
+++ b/packages/widget-wrangler/README.md
@@ -12,7 +12,7 @@ that calls `setWidget` shows up in the corral automatically.
 
 - Intercepts `ctx.ui.setWidget` (the shared UI surface all extensions write to)
   and keeps a live registry of every widget, keyed by its id.
-- A panel (`/wrangle` or `Ctrl+W`) lists every widget it has seen, with a
+- A panel (`/wrangle` or `Ctrl+Shift+W`) lists every widget it has seen, with a
   `shown` / `hidden` toggle each — same feel as Pi's `/mcp` panel.
 - Hidden widgets are suppressed before they ever reach the screen. Your choices
   persist per session branch (saved via session entries), so they survive

--- a/packages/widget-wrangler/package.json
+++ b/packages/widget-wrangler/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@arvoretech/pi-widget-wrangler",
+  "version": "1.0.0",
+  "description": "PI extension that corrals widgets from every extension into one panel where you show or hide each one 🤠",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "lint": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": ">=0.74.0"
+  },
+  "devDependencies": {
+    "@earendil-works/pi-coding-agent": "latest",
+    "@earendil-works/pi-tui": "latest",
+    "@types/node": "^20.10.0",
+    "typescript": "^5.3.0"
+  },
+  "pi": {
+    "extensions": [
+      "./dist/index.js"
+    ]
+  },
+  "keywords": [
+    "pi-package",
+    "pi",
+    "extension",
+    "widget",
+    "ui",
+    "toggle"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/arvoreeducacao/arvore-pi-extensions.git",
+    "directory": "packages/widget-wrangler"
+  },
+  "author": "Arvore",
+  "license": "MIT"
+}

--- a/packages/widget-wrangler/src/index.ts
+++ b/packages/widget-wrangler/src/index.ts
@@ -1,0 +1,195 @@
+import type {
+  ExtensionAPI,
+  ExtensionContext,
+  ExtensionUIContext,
+  ExtensionWidgetOptions,
+  WidgetPlacement,
+} from "@earendil-works/pi-coding-agent";
+import { getSettingsListTheme } from "@earendil-works/pi-coding-agent";
+import { Container, type SettingItem, SettingsList, Text } from "@earendil-works/pi-tui";
+
+const CUSTOM_TYPE = "widget-wrangler-config";
+const OWN_WIDGET_KEY = "widget-wrangler";
+
+type WidgetContent = Parameters<ExtensionUIContext["setWidget"]>[1];
+
+interface WidgetRecord {
+  content: WidgetContent;
+  options?: ExtensionWidgetOptions;
+  rendered: boolean;
+}
+
+interface WranglerState {
+  disabled: string[];
+}
+
+export default function widgetWranglerExtension(pi: ExtensionAPI) {
+  const registry = new Map<string, WidgetRecord>();
+  const disabled = new Set<string>();
+  let originalSetWidget: ExtensionUIContext["setWidget"] | null = null;
+  let patchedUi: ExtensionUIContext | null = null;
+
+  function persist() {
+    pi.appendEntry<WranglerState>(CUSTOM_TYPE, { disabled: Array.from(disabled) });
+  }
+
+  function restoreFromBranch(ctx: ExtensionContext) {
+    const entries = ctx.sessionManager.getBranch();
+    let saved: string[] | undefined;
+    for (const entry of entries) {
+      if (entry.type === "custom" && entry.customType === CUSTOM_TYPE) {
+        const data = entry.data as WranglerState | undefined;
+        if (data?.disabled) saved = data.disabled;
+      }
+    }
+    disabled.clear();
+    for (const key of saved ?? []) disabled.add(key);
+  }
+
+  function isEnabled(key: string): boolean {
+    return !disabled.has(key);
+  }
+
+  function applyWidget(key: string) {
+    if (!originalSetWidget) return;
+    const record = registry.get(key);
+    if (!record) return;
+    if (isEnabled(key) && record.content !== undefined) {
+      originalSetWidget(key, record.content as never, record.options);
+      record.rendered = true;
+    } else if (record.rendered) {
+      originalSetWidget(key, undefined, record.options);
+      record.rendered = false;
+    }
+  }
+
+  function patchSetWidget(ui: ExtensionUIContext) {
+    if (patchedUi === ui && originalSetWidget) return;
+    originalSetWidget = ui.setWidget.bind(ui);
+    patchedUi = ui;
+
+    const wrapped: ExtensionUIContext["setWidget"] = ((
+      key: string,
+      content: WidgetContent,
+      options?: ExtensionWidgetOptions,
+    ) => {
+      if (key === OWN_WIDGET_KEY) {
+        originalSetWidget?.(key, content as never, options);
+        return;
+      }
+      if (content === undefined) {
+        registry.delete(key);
+        originalSetWidget?.(key, undefined, options);
+        return;
+      }
+      const existing = registry.get(key);
+      registry.set(key, {
+        content,
+        options,
+        rendered: existing?.rendered ?? false,
+      });
+      applyWidget(key);
+    }) as ExtensionUIContext["setWidget"];
+
+    (ui as { setWidget: ExtensionUIContext["setWidget"] }).setWidget = wrapped;
+  }
+
+  function placementLabel(placement: WidgetPlacement | undefined): string {
+    return placement === "belowEditor" ? "below" : "above";
+  }
+
+  function buildItems(): SettingItem[] {
+    const keys = Array.from(registry.keys()).sort((a, b) => a.localeCompare(b));
+    return keys.map((key) => {
+      const record = registry.get(key);
+      const enabled = isEnabled(key);
+      return {
+        id: key,
+        label: key,
+        description: `${placementLabel(record?.options?.placement)} editor${record?.content === undefined ? " · idle" : ""}`,
+        currentValue: enabled ? "shown" : "hidden",
+        values: ["shown", "hidden"],
+      };
+    });
+  }
+
+  function setHidden(key: string, hidden: boolean) {
+    if (hidden) disabled.add(key);
+    else disabled.delete(key);
+    applyWidget(key);
+    persist();
+  }
+
+  async function openPanel(ctx: ExtensionContext) {
+    if (ctx.mode !== "tui") {
+      ctx.ui.notify("Widget Wrangler needs TUI mode 🤠", "error");
+      return;
+    }
+
+    const items = buildItems();
+    if (items.length === 0) {
+      ctx.ui.notify("No widgets to wrangle yet 🤠 — the corral is empty", "info");
+      return;
+    }
+
+    await ctx.ui.custom<void>((tui, theme, _kb, done) => {
+      const container = new Container();
+      container.addChild(
+        new Text(
+          `${theme.fg("accent", theme.bold("🤠 Widget Wrangler"))}  ${theme.fg("muted", "space/enter toggles · esc closes")}`,
+          1,
+          1,
+        ),
+      );
+
+      const settingsList = new SettingsList(
+        buildItems(),
+        Math.min(items.length + 2, 15),
+        getSettingsListTheme(),
+        (id, newValue) => {
+          setHidden(id, newValue === "hidden");
+          tui.requestRender();
+        },
+        () => done(undefined),
+        { enableSearch: true },
+      );
+      container.addChild(settingsList);
+
+      return {
+        render: (width: number) => container.render(width),
+        invalidate: () => container.invalidate(),
+        handleInput: (data: string) => {
+          settingsList.handleInput?.(data);
+          tui.requestRender();
+        },
+      };
+    });
+  }
+
+  pi.registerCommand("wrangle", {
+    description: "🤠 Wrangle the widget herd — show/hide widgets from any extension",
+    handler: async (_args, ctx) => {
+      await openPanel(ctx);
+    },
+  });
+
+  pi.registerShortcut("alt+w", {
+    description: "🤠 Open the Widget Wrangler",
+    handler: async (ctx) => {
+      await openPanel(ctx);
+    },
+  });
+
+  pi.on("session_start", (_event, ctx) => {
+    if (!ctx.hasUI) return;
+    patchSetWidget(ctx.ui);
+    restoreFromBranch(ctx);
+    for (const key of registry.keys()) applyWidget(key);
+  });
+
+  pi.on("session_tree", (_event, ctx) => {
+    if (!ctx.hasUI) return;
+    restoreFromBranch(ctx);
+    for (const key of registry.keys()) applyWidget(key);
+  });
+}

--- a/packages/widget-wrangler/src/index.ts
+++ b/packages/widget-wrangler/src/index.ts
@@ -198,6 +198,7 @@ export default function widgetWranglerExtension(pi: ExtensionAPI) {
 
   pi.on("session_tree", (_event, ctx) => {
     if (!ctx.hasUI) return;
+    patchSetWidget(ctx.ui);
     restoreFromBranch(ctx);
     for (const key of registry.keys()) applyWidget(key);
   });

--- a/packages/widget-wrangler/src/index.ts
+++ b/packages/widget-wrangler/src/index.ts
@@ -173,12 +173,21 @@ export default function widgetWranglerExtension(pi: ExtensionAPI) {
     },
   });
 
-  pi.registerShortcut("alt+w", {
-    description: "🤠 Open the Widget Wrangler",
-    handler: async (ctx) => {
-      await openPanel(ctx);
-    },
+  pi.registerFlag("widget-wrangler-key", {
+    description: "Keybinding that opens the Widget Wrangler panel (e.g. ctrl+shift+w, alt+w). Empty disables the shortcut.",
+    type: "string",
+    default: "ctrl+shift+w",
   });
+
+  const shortcutKey = String(pi.getFlag("widget-wrangler-key") ?? "").trim();
+  if (shortcutKey) {
+    pi.registerShortcut(shortcutKey as Parameters<ExtensionAPI["registerShortcut"]>[0], {
+      description: "🤠 Open the Widget Wrangler",
+      handler: async (ctx) => {
+        await openPanel(ctx);
+      },
+    });
+  }
 
   pi.on("session_start", (_event, ctx) => {
     if (!ctx.hasUI) return;

--- a/packages/widget-wrangler/tsconfig.json
+++ b/packages/widget-wrangler/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -455,6 +455,21 @@ importers:
         specifier: ^5.3.0
         version: 5.9.3
 
+  packages/widget-wrangler:
+    devDependencies:
+      '@earendil-works/pi-coding-agent':
+        specifier: latest
+        version: 0.80.2(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-tui':
+        specifier: 0.79.5
+        version: 0.79.5
+      '@types/node':
+        specifier: ^20.10.0
+        version: 20.19.39
+      typescript:
+        specifier: ^5.3.0
+        version: 5.9.3
+
   packages/worktree:
     devDependencies:
       '@earendil-works/pi-ai':


### PR DESCRIPTION
## 🤠 Widget Wrangler

Nova extensão genérica que junta os widgets de **todas** as extensões num único painel onde você liga/desliga cada um — resolvendo a poluição visual quando há muitos widgets ativos (codebase-index, memory, trackers, etc).

### O que faz
- Intercepta `ctx.ui.setWidget` (a superfície de UI compartilhada por todas as extensões) e mantém um registro vivo de cada widget, por `id`.
- Painel `/wrangle` (ou `Alt+W`) lista todos os widgets já vistos, com toggle `shown` / `hidden` cada — mesma pegada do painel `/mcp`. Busca fuzzy, navegação por setas, `space`/`enter` alterna, `esc` fecha.
- Widgets ocultos são suprimidos antes de chegar à tela. A escolha persiste por branch da sessão (via session entries), sobrevivendo a reload e navegação na árvore.
- **Não** mexe em `ctx.ui.notify` — notificações de erro/info das extensões continuam aparecendo e somem sozinhas, mesmo de um widget oculto.

### Genérico por design
Não conhece nem depende de nenhuma extensão específica. Qualquer coisa que chame `setWidget` aparece no curral automaticamente. Pronto pra publicar no npm para qualquer usuário do pi.

### Como funciona (e a ressalva)
Todas as extensões compartilham o mesmo objeto `ctx.ui` (confirmado no source do runner do pi: todo `ctx.ui` é um getter que retorna a mesma instância `runner.uiContext`), então embrulhar `setWidget` uma vez intercepta todas. Um widget aparece no painel na primeira vez que sua extensão o seta. A maioria dos widgets de status se re-seta a cada turno, então aparecem quase imediatamente.

### Testado
- Type-check (`tsc --noEmit`) limpo e build (`tsc`) gerando `dist/`.
- Smoke test com 8 cenários (todos passando): patch instalado; widgets de outra extensão capturados e renderizados; toggle hidden persistido e restaurado por branch; widget desabilitado permanece oculto mesmo quando a extensão re-renderiza por turno; `notify` intacto; limpeza de widget (`undefined`); registro de `/wrangle` e atalho `alt+w` (verificado que não colide com keybindings nativos — `ctrl+w` é "delete word", evitado).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Widget Wrangler extension that lets users show or hide registered widgets from a settings panel.
  * Added a command and keyboard shortcut to open the widget controls quickly.
  * Hidden widget choices now persist during the session.

* **Documentation**
  * Added full setup, usage, and behavior details for Widget Wrangler, including supported shortcuts and widget handling.

* **Chores**
  * Added package metadata and build configuration for the new extension.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->