### PR TITLE
feat(secret-firewall): self-descriptive placeholders + system-prompt guidance

### DIFF
--- a/packages/secret-firewall/README.md
+++ b/packages/secret-firewall/README.md
@@ -1,8 +1,11 @@
 # @arvoretech/pi-secret-firewall
 
 A secret firewall for the Pi/Kiro agent. It keeps secret **values** out of the
-model context entirely, exposing them only as `$SECRET_*` shell environment
-variables that the model can *reference by name* but never *read*.
+model context entirely, exposing them only as shell environment variables that
+the model can *reference by name* but never *read*. Where a secret value would
+appear, the model instead sees a self-describing placeholder that names the
+exact shell variable to use, e.g.
+`«SECRET DATABASE_URL redacted — ... read it in bash as "$DATABASE_URL"»`.
 
 ## How it works
 
@@ -13,8 +16,10 @@ On session start (and on demand) it discovers secrets from two sources:
    value match, zero false positives.
 2. **`.env` / `.env.local` / `.env.development*`** files in the cwd.
 
-Each secret value gets a stable placeholder: `MY_API_KEY=xptolksjf` →
-`$SECRET_MY_API_KEY`.
+Each secret value gets a stable, self-describing placeholder that tells the
+model exactly how to use it. For env/dotenv secrets the shell variable is the
+secret's **original name**: `MY_API_KEY=xptolksjf` →
+`«SECRET MY_API_KEY redacted — the real value is live in your shell env; read it in bash as "$MY_API_KEY"»`.
 
 Redaction happens on two channels:
 
@@ -27,26 +32,35 @@ Redaction happens on two channels:
 A pattern fallback also catches well-known token shapes (AWS keys, JWTs,
 `sk-...`, GitHub/Slack tokens, PEM private keys) that leak into output even when
 they were never in an env var. When such a token is caught, it is **captured and
-auto-exported** to the shell: the matched value is assigned a stable placeholder
-(`$SECRET_JWT`, `$SECRET_JWT_2`, ...), written to `process.env`, and replaced in
-the context. So if you paste a JWT into the chat, it is redacted to
-`$SECRET_JWT` for the model *and* becomes a real shell variable you can use:
-`curl -H "Authorization: Bearer $SECRET_JWT"`. Captured names show up under
-`/secret-firewall` status.
+auto-exported** to the shell under a generated name (`SECRET_JWT`,
+`SECRET_JWT_2`, ...), written to `process.env`, and replaced in the context with
+the same self-describing placeholder. So if you paste a JWT into the chat, the
+model sees `... read it in bash as "$SECRET_JWT"` and can use it via
+`curl -H "Authorization: Bearer $SECRET_JWT"` without ever seeing the value.
+Captured names show up under `/secret-firewall` status.
+
+### Standing guidance in the system prompt
+
+A `before_agent_start` hook appends a short section to the system prompt every
+turn explaining the contract: placeholders are **not** the value and **not** an
+unset variable; the real value is **live in the shell**; reference it by name in
+a `bash` command; never echo/print/cat it. It also lists the currently available
+secret env var names. This is what stops the model from concluding "the env var
+isn't set" or treating the placeholder text as the literal value.
 
 ## Security model — the model never sees the value
 
 This extension uses the **shell-env-only** strategy:
 
 - The real value lives in `process.env` (which the `bash` tool inherits).
-- The model references it as a shell variable: `curl -H "Authorization: Bearer $SECRET_MY_API_KEY"`.
-- The shell resolves `$SECRET_MY_API_KEY` at execution time.
+- The model references it as a shell variable: `curl -H "Authorization: Bearer $MY_API_KEY"`.
+- The shell resolves `$MY_API_KEY` at execution time.
 - The value never returns to the context — any echo of it in tool output is
   redacted again.
 
 The extension never re-hydrates placeholders itself. If the model writes the
-literal *value* instead of the placeholder, that value is redacted on the way
-back, but the model must use the `$SECRET_*` reference for a command to actually
+literal *value* instead of the shell reference, that value is redacted on the
+way back, but the model must use the `$NAME` reference for a command to actually
 use the secret.
 
 ### Pasted/leaked tokens are captured and exported
@@ -56,7 +70,7 @@ not only masked — its real value is captured and exported as a `$SECRET_*` she
 variable on the fly. This means a token pasted into the chat becomes usable in
 bash (`$SECRET_JWT`) without the model ever seeing the value, and without
 needing it in `.env` beforehand. Distinct values caught by the same pattern get
-suffixed placeholders (`$SECRET_JWT_2`).
+suffixed names (`$SECRET_JWT_2`).
 
 ### Limits / non-goals
 
@@ -70,7 +84,7 @@ suffixed placeholders (`$SECRET_JWT_2`).
 ## Commands
 
 - `/secret-firewall` — show status (protected secrets, redaction count, the
-  `$SECRET_*` names the model may reference).
+  shell env var names the model may reference).
 - `/secret-firewall-toggle` — enable/disable redaction.
 - `/secret-firewall-rescan` — re-scan env + `.env` files.
 

--- a/packages/secret-firewall/src/index.ts
+++ b/packages/secret-firewall/src/index.ts
@@ -5,10 +5,6 @@ import { createRedactor } from "./redact.js";
 
 type ContentBlock = TextContent | ImageContent;
 
-function shellVarName(placeholder: string): string {
-  return placeholder.replace(/^\$/, "");
-}
-
 export default function (pi: ExtensionAPI) {
   let enabled = true;
   let entries: SecretEntry[] = [];
@@ -18,15 +14,14 @@ export default function (pi: ExtensionAPI) {
 
   function exportToShell(list: SecretEntry[]): void {
     for (const name of exportedNames) {
-      if (!list.some((e) => shellVarName(e.placeholder) === name)) {
+      if (!list.some((e) => e.name === name)) {
         delete process.env[name];
       }
     }
     exportedNames = [];
     for (const e of list) {
-      const varName = shellVarName(e.placeholder);
-      process.env[varName] = e.value;
-      exportedNames.push(varName);
+      process.env[e.name] = e.value;
+      exportedNames.push(e.name);
     }
   }
 
@@ -112,6 +107,45 @@ export default function (pi: ExtensionAPI) {
 
   pi.on("session_start", async (_event, ctx) => {
     rescan(ctx.cwd);
+  });
+
+  function buildGuidance(): string {
+    const shellVars = entries.map((e) => `$${e.name}`);
+    const lines = [
+      "## Secret firewall (IMPORTANT)",
+      "",
+      "Secret values in this session are redacted before you see them and replaced by a",
+      'placeholder that looks like: «SECRET NAME redacted — ... read it in bash as "$NAME"».',
+      "",
+      "What this means, concretely:",
+      "- The placeholder is NOT the secret value and NOT an empty/missing variable.",
+      "- The REAL value IS present and live in your shell environment under its original",
+      "  variable name. The env var is fully usable.",
+      "- To USE a secret, just reference it by name inside a `bash` command. Do NOT try to",
+      "  read it from the placeholder text, and do NOT assume it is unset.",
+      "",
+      "Examples (these WORK — the value is injected by the shell, never shown to you):",
+      "  bash: curl -H \"Authorization: Bearer $OPENAI_API_KEY\" https://api.example.com",
+      "  bash: psql \"$DATABASE_URL\" -c 'select 1'",
+      "  bash: aws s3 ls --profile \"$AWS_PROFILE\"",
+      "",
+      "Rules:",
+      "- Never echo, cat, print, or write a secret value to a file or to your output. If you",
+      "  do, it will just be redacted again — it is pointless and noisy.",
+      "- To check a secret exists, test it without printing it, e.g.",
+      '  bash: [ -n "$OPENAI_API_KEY" ] && echo present || echo missing',
+    ];
+    if (shellVars.length > 0) {
+      lines.push("", `Currently available secret env vars: ${shellVars.join(", ")}.`);
+    }
+    return lines.join("\n");
+  }
+
+  pi.on("before_agent_start", async (event) => {
+    if (!enabled) return;
+    return {
+      systemPrompt: `${event.systemPrompt}\n\n${buildGuidance()}`,
+    };
   });
 
   pi.on("context", async (event, _ctx) => {

--- a/packages/secret-firewall/src/redact.ts
+++ b/packages/secret-firewall/src/redact.ts
@@ -39,31 +39,32 @@ export function createRedactor(initial: SecretEntry[]): Redactor {
   let valueRules: { re: RegExp; placeholder: string }[] = [];
 
   const captured = new Map<string, DynamicSecret>();
-  const takenPlaceholders = new Set<string>();
+  const takenNames = new Set<string>();
   let pending: DynamicSecret[] = [];
 
   function refresh(entries: SecretEntry[]): void {
     valueRules = entries
       .filter((e) => e.value.length > 0)
       .map((e) => ({ re: new RegExp(escapeRe(e.value), "g"), placeholder: e.placeholder }));
-    for (const e of entries) takenPlaceholders.add(e.placeholder);
+    for (const e of entries) takenNames.add(e.name);
   }
 
-  function allocatePlaceholder(patternName: string): string {
-    const base = `$SECRET_${patternName}`;
-    if (!takenPlaceholders.has(base)) return base;
+  function allocateName(patternName: string): string {
+    const base = `SECRET_${patternName}`;
+    if (!takenNames.has(base)) return base;
     let i = 2;
-    while (takenPlaceholders.has(`${base}_${i}`)) i++;
+    while (takenNames.has(`${base}_${i}`)) i++;
     return `${base}_${i}`;
   }
 
   function capture(patternName: string, value: string): string {
     const existing = captured.get(value);
     if (existing) return existing.placeholder;
-    const placeholder = allocatePlaceholder(patternName);
-    takenPlaceholders.add(placeholder);
+    const name = allocateName(patternName);
+    takenNames.add(name);
+    const placeholder = `«SECRET ${patternName} redacted — the real value is live in your shell env; read it in bash as "$${name}"»`;
     const entry: DynamicSecret = {
-      name: placeholder.replace(/^\$/, ""),
+      name,
       placeholder,
       value,
     };

--- a/packages/secret-firewall/src/secrets.ts
+++ b/packages/secret-firewall/src/secrets.ts
@@ -42,11 +42,14 @@ function isSensitiveValue(name: string, value: string): boolean {
 }
 
 function toPlaceholder(name: string, taken: Set<string>): string {
-  const base = `$SECRET_${name.replace(/[^A-Za-z0-9_]/g, "_").toUpperCase()}`;
+  const shellVar = name.replace(/[^A-Za-z0-9_]/g, "_");
+  const make = (tag: string) =>
+    `«SECRET ${name}${tag} redacted — the real value is live in your shell env; read it in bash as "$${shellVar}"»`;
+  const base = make("");
   if (!taken.has(base)) return base;
   let i = 2;
-  while (taken.has(`${base}_${i}`)) i++;
-  return `${base}_${i}`;
+  while (taken.has(make(`#${i}`))) i++;
+  return make(`#${i}`);
 }
 
 function parseDotenv(path: string): Map<string, string> {

--- a/packages/secret-firewall/test/smoke.test.ts
+++ b/packages/secret-firewall/test/smoke.test.ts
@@ -51,10 +51,12 @@ test("never treats infra/session env vars as secrets", () => {
   assert.ok(!names.includes("SSH_AUTH_SOCK"));
 });
 
-test("assigns stable $SECRET_ placeholders", () => {
+test("assigns stable self-descriptive placeholders", () => {
   withEnvFile(["STRIPE_SECRET=rk_live_xYz0123456789abcdef"], (dir) => {
     const entry = discoverSecrets(dir).find((e) => e.name === "STRIPE_SECRET");
-    assert.equal(entry?.placeholder, "$SECRET_STRIPE_SECRET");
+    assert.ok(entry);
+    assert.ok(entry.placeholder.includes("SECRET STRIPE_SECRET"));
+    assert.ok(entry.placeholder.includes('"$STRIPE_SECRET"'));
   });
 });
 
@@ -62,7 +64,8 @@ test("redactor replaces real values with placeholders", () => {
   withEnvFile(["DATABASE_URL=postgres://u:supersecretpw@db:5432/app"], (dir) => {
     const r = createRedactor(discoverSecrets(dir));
     const out = r.redactString("connecting to postgres://u:supersecretpw@db:5432/app now");
-    assert.equal(out.text, "connecting to $SECRET_DATABASE_URL now");
+    assert.ok(!out.text.includes("supersecretpw"));
+    assert.ok(out.text.includes('"$DATABASE_URL"'));
     assert.equal(out.hits, 1);
   });
 });
@@ -70,7 +73,8 @@ test("redactor replaces real values with placeholders", () => {
 test("redactor catches token patterns not present in env", () => {
   const r = createRedactor([]);
   const out = r.redactString("leaked AKIAIOSFODNN7EXAMPLE here");
-  assert.ok(out.text.includes("$SECRET_AWS_ACCESS_KEY"));
+  assert.ok(!out.text.includes("AKIAIOSFODNN7EXAMPLE"));
+  assert.ok(out.text.includes('"$SECRET_AWS_ACCESS_KEY"'));
 });
 
 test("redactor leaves non-secret text untouched", () => {
@@ -84,11 +88,12 @@ test("captures pattern-matched secrets for shell export", () => {
   const r = createRedactor([]);
   const jwt = fakeJwt("user-123");
   const out = r.redactString(`Authorization: Bearer ${jwt}`);
-  assert.equal(out.text, "Authorization: Bearer $SECRET_JWT");
+  assert.ok(!out.text.includes(jwt));
+  assert.ok(out.text.includes('"$SECRET_JWT"'));
   const captured = r.drainCaptured();
   assert.equal(captured.length, 1);
   assert.equal(captured[0].name, "SECRET_JWT");
-  assert.equal(captured[0].placeholder, "$SECRET_JWT");
+  assert.ok(captured[0].placeholder.includes('"$SECRET_JWT"'));
   assert.equal(captured[0].value, jwt);
 });
 
@@ -106,7 +111,10 @@ test("distinct pattern matches get distinct placeholders", () => {
   const a = fakeJwt("aaa");
   const b = fakeJwt("bbb");
   const out = r.redactString(`${a} and ${b}`);
-  assert.equal(out.text, "$SECRET_JWT and $SECRET_JWT_2");
+  assert.ok(!out.text.includes(a));
+  assert.ok(!out.text.includes(b));
+  assert.ok(out.text.includes('"$SECRET_JWT"'));
+  assert.ok(out.text.includes('"$SECRET_JWT_2"'));
   const captured = r.drainCaptured();
   assert.equal(captured.length, 2);
 });


### PR DESCRIPTION
## Problem

The firewall replaced secrets with opaque `$SECRET_DATABASE_PASSWORD_1` placeholders. The model had zero context about what they meant, so it concluded the env var wasn't set or treated the placeholder string as the literal value.

## Changes

**Self-describing placeholders** (`secrets.ts`, `redact.ts`)
Placeholders now encode the exact shell var to use:
```
«SECRET DATABASE_PASSWORD redacted — the real value is live in your shell env; read it in bash as "$DATABASE_PASSWORD"»
```
Env/dotenv secrets use the original name (`$DATABASE_PASSWORD`); pattern-captured tokens (JWT/AWS/etc.) use an exported name (`$SECRET_JWT`).

**Standing system-prompt guidance** (`index.ts`)
New `before_agent_start` hook appends a section every turn: placeholder ≠ unset var, real value is live in shell, use `$NAME` in bash, never echo/print it. Lists current secret var names.

**Fixed `exportToShell`**
Uses `e.name` directly instead of deriving it from the now-descriptive placeholder string.

## Testing

- `pnpm test`: 9/9 pass (smoke tests updated to new format)
- `pnpm build`: clean
- `lsp_diagnostics`: no errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Secret placeholders are now more descriptive, showing how to access the real value from the shell environment.
  * Available secret environment variable names can now be surfaced in startup guidance.

* **Bug Fixes**
  * Improved secret redaction so captured sensitive values are replaced more reliably.
  * Updated handling for newly detected secrets to keep naming consistent.

* **Documentation**
  * Clarified secret-handling behavior and command output wording in the guide.

* **Tests**
  * Updated coverage to match the new placeholder format and stronger redaction checks.

* **Chores**
  * Bumped the worktree package version to 1.9.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->