### PR TITLE
fix(widget-wrangler): resolve ctrl+shift+w conflict with pi-web-access

### DIFF
--- a/packages/widget-wrangler/README.md
+++ b/packages/widget-wrangler/README.md
@@ -44,7 +44,7 @@ pi --widget-wrangler-key=
 
 > Note on `Alt`/`Option`: `alt+*` shortcuts are reliable on Linux but depend on
 > terminal configuration on macOS (e.g. iTerm2 needs "Use ⌥ as Meta"). The
-> default `ctrl+shift+w` is the most portable choice across macOS, Linux, and
+> default `ctrl+shift+g` is the most portable choice across macOS, Linux, and
 > Windows.
 
 ## Install

--- a/packages/widget-wrangler/package.json
+++ b/packages/widget-wrangler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-widget-wrangler",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "PI extension that corrals widgets from every extension into one panel where you show or hide each one 🤠",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/widget-wrangler/src/index.ts
+++ b/packages/widget-wrangler/src/index.ts
@@ -174,9 +174,9 @@ export default function widgetWranglerExtension(pi: ExtensionAPI) {
   });
 
   pi.registerFlag("widget-wrangler-key", {
-    description: "Keybinding that opens the Widget Wrangler panel (e.g. ctrl+shift+w, alt+w). Empty disables the shortcut.",
+    description: "Keybinding that opens the Widget Wrangler panel (e.g. ctrl+shift+g, alt+w). Empty disables the shortcut.",
     type: "string",
-    default: "ctrl+shift+w",
+    default: "ctrl+shift+g",
   });
 
   const shortcutKey = String(pi.getFlag("widget-wrangler-key") ?? "").trim();


### PR DESCRIPTION
## Problema

`pi-widget-wrangler` e `pi-web-access` registravam ambos o atalho `ctrl+shift+w`. O pi-web-access vence o conflito, então o atalho do widget-wrangler não funcionava para os devs:

```
Extension shortcut conflict: 'ctrl+shift+w' registered by both
.../pi-widget-wrangler/dist/index.js and .../pi-web-access/index.ts.
Using .../pi-web-access/index.ts.
```

## Solução

Muda o default do flag `widget-wrangler-key` de `ctrl+shift+w` para `ctrl+shift+g` (atalho livre — `ctrl+o`, `ctrl+shift+s` e `ctrl+shift+w` já estão tomados pelas demais extensões).

- `src/index.ts`: novo default `ctrl+shift+g`
- `README.md`: atualizado
- `package.json`: bump `1.0.0` → `1.0.1`

O comando `/wrangle` continua funcionando normalmente; quem quiser outro atalho pode sobrescrever com `--widget-wrangler-key=...`.

## O que foi testado

- `pnpm lint` (tsc --noEmit) passou
- Verificado que não há mais menções a `ctrl+shift+w` no pacote

## Próximo passo

Após o merge, publicar `@arvoretech/pi-widget-wrangler@1.0.1` no npm para os devs receberem o fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Widget Wrangler keybinding guidance to show the current default shortcut: `ctrl+shift+g`.

* **Chores**
  * Bumped the Widget Wrangler package version to `1.0.1`.
  * Updated the default shortcut shown to users so it matches the documented value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->