### PR TITLE
feat(secret-firewall): redact secrets in user input at submit time

### DIFF
--- a/packages/secret-firewall/README.md
+++ b/packages/secret-firewall/README.md
@@ -21,8 +21,12 @@ model exactly how to use it. For env/dotenv secrets the shell variable is the
 secret's **original name**: `MY_API_KEY=xptolksjf` →
 `«SECRET MY_API_KEY redacted — the real value is live in your shell env; read it in bash as "$MY_API_KEY"»`.
 
-Redaction happens on two channels:
+Redaction happens on three channels:
 
+- **`input` hook** — the user's own message is redacted at the moment it is
+  submitted, before it is stored in the session or shown in the transcript. So a
+  pasted secret never persists in the user's session and the user sees the
+  placeholder too, making it clear the value was redacted.
 - **`context` hook** — every message sent to the model (user text, assistant
   text, thinking, and tool-call arguments) has secret values swapped for their
   placeholder.

--- a/packages/secret-firewall/src/index.ts
+++ b/packages/secret-firewall/src/index.ts
@@ -148,6 +148,14 @@ export default function (pi: ExtensionAPI) {
     };
   });
 
+  pi.on("input", async (event) => {
+    if (!enabled) return { action: "continue" };
+    const { text, hits } = redactor.redactString(event.text);
+    exportCaptured();
+    if (hits === 0) return { action: "continue" };
+    return { action: "transform", text, images: event.images };
+  });
+
   pi.on("context", async (event, _ctx) => {
     if (!enabled) return;
     let changed = false;


### PR DESCRIPTION
## Summary

The secret-firewall só redactava segredos no payload enviado ao modelo (`context` hook). A mensagem original digitada pelo usuário continuava crua no transcript e persistia na sessão — o segredo ficava visível e gravado.

Este PR adiciona um hook `input` que redacta os segredos **na própria mensagem do usuário**, no momento do submit, antes de ser armazenada/exibida.

## Changes

- **`input` hook** em `packages/secret-firewall/src/index.ts`: roda `redactor.redactString` no texto do usuário e retorna `{ action: "transform", text }` quando há hits, trocando o segredo pelo placeholder na sessão e no transcript.
- Segredos por padrão (JWT, AWS, `sk-...`, GitHub/Slack, PEM) colados no chat continuam sendo capturados e exportados pro shell a partir do `input` hook (`exportCaptured()`), permanecendo usáveis via `$SECRET_*`.
- README atualizado: agora documenta os **três** canais de redação (`input`, `context`, `tool_result`).

## Why

- O segredo não persiste mais na sessão do usuário.
- Fica claro pro usuário que o valor foi redactado (ele vê o placeholder).
- Defesa em profundidade: o `context` hook permanece como fallback para mensagens antigas/resumidas.

## Testing

- `tsc --noEmit` passou (exit 0).
- Suite de testes existente: 9/9 passando. A lógica de redação reutiliza `redactString`, já coberto por testes unitários (valores de env/dotenv e padrões).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Secret redaction now happens as soon as a message is submitted, before it appears in the conversation history.
  * Secrets can be captured and applied to the shell environment more quickly when detected.
* **Bug Fixes**
  * Prevents pasted secrets from persisting in the transcript or session state when redaction is enabled.
  * Shows a redacted placeholder immediately for messages containing sensitive content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->