### PR TITLE
chore(secret-firewall): bump version to 0.3.0

### DIFF
--- a/packages/secret-firewall/package.json
+++ b/packages/secret-firewall/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-secret-firewall",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Redacts secrets (env vars, .env files, token patterns) from the model context and tool outputs, exposing them only as $SECRET_* shell env vars the model can reference but never read",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Resumo

Bump da versão do package \`@arvoretech/pi-secret-firewall\` de \`0.2.0\` → \`0.3.0\`.

O bump minor reflete a feature já mergeada em \`main\` ([49a7937](https://github.com/arvoreeducacao/arvore-pi-extensions/commit/49a7937)) que adicionou redaction de secrets no input do próprio usuário no momento do submit — antes apenas o contexto do modelo era redacted, então o secret cru persistia na sessão do usuário e ficava visível na TUI.

## Mudanças

- \`packages/secret-firewall/package.json\`: \`version\` \`0.2.0\` → \`0.3.0\`

## Testes

- N/A — apenas bump de versão. A feature correspondente já está em main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped the package version to **0.3.0**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->