### PR TITLE
fix(pi-codebase-index): limitar tamanho de chunk por caracteres

### DIFF
--- a/packages/pi-codebase-index/package.json
+++ b/packages/pi-codebase-index/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-codebase-index",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "PI extension for semantic codebase search (vendor-neutral backend contract)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/pi-codebase-index/src/chunker.ts
+++ b/packages/pi-codebase-index/src/chunker.ts
@@ -296,6 +296,7 @@ function capChunkSizes(chunks: Chunk[]): Chunk[] {
 function splitChunkByChars(chunk: Chunk): Chunk[] {
   const parts: Chunk[] = [];
   const content = chunk.content;
+  const baseLine = chunk.lineStart ?? 1;
   let offset = 0;
   let part = 1;
   while (offset < content.length) {
@@ -306,13 +307,32 @@ function splitChunkByChars(chunk: Chunk): Chunk[] {
         end = lastBreak + 1;
       }
     }
+    const slice = content.slice(offset, end);
+    const linesBefore = countLines(content.slice(0, offset));
+    const sliceLines = countLines(slice);
+    const lineStart = baseLine + linesBefore;
     parts.push({
       ...chunk,
       symbol: `${chunk.symbol}#chars${part}`,
-      content: content.slice(offset, end),
+      content: slice,
+      lineStart,
+      lineEnd: lineStart + Math.max(sliceLines - 1, 0),
     });
     offset = end;
     part += 1;
   }
   return parts;
+}
+
+function countLines(text: string): number {
+  if (text.length === 0) {
+    return 0;
+  }
+  let count = 1;
+  for (let i = 0; i < text.length; i += 1) {
+    if (text[i] === "\n") {
+      count += 1;
+    }
+  }
+  return count;
 }

--- a/packages/pi-codebase-index/src/chunker.ts
+++ b/packages/pi-codebase-index/src/chunker.ts
@@ -7,6 +7,7 @@ import type { DefNode } from "./ast.js";
 const MAX_LINES_PER_CHUNK = 200;
 const OVERLAP_LINES = 20;
 const MIN_PREAMBLE_LINES = 3;
+const MAX_CHUNK_CHARS = 24_000;
 
 const LANG_BY_EXT: Record<string, string> = {
   ".ts": "typescript",
@@ -270,12 +271,48 @@ export async function chunkFile(
     try {
       const ast = await astChunks(repo, relPath, astLang, lang, lines, fileHash);
       if (ast && ast.length > 0) {
-        return ast;
+        return capChunkSizes(ast);
       }
     } catch {
       // falls through to window chunking
     }
   }
 
-  return windowChunks(repo, relPath, lang, lines, fileHash);
+  return capChunkSizes(windowChunks(repo, relPath, lang, lines, fileHash));
+}
+
+function capChunkSizes(chunks: Chunk[]): Chunk[] {
+  const result: Chunk[] = [];
+  for (const chunk of chunks) {
+    if (chunk.content.length <= MAX_CHUNK_CHARS) {
+      result.push(chunk);
+      continue;
+    }
+    result.push(...splitChunkByChars(chunk));
+  }
+  return result;
+}
+
+function splitChunkByChars(chunk: Chunk): Chunk[] {
+  const parts: Chunk[] = [];
+  const content = chunk.content;
+  let offset = 0;
+  let part = 1;
+  while (offset < content.length) {
+    let end = Math.min(offset + MAX_CHUNK_CHARS, content.length);
+    if (end < content.length) {
+      const lastBreak = content.lastIndexOf("\n", end);
+      if (lastBreak > offset) {
+        end = lastBreak + 1;
+      }
+    }
+    parts.push({
+      ...chunk,
+      symbol: `${chunk.symbol}#chars${part}`,
+      content: content.slice(offset, end),
+    });
+    offset = end;
+    part += 1;
+  }
+  return parts;
 }


### PR DESCRIPTION
## Contexto

O monitor Datadog **[API Monitor] 50 Erros Identificados na Rota POST /api-arvore/codebase-index/index** (id `155588757`) disparou por >100 respostas HTTP 500 na rota de indexação do code-index.

Causa raiz: `AI_APICallError: Invalid 'input[24]': maximum input length is 8192 tokens.` — o modelo de embedding da OpenAI rejeita qualquer input acima de 8192 tokens, e um único chunk grande derruba o batch inteiro (`embedMany`).

O chunker limitava apenas por **linhas** (`MAX_LINES_PER_CHUNK = 200`), sem teto de tamanho. Arquivos com linhas muito longas (minificados, JSON, símbolos densos) podiam gerar chunks < 200 linhas porém > 8192 tokens.

## Mudanças

- Novo limite `MAX_CHUNK_CHARS = 24000` (~abaixo de 8192 tokens com margem).
- `capChunkSizes` aplicado como passe final tanto no caminho AST quanto no window chunking.
- `splitChunkByChars` quebra chunks acima do limite respeitando quebras de linha, com sufixo `#chars<N>` no symbol.
- Bump de versão `0.1.4` → `0.1.5`.

## Correção complementar

Rede de proteção definitiva no backend em api-arvore (trunca o input de embedding): PR separado.

## Teste

- `tsc --noEmit` do pacote passa sem erros.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chunking now caps oversized pieces by maximum character length, producing smaller, more consistent chunks.
  * Large chunks are split more cleanly, with an added preference to break on newline boundaries when possible.

* **Chores**
  * Updated the package version to `0.1.5`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->