### PR TITLE
fix(git-review): prevent crash on concurrent /review sessions

### DIFF
--- a/packages/git-review/package.json
+++ b/packages/git-review/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-git-review",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "PI extension that opens a browser-based git diff reviewer; selected code + comments are sent to the agent in real time",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/git-review/src/server.ts
+++ b/packages/git-review/src/server.ts
@@ -960,6 +960,7 @@ export function startGitReviewServer(
     });
 
     const wss = new WebSocketServer({ server: httpServer, path: "/ws" });
+    wss.on("error", () => {});
 
     wss.on("connection", (ws, req) => {
       const url = new URL(req.url || "/", `http://127.0.0.1:${port}`);


### PR DESCRIPTION
## Summary
Running `/review` in a second pi agent while a first one already had the git-review server open would crash the entire pi process instead of just failing to start the server.

## Root cause
`git-review`'s server scans ports 9890–9899 and relies on `httpServer.on("error", reject)` to catch `EADDRINUSE` and try the next port. However, `ws`'s `WebSocketServer` also attaches to the underlying `http.Server` and re-emits its `error` events on itself. Since `wss` had no `error` listener, Node treated the re-emitted `EADDRINUSE` as an unhandled `error` event on an `EventEmitter`, which throws and crashes the process — bypassing the intended retry loop entirely.

## Fix
Add a no-op `wss.on("error", () => {})` listener right after `wss` is constructed. `httpServer`'s own `error` → `reject()` handler still drives the existing port-scan/retry logic as originally designed.

## Testing
- Reproduced the crash in isolation (two servers binding the same port without the fix throws `Unhandled 'error' event` and exits with code 1).
- Confirmed the fix removes the crash; second server's `listen` promise now rejects cleanly with `EADDRINUSE`, allowing `ensureServer`'s port-scan loop to continue to the next port as intended.
- `pnpm build` and `lsp_diagnostics` clean, no type errors.

Bumped `@arvoretech/pi-git-review` to 0.4.1.