### PR TITLE
feat(widget-wrangler): config global de widgets escondidos entre chats

### DIFF
--- a/packages/widget-wrangler/README.md
+++ b/packages/widget-wrangler/README.md
@@ -15,8 +15,9 @@ that calls `setWidget` shows up in the corral automatically.
 - A panel (`/wrangle` or `Ctrl+Shift+W`) lists every widget it has seen, with a
   `shown` / `hidden` toggle each — same feel as Pi's `/mcp` panel.
 - Hidden widgets are suppressed before they ever reach the screen. Your choices
-  persist per session branch (saved via session entries), so they survive
-  reloads and branch navigation.
+  persist **globally** for your user (saved to `~/.pi/agent/widget-wrangler.json`),
+  so the same widgets stay hidden across every chat, reload, and branch. A
+  choice made in one session takes effect in all others.
 - It never touches `ctx.ui.notify`, so error/info notifications from your
   extensions still pop up and fade on their own — even for a hidden widget.
 

--- a/packages/widget-wrangler/src/index.ts
+++ b/packages/widget-wrangler/src/index.ts
@@ -7,7 +7,7 @@ import type {
 } from "@earendil-works/pi-coding-agent";
 import { getAgentDir, getSettingsListTheme } from "@earendil-works/pi-coding-agent";
 import { Container, type SettingItem, SettingsList, Text } from "@earendil-works/pi-tui";
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 
 const CUSTOM_TYPE = "widget-wrangler-config";
@@ -17,22 +17,27 @@ function configPath(): string {
   return join(getAgentDir(), "widget-wrangler.json");
 }
 
-function loadGlobalConfig(): string[] {
+function loadGlobalConfig(): string[] | null {
   try {
     const raw = readFileSync(configPath(), "utf8");
     const data = JSON.parse(raw) as WranglerState | undefined;
-    return Array.isArray(data?.disabled) ? data.disabled : [];
+    return Array.isArray(data?.disabled) ? data.disabled : null;
   } catch {
-    return [];
+    return null;
   }
 }
 
-function saveGlobalConfig(state: WranglerState): void {
+function saveGlobalConfig(state: WranglerState): boolean {
   try {
     const path = configPath();
     mkdirSync(dirname(path), { recursive: true });
-    writeFileSync(path, `${JSON.stringify(state, null, 2)}\n`, "utf8");
-  } catch {}
+    const tmp = `${path}.${process.pid}.tmp`;
+    writeFileSync(tmp, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+    renameSync(tmp, path);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 type WidgetContent = Parameters<ExtensionUIContext["setWidget"]>[1];
@@ -53,18 +58,16 @@ export default function widgetWranglerExtension(pi: ExtensionAPI) {
   let originalSetWidget: ExtensionUIContext["setWidget"] | null = null;
   let patchedUi: ExtensionUIContext | null = null;
 
-  function persist() {
-    saveGlobalConfig({ disabled: Array.from(disabled) });
+  function persist(): boolean {
+    return saveGlobalConfig({ disabled: Array.from(disabled) });
   }
 
   function restoreConfig(ctx: ExtensionContext) {
     let saved = loadGlobalConfig();
-    if (saved.length === 0) {
+    if (saved === null) {
       const legacy = readLegacyBranchConfig(ctx);
-      if (legacy.length > 0) {
-        saved = legacy;
-        saveGlobalConfig({ disabled: saved });
-      }
+      saved = legacy;
+      saveGlobalConfig({ disabled: saved });
     }
     disabled.clear();
     for (const key of saved) disabled.add(key);
@@ -149,11 +152,13 @@ export default function widgetWranglerExtension(pi: ExtensionAPI) {
     });
   }
 
-  function setHidden(key: string, hidden: boolean) {
+  function setHidden(key: string, hidden: boolean, ui?: ExtensionUIContext) {
     if (hidden) disabled.add(key);
     else disabled.delete(key);
     applyWidget(key);
-    persist();
+    if (!persist()) {
+      ui?.notify(`Failed to save widget-wrangler config to ${configPath()} 🤠`, "error");
+    }
   }
 
   async function openPanel(ctx: ExtensionContext) {
@@ -183,7 +188,7 @@ export default function widgetWranglerExtension(pi: ExtensionAPI) {
         Math.min(items.length + 2, 15),
         getSettingsListTheme(),
         (id, newValue) => {
-          setHidden(id, newValue === "hidden");
+          setHidden(id, newValue === "hidden", ctx.ui);
           tui.requestRender();
         },
         () => done(undefined),

--- a/packages/widget-wrangler/src/index.ts
+++ b/packages/widget-wrangler/src/index.ts
@@ -5,11 +5,35 @@ import type {
   ExtensionWidgetOptions,
   WidgetPlacement,
 } from "@earendil-works/pi-coding-agent";
-import { getSettingsListTheme } from "@earendil-works/pi-coding-agent";
+import { getAgentDir, getSettingsListTheme } from "@earendil-works/pi-coding-agent";
 import { Container, type SettingItem, SettingsList, Text } from "@earendil-works/pi-tui";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 
 const CUSTOM_TYPE = "widget-wrangler-config";
 const OWN_WIDGET_KEY = "widget-wrangler";
+
+function configPath(): string {
+  return join(getAgentDir(), "widget-wrangler.json");
+}
+
+function loadGlobalConfig(): string[] {
+  try {
+    const raw = readFileSync(configPath(), "utf8");
+    const data = JSON.parse(raw) as WranglerState | undefined;
+    return Array.isArray(data?.disabled) ? data.disabled : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveGlobalConfig(state: WranglerState): void {
+  try {
+    const path = configPath();
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+  } catch {}
+}
 
 type WidgetContent = Parameters<ExtensionUIContext["setWidget"]>[1];
 
@@ -30,10 +54,23 @@ export default function widgetWranglerExtension(pi: ExtensionAPI) {
   let patchedUi: ExtensionUIContext | null = null;
 
   function persist() {
-    pi.appendEntry<WranglerState>(CUSTOM_TYPE, { disabled: Array.from(disabled) });
+    saveGlobalConfig({ disabled: Array.from(disabled) });
   }
 
-  function restoreFromBranch(ctx: ExtensionContext) {
+  function restoreConfig(ctx: ExtensionContext) {
+    let saved = loadGlobalConfig();
+    if (saved.length === 0) {
+      const legacy = readLegacyBranchConfig(ctx);
+      if (legacy.length > 0) {
+        saved = legacy;
+        saveGlobalConfig({ disabled: saved });
+      }
+    }
+    disabled.clear();
+    for (const key of saved) disabled.add(key);
+  }
+
+  function readLegacyBranchConfig(ctx: ExtensionContext): string[] {
     const entries = ctx.sessionManager.getBranch();
     let saved: string[] | undefined;
     for (const entry of entries) {
@@ -42,8 +79,7 @@ export default function widgetWranglerExtension(pi: ExtensionAPI) {
         if (data?.disabled) saved = data.disabled;
       }
     }
-    disabled.clear();
-    for (const key of saved ?? []) disabled.add(key);
+    return saved ?? [];
   }
 
   function isEnabled(key: string): boolean {
@@ -192,14 +228,14 @@ export default function widgetWranglerExtension(pi: ExtensionAPI) {
   pi.on("session_start", (_event, ctx) => {
     if (!ctx.hasUI) return;
     patchSetWidget(ctx.ui);
-    restoreFromBranch(ctx);
+    restoreConfig(ctx);
     for (const key of registry.keys()) applyWidget(key);
   });
 
   pi.on("session_tree", (_event, ctx) => {
     if (!ctx.hasUI) return;
     patchSetWidget(ctx.ui);
-    restoreFromBranch(ctx);
+    restoreConfig(ctx);
     for (const key of registry.keys()) applyWidget(key);
   });
 }


### PR DESCRIPTION
## Resumo

O `widget-wrangler` persistia os widgets escondidos por branch de sessão (via `pi.appendEntry`), então cada chat começava do zero e a escolha não valia entre sessões.

Agora a configuração é **global por usuário**: gravada e lida de `~/.pi/agent/widget-wrangler.json` usando `getAgentDir()` do SDK. Esconder um widget em qualquer chat passa a valer para todos — novos e existentes, reloads e navegação de branch.

## Mudanças

- `persist()` grava no arquivo global (`saveGlobalConfig`).
- `restoreFromBranch()` → `restoreConfig()`: lê do arquivo global; se estiver vazio, migra uma única vez a config legada da branch (custom entry `widget-wrangler-config`) para o arquivo global.
- Handlers `session_start`/`session_tree` atualizados para `restoreConfig`.
- README atualizado descrevendo a persistência global.

## Testado

- `pnpm build` (tsc) passou e `dist/` foi reconstruído.
- Tipos validados via LSP (sem diagnostics).

## Notas

- Requer SDK `@earendil-works/pi-coding-agent` >= 0.79.1 (`getAgentDir` exportado); peerDep do pacote é `>=0.74.0`.
- `dist/` não é versionado (está no `.gitignore`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Widget visibility preferences now persist globally for your account across chats, reloads, and branch navigation.
  * Existing saved preferences are automatically carried over to the new persistence behavior.

* **Documentation**
  * Updated the help text to explain the new global saving behavior and where preferences are stored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->