### PR TITLE
chore(catch-the-fox): bump para 0.2.0

### DIFF
--- a/packages/catch-the-fox/package.json
+++ b/packages/catch-the-fox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-catch-the-fox",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "PI extension: uma raposa em pixel-art que reage ao que o agente está fazendo (farejando, cavando, executando, dormindo)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Bump de versão para 0.2.0

Publica no npm as mudanças visuais que foram mergeadas no #108 mas ficaram sem versão nova (o publish só sobe quando a versão muda):

- Sprite reduzido de 10 → 6 linhas de pixel (3 linhas de texto)
- Label do estado acima da raposa, com linha em branco de espaçamento
- Sem emoji no label

Após o merge, `@arvoretech/pi-catch-the-fox@0.2.0` fica disponível no npm.