### PR TITLE
fix: pi-codebase-index robustness and data-heavy file handling

### DIFF
--- a/packages/pi-codebase-index/src/chunker.ts
+++ b/packages/pi-codebase-index/src/chunker.ts
@@ -7,7 +7,9 @@ import type { DefNode } from "./ast.js";
 const MAX_LINES_PER_CHUNK = 200;
 const OVERLAP_LINES = 20;
 const MIN_PREAMBLE_LINES = 3;
-const MAX_CHUNK_CHARS = 24_000;
+const MAX_CHUNK_CHARS = 12_000;
+const MAX_LINE_CHARS = 5_000;
+const MAX_AVG_LINE_CHARS = 400;
 
 const LANG_BY_EXT: Record<string, string> = {
   ".ts": "typescript",
@@ -265,6 +267,13 @@ export async function chunkFile(
 
   const lang = langOf(relPath);
   const lines = content.split("\n");
+
+  const longestLine = lines.reduce((max, l) => (l.length > max ? l.length : max), 0);
+  const avgLine = content.length / Math.max(lines.length, 1);
+  if (longestLine > MAX_LINE_CHARS || avgLine > MAX_AVG_LINE_CHARS) {
+    return [];
+  }
+
   const astLang = astLangOf(relPath);
 
   if (astLang) {

--- a/packages/pi-codebase-index/src/merkle.ts
+++ b/packages/pi-codebase-index/src/merkle.ts
@@ -7,6 +7,8 @@ import { promisify } from "node:util";
 const exec = promisify(execFile);
 
 const MAX_FILE_BYTES = 256 * 1024;
+const MAX_LINE_CHARS = 5_000;
+const MAX_AVG_LINE_CHARS = 400;
 
 const INDEXABLE_EXTENSIONS = new Set([
   ".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs",
@@ -55,10 +57,31 @@ async function hashFile(absPath: string): Promise<string | null> {
   try {
     const content = await readFile(absPath);
     if (content.byteLength > MAX_FILE_BYTES) return null;
+    if (isDataHeavy(content)) return null;
     return createHash("sha256").update(content).digest("hex");
   } catch {
     return null;
   }
+}
+
+function isDataHeavy(content: Buffer): boolean {
+  const text = content.toString("utf-8");
+  let longest = 0;
+  let lineLen = 0;
+  for (let i = 0; i < text.length; i += 1) {
+    if (text[i] === "\n") {
+      if (lineLen > longest) longest = lineLen;
+      lineLen = 0;
+    } else {
+      lineLen += 1;
+    }
+  }
+  if (lineLen > longest) longest = lineLen;
+  if (longest > MAX_LINE_CHARS) return true;
+
+  const lineCount = (text.match(/\n/g)?.length ?? 0) + 1;
+  const avg = text.length / lineCount;
+  return avg > MAX_AVG_LINE_CHARS;
 }
 
 export async function snapshotRepo(repoDir: string, name: string): Promise<RepoSnapshot | null> {

--- a/packages/pi-codebase-index/src/sync.ts
+++ b/packages/pi-codebase-index/src/sync.ts
@@ -90,6 +90,8 @@ async function indexChanged(
 
   const total = changed.length;
   let done = 0;
+  let indexed = 0;
+  let failed = 0;
   let pending: Awaited<ReturnType<typeof chunkFile>> = [];
 
   const flush = async () => {
@@ -99,9 +101,17 @@ async function indexChanged(
     for (let attempt = 0; attempt < 4; attempt++) {
       try {
         await index(batch);
+        indexed += batch.length;
         return;
-      } catch {
-        if (attempt === 3) break;
+      } catch (error) {
+        if (attempt === 3) {
+          failed += batch.length;
+          throw new Error(
+            `codebase: index flush failed after 4 attempts (${batch.length} chunks): ${
+              error instanceof Error ? error.message : String(error)
+            }`
+          );
+        }
         await new Promise((r) => setTimeout(r, 500 * 2 ** attempt));
       }
     }
@@ -122,6 +132,14 @@ async function indexChanged(
     }
   }
 
-  await flush();
+  try {
+    await flush();
+  } catch (error) {
+    setStatus(
+      `codebase: ⚠ indexed ${indexed} chunks, ${failed} failed — will retry next sync`
+    );
+    throw error instanceof Error ? error : new Error(String(error));
+  }
+
   setStatus(`codebase: ✓ indexed ${total} files`);
 }


### PR DESCRIPTION
## Problem
The pi-codebase-index extension showed "codebase: indexing…" on every session start even without real code changes. Investigation revealed two issues:

1. **Silent error swallowing in flush()**: After 4 failed retry attempts, the flush() function would break without propagating the error, causing "✓ indexed N files" to display even when chunks weren't persisted. Files remained permanently in the "changed" state.

2. **Data-heavy files causing 500 errors**: Files like `reportPdfAssets.ts` (base64) and `lib/icons/index.js` generated chunks up to 24000 chars, exceeding the token limit of text-embedding-3-large (8191 tokens), causing HTTP 500 errors that were silently retried endlessly.

## Solution
- **sync.ts**: flush() now propagates errors after 4 retries and reports "⚠ indexed X, Y failed — will retry next sync"
- **chunker.ts**: Reduce MAX_CHUNK_CHARS from 24000 → 12000 for safety margin
- **merkle.ts**: Add isDataHeavy() guard to exclude minified/base64 files from the snapshot (prevents files from perpetually appearing as "changed")

## Verification
- All 19 workspace repos now at 100% indexed (changed: 0)
- Session starts show "✓ up to date" instead of "indexing"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved indexing reliability by skipping files that appear too dense or unusually formatted to process safely.
  * Added clearer failure handling during sync, including more informative error reporting and automatic retry on the next run.
  * Better tracks how many items were indexed versus failed, helping sync status reflect progress more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->