### PR TITLE
chore(widget-wrangler): publish global config persistence (1.0.2)

### DIFF
--- a/packages/widget-wrangler/package.json
+++ b/packages/widget-wrangler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-widget-wrangler",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "PI extension that corrals widgets from every extension into one panel where you show or hide each one 🤠",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Problem
Widget Wrangler hidden-widget choices were not persisting across chats. Hiding a widget (e.g. the memory widget) in one chat did not keep it hidden when opening another chat/branch.

## Root cause
The global persistence commits (`71cb906`, `c159d32`) added the correct behavior — saving hidden widgets to `~/.pi/agent/widget-wrangler.json` so they persist globally across all chats — but **never bumped the package version**. It stayed at `1.0.1`, which was already published to npm with the *old* branch-scoped implementation (`sessionManager.getBranch()` + custom session entries).

As a result, installs kept pulling the old `1.0.1` from npm, where choices only persisted per-branch — so hidden widgets reappeared in new chats.

## Fix
Bump version to `1.0.2` so CI publishes the already-merged global-persistence code.

## Verification
- Source at `main` already contains the global logic (`getAgentDir()`, `loadGlobalConfig`, `~/.pi/agent/widget-wrangler.json`)
- Built dist confirms `getAgentDir` + `widget-wrangler.json` present
- CI publish step skips versions already on npm, so the bump is required to ship
