### PR TITLE
feat(orca-bridge): extensão pi que faz ponte com o orca-cli (status/terminal/orquestração/computer)

### DIFF
--- a/packages/orca-bridge/package.json
+++ b/packages/orca-bridge/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@arvoretech/pi-orca-bridge",
+  "version": "1.0.0",
+  "description": "PI extension bridging pi to orca-cli: worktree status sync, long-running terminals, orchestration, and computer use",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "lint": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": ">=0.74.0"
+  },
+  "devDependencies": {
+    "@earendil-works/pi-coding-agent": "latest",
+    "@earendil-works/pi-ai": "latest",
+    "@types/node": "^20.10.0",
+    "typescript": "^5.3.0"
+  },
+  "pi": {
+    "extensions": [
+      "./dist/index.js"
+    ]
+  },
+  "keywords": [
+    "pi-package",
+    "pi",
+    "extension",
+    "orca",
+    "orca-cli",
+    "orchestration",
+    "terminal",
+    "computer-use"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/arvoreeducacao/arvore-pi-extensions.git",
+    "directory": "packages/orca-bridge"
+  },
+  "author": "Arvore",
+  "license": "MIT"
+}

--- a/packages/orca-bridge/src/computer.ts
+++ b/packages/orca-bridge/src/computer.ts
@@ -1,0 +1,209 @@
+import { Type } from "@earendil-works/pi-ai";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { runOrca, isOrcaSession } from "./core.js";
+
+function notInOrca() {
+  return { content: [{ type: "text" as const, text: "Not running inside an Orca session." }], details: {} };
+}
+
+function windowArgs(params: { windowId?: string; windowIndex?: number }): string[] {
+  const args: string[] = [];
+  if (params.windowId) args.push("--window-id", params.windowId);
+  else if (typeof params.windowIndex === "number") args.push("--window-index", String(params.windowIndex));
+  return args;
+}
+
+function summarizeState(result: any): string {
+  const elements = result?.elements || result?.tree || [];
+  if (!Array.isArray(elements) || elements.length === 0) {
+    return JSON.stringify(result || {}, null, 2).slice(0, 4000);
+  }
+  const lines = elements.slice(0, 200).map((e: any, i: number) => {
+    const idx = typeof e.index === "number" ? e.index : i;
+    const role = e.role || e.type || "?";
+    const label = e.label || e.title || e.value || e.text || "";
+    return `[${idx}] ${role}${label ? `: ${label}` : ""}`;
+  });
+  return lines.join("\n");
+}
+
+export function registerComputerTools(pi: ExtensionAPI): void {
+  pi.registerTool({
+    name: "orca_computer_list_apps",
+    label: "Orca List Apps",
+    description: "List running desktop apps available to Orca computer-use.",
+    promptSnippet: "List desktop apps for computer use",
+    promptGuidelines: [
+      "Use Orca computer-use tools to inspect and drive native desktop apps when running inside an Orca session (e.g. to validate a UI after implementing it).",
+      "Workflow: `orca_computer_app_state` to get an accessibility snapshot with element indices, then `orca_computer_click`/`orca_computer_type` targeting those indices. Re-snapshot after navigation because indices change.",
+    ],
+    parameters: Type.Object({}),
+    async execute() {
+      if (!isOrcaSession()) return notInOrca();
+      const r = runOrca<any>(["computer", "list-apps"]);
+      if (!r.ok) return { content: [{ type: "text", text: `list-apps failed: ${r.error}` }], details: {} };
+      const apps = r.result?.apps || [];
+      const lines = apps.map((a: any) => `${a.name || a.bundleId}${a.pid ? ` (pid:${a.pid})` : ""}`);
+      return { content: [{ type: "text", text: lines.join("\n") || "No apps." }], details: { apps } };
+    },
+  });
+
+  pi.registerTool({
+    name: "orca_computer_list_windows",
+    label: "Orca List Windows",
+    description: "List visible windows for a desktop app.",
+    promptSnippet: "List windows for a desktop app",
+    parameters: Type.Object({
+      app: Type.String({ description: "App name, bundle id, or pid:N" }),
+    }),
+    async execute(_id, params) {
+      if (!isOrcaSession()) return notInOrca();
+      const r = runOrca<any>(["computer", "list-windows", "--app", params.app]);
+      if (!r.ok) return { content: [{ type: "text", text: `list-windows failed: ${r.error}` }], details: {} };
+      const windows = r.result?.windows || [];
+      const lines = windows.map((w: any, i: number) => `[${w.index ?? i}] ${w.title || "(untitled)"}${w.id ? ` id=${w.id}` : ""}`);
+      return { content: [{ type: "text", text: lines.join("\n") || "No windows." }], details: { windows } };
+    },
+  });
+
+  pi.registerTool({
+    name: "orca_computer_app_state",
+    label: "Orca App State",
+    description:
+      "Capture a compact accessibility snapshot of a desktop app, returning UI elements with indices to target with click/type/set-value. Element indices change after the UI changes, so re-snapshot before interacting.",
+    promptSnippet: "Snapshot a desktop app's accessibility tree",
+    parameters: Type.Object({
+      app: Type.String({ description: "App name, bundle id, or pid:N" }),
+      windowId: Type.Optional(Type.String({ description: "Target window id" })),
+      windowIndex: Type.Optional(Type.Number({ description: "Target window index" })),
+      session: Type.Optional(Type.String({ description: "Snapshot namespace for a related workflow" })),
+    }),
+    async execute(_id, params) {
+      if (!isOrcaSession()) return notInOrca();
+      const args = ["computer", "get-app-state", "--app", params.app, "--no-screenshot", ...windowArgs(params)];
+      if (params.session) args.push("--session", params.session);
+      const r = runOrca<any>(args);
+      if (!r.ok) return { content: [{ type: "text", text: `get-app-state failed: ${r.error}` }], details: {} };
+      return { content: [{ type: "text", text: summarizeState(r.result) }], details: r.result || {} };
+    },
+  });
+
+  pi.registerTool({
+    name: "orca_computer_click",
+    label: "Orca Computer Click",
+    description: "Click an element (by index from orca_computer_app_state) or a window coordinate in a desktop app.",
+    promptSnippet: "Click in a desktop app",
+    parameters: Type.Object({
+      app: Type.String({ description: "App name, bundle id, or pid:N" }),
+      elementIndex: Type.Optional(Type.Number({ description: "Element index from app_state" })),
+      x: Type.Optional(Type.Number({ description: "Window x coordinate (use with y instead of elementIndex)" })),
+      y: Type.Optional(Type.Number({ description: "Window y coordinate" })),
+      windowId: Type.Optional(Type.String()),
+      windowIndex: Type.Optional(Type.Number()),
+      clickCount: Type.Optional(Type.Number({ description: "Number of clicks (e.g. 2 for double-click)" })),
+      button: Type.Optional(Type.Union([Type.Literal("left"), Type.Literal("right"), Type.Literal("middle")])),
+    }),
+    async execute(_id, params) {
+      if (!isOrcaSession()) return notInOrca();
+      const args = ["computer", "click", "--app", params.app, "--no-screenshot", ...windowArgs(params)];
+      if (typeof params.elementIndex === "number") args.push("--element-index", String(params.elementIndex));
+      else if (typeof params.x === "number" && typeof params.y === "number") args.push("--x", String(params.x), "--y", String(params.y));
+      else return { content: [{ type: "text", text: "Provide elementIndex or both x and y." }], details: {} };
+      if (params.clickCount) args.push("--click-count", String(params.clickCount));
+      if (params.button) args.push("--mouse-button", params.button);
+      const r = runOrca<any>(args);
+      if (!r.ok) return { content: [{ type: "text", text: `click failed: ${r.error}` }], details: {} };
+      return { content: [{ type: "text", text: "Clicked." }], details: r.result || {} };
+    },
+  });
+
+  pi.registerTool({
+    name: "orca_computer_type",
+    label: "Orca Computer Type",
+    description: "Type literal text at the current focus in a desktop app.",
+    promptSnippet: "Type text into a desktop app",
+    parameters: Type.Object({
+      app: Type.String({ description: "App name, bundle id, or pid:N" }),
+      text: Type.String({ description: "Text to type" }),
+      windowId: Type.Optional(Type.String()),
+      windowIndex: Type.Optional(Type.Number()),
+    }),
+    async execute(_id, params) {
+      if (!isOrcaSession()) return notInOrca();
+      const args = ["computer", "type-text", "--app", params.app, "--text", params.text, "--no-screenshot", ...windowArgs(params)];
+      const r = runOrca<any>(args);
+      if (!r.ok) return { content: [{ type: "text", text: `type-text failed: ${r.error}` }], details: {} };
+      return { content: [{ type: "text", text: "Typed." }], details: r.result || {} };
+    },
+  });
+
+  pi.registerTool({
+    name: "orca_computer_key",
+    label: "Orca Computer Key",
+    description: "Press a single key (e.g. Return, Escape, Tab) or a hotkey combo (e.g. CmdOrCtrl+A) in a desktop app.",
+    promptSnippet: "Press a key or hotkey in a desktop app",
+    parameters: Type.Object({
+      app: Type.String({ description: "App name, bundle id, or pid:N" }),
+      key: Type.String({ description: "Key or combo. Single key like 'Return', or combo like 'CmdOrCtrl+A'" }),
+      windowId: Type.Optional(Type.String()),
+      windowIndex: Type.Optional(Type.Number()),
+    }),
+    async execute(_id, params) {
+      if (!isOrcaSession()) return notInOrca();
+      const isCombo = params.key.includes("+");
+      const sub = isCombo ? "hotkey" : "press-key";
+      const args = ["computer", sub, "--app", params.app, "--key", params.key, "--no-screenshot", ...windowArgs(params)];
+      const r = runOrca<any>(args);
+      if (!r.ok) return { content: [{ type: "text", text: `${sub} failed: ${r.error}` }], details: {} };
+      return { content: [{ type: "text", text: `Pressed ${params.key}.` }], details: r.result || {} };
+    },
+  });
+
+  pi.registerTool({
+    name: "orca_computer_set_value",
+    label: "Orca Computer Set Value",
+    description: "Set the value of a settable element (by index) in a desktop app, e.g. a text field.",
+    promptSnippet: "Set a desktop app element value",
+    parameters: Type.Object({
+      app: Type.String({ description: "App name, bundle id, or pid:N" }),
+      elementIndex: Type.Number({ description: "Element index from app_state" }),
+      value: Type.String({ description: "Value to set" }),
+      windowId: Type.Optional(Type.String()),
+      windowIndex: Type.Optional(Type.Number()),
+    }),
+    async execute(_id, params) {
+      if (!isOrcaSession()) return notInOrca();
+      const args = ["computer", "set-value", "--app", params.app, "--element-index", String(params.elementIndex), "--value", params.value, "--no-screenshot", ...windowArgs(params)];
+      const r = runOrca<any>(args);
+      if (!r.ok) return { content: [{ type: "text", text: `set-value failed: ${r.error}` }], details: {} };
+      return { content: [{ type: "text", text: "Value set." }], details: r.result || {} };
+    },
+  });
+
+  pi.registerTool({
+    name: "orca_computer_scroll",
+    label: "Orca Computer Scroll",
+    description: "Scroll an element (by index) or window coordinate in a desktop app.",
+    promptSnippet: "Scroll a desktop app",
+    parameters: Type.Object({
+      app: Type.String({ description: "App name, bundle id, or pid:N" }),
+      direction: Type.Union([Type.Literal("up"), Type.Literal("down"), Type.Literal("left"), Type.Literal("right")]),
+      elementIndex: Type.Optional(Type.Number({ description: "Element index to scroll" })),
+      x: Type.Optional(Type.Number()),
+      y: Type.Optional(Type.Number()),
+      pages: Type.Optional(Type.Number({ description: "Number of pages to scroll" })),
+      windowId: Type.Optional(Type.String()),
+      windowIndex: Type.Optional(Type.Number()),
+    }),
+    async execute(_id, params) {
+      if (!isOrcaSession()) return notInOrca();
+      const args = ["computer", "scroll", "--app", params.app, "--direction", params.direction, "--no-screenshot", ...windowArgs(params)];
+      if (typeof params.elementIndex === "number") args.push("--element-index", String(params.elementIndex));
+      else if (typeof params.x === "number" && typeof params.y === "number") args.push("--x", String(params.x), "--y", String(params.y));
+      if (params.pages) args.push("--pages", String(params.pages));
+      const r = runOrca<any>(args);
+      if (!r.ok) return { content: [{ type: "text", text: `scroll failed: ${r.error}` }], details: {} };
+      return { content: [{ type: "text", text: `Scrolled ${params.direction}.` }], details: r.result || {} };
+    },
+  });
+}

--- a/packages/orca-bridge/src/core.ts
+++ b/packages/orca-bridge/src/core.ts
@@ -1,0 +1,79 @@
+import { spawnSync } from "node:child_process";
+import { resolve, basename } from "node:path";
+
+let orcaAvailability: boolean | null = null;
+
+export function orcaBinary(): string {
+  return process.env.ORCA_CLI_BIN || (process.platform === "linux" ? "orca-ide" : "orca");
+}
+
+export function hasBinary(bin: string): boolean {
+  const result = spawnSync(bin, ["--version"], { encoding: "utf-8", stdio: ["ignore", "ignore", "ignore"] });
+  return !result.error;
+}
+
+export function isOrcaSession(): boolean {
+  if (!process.env.ORCA_WORKTREE_ID) return false;
+  if (orcaAvailability === null) orcaAvailability = hasBinary(orcaBinary());
+  return orcaAvailability;
+}
+
+export interface OrcaResult<T = any> {
+  ok: boolean;
+  result?: T;
+  error?: string;
+}
+
+export function runOrca<T = any>(args: string[], timeoutMs = 30000, cwd?: string): OrcaResult<T> {
+  const result = spawnSync(orcaBinary(), [...args, "--json"], { encoding: "utf-8", timeout: timeoutMs, cwd });
+  if (result.error) {
+    const isTimeout = (result.error as NodeJS.ErrnoException).code === "ETIMEDOUT";
+    return { ok: false, error: isTimeout ? `orca ${args[0]} timed out after ${timeoutMs}ms` : result.error.message };
+  }
+  const raw = (result.stdout || "").trim();
+  if (!raw) {
+    return { ok: result.status === 0, error: result.stderr?.trim() || `orca ${args.join(" ")} produced no output` };
+  }
+  try {
+    const parsed = JSON.parse(raw) as { ok?: boolean; result?: T; error?: any };
+    if (parsed.ok === false) {
+      const err = typeof parsed.error === "string" ? parsed.error : JSON.stringify(parsed.error);
+      return { ok: false, error: err || "orca reported failure" };
+    }
+    return { ok: true, result: parsed.result as T };
+  } catch {
+    return { ok: result.status === 0, error: result.status === 0 ? undefined : raw };
+  }
+}
+
+export interface OrcaWorktreeInfo {
+  id: string;
+  path: string;
+  displayName?: string;
+  branch?: string;
+  isMainWorktree?: boolean;
+}
+
+export function orcaCurrentWorktree(cwd?: string): OrcaWorktreeInfo | null {
+  const current = runOrca<{ worktree?: OrcaWorktreeInfo }>(["worktree", "current"], 30000, cwd);
+  return current.result?.worktree || null;
+}
+
+export function orcaResolveRepoSelector(repoPath: string): string | null {
+  const listed = runOrca<{ repos?: Array<{ id: string; path: string }> }>(["repo", "list"]);
+  const match = listed.result?.repos?.find((r) => resolve(r.path) === resolve(repoPath));
+  if (match) return `id:${match.id}`;
+
+  const added = runOrca<{ repo?: { id: string } }>(["repo", "add", "--path", repoPath]);
+  if (added.ok && added.result?.repo?.id) return `id:${added.result.repo.id}`;
+
+  return null;
+}
+
+export function shortBranch(branch?: string): string {
+  return (branch || "").replace(/^refs\/heads\//, "");
+}
+
+export function repoName(repoPath: string): string {
+  return basename(repoPath);
+}

--- a/packages/orca-bridge/src/index.ts
+++ b/packages/orca-bridge/src/index.ts
@@ -1,0 +1,65 @@
+import { Type } from "@earendil-works/pi-ai";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { isOrcaSession } from "./core.js";
+import { syncStatusFromTool, pushManualStatus, setStatusSyncEnabled, isStatusSyncEnabled } from "./status-sync.js";
+import { registerTerminalTools } from "./terminal.js";
+import { registerOrchestrationTools } from "./orchestration.js";
+import { registerComputerTools } from "./computer.js";
+
+const STATUS_SYNC_TOOLS = new Set(["todo", "create_goal", "update_goal"]);
+
+export default function orcaBridgeExtension(pi: ExtensionAPI): void {
+  let cwd = process.cwd();
+
+  pi.on("session_start", async (_e, ctx) => {
+    cwd = ctx.cwd || cwd;
+  });
+
+  pi.on("tool_execution_end", async (event) => {
+    if (event.isError) return;
+    if (!STATUS_SYNC_TOOLS.has(event.toolName)) return;
+    try {
+      syncStatusFromTool(event.toolName, event.result, cwd);
+    } catch {
+      // status sync is best-effort; never break the turn
+    }
+  });
+
+  pi.registerTool({
+    name: "orca_set_status",
+    label: "Orca Set Status",
+    description:
+      "Manually set the Orca worktree card comment and (optionally) its board status. Use for milestones like moving a card to in-review. Status auto-syncs from todo/goal changes; use this for explicit control.",
+    promptSnippet: "Set the Orca worktree card status/comment",
+    parameters: Type.Object({
+      comment: Type.String({ description: "Comment shown on the Orca card" }),
+      status: Type.Optional(
+        Type.Union(
+          [Type.Literal("todo"), Type.Literal("in-progress"), Type.Literal("in-review"), Type.Literal("completed")],
+          { description: "Board column id" },
+        ),
+      ),
+    }),
+    async execute(_id, params) {
+      const r = pushManualStatus(cwd, params.comment, params.status);
+      return { content: [{ type: "text", text: r.message }], details: { ok: r.ok } };
+    },
+  });
+
+  pi.registerCommand("orca-status-sync", {
+    description: "Toggle automatic Orca card status sync from todo/goal changes",
+    async handler(ctx: any) {
+      const args = (ctx.args || "").trim().toLowerCase();
+      if (args === "on") setStatusSyncEnabled(true);
+      else if (args === "off") setStatusSyncEnabled(false);
+      else setStatusSyncEnabled(!isStatusSyncEnabled());
+      const state = isStatusSyncEnabled() ? "ON" : "OFF";
+      const note = isOrcaSession() ? "" : " (no-op: not in an Orca session)";
+      ctx.ui?.notify?.(`Orca status sync: ${state}${note}`, "info");
+    },
+  });
+
+  registerTerminalTools(pi);
+  registerOrchestrationTools(pi);
+  registerComputerTools(pi);
+}

--- a/packages/orca-bridge/src/orchestration.ts
+++ b/packages/orca-bridge/src/orchestration.ts
@@ -1,0 +1,247 @@
+import { Type } from "@earendil-works/pi-ai";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { runOrca, isOrcaSession } from "./core.js";
+
+function notInOrca() {
+  return { content: [{ type: "text" as const, text: "Not running inside an Orca session." }], details: {} };
+}
+
+export function registerOrchestrationTools(pi: ExtensionAPI): void {
+  pi.registerTool({
+    name: "orca_task_create",
+    label: "Orca Task Create",
+    description:
+      "Create an Orca orchestration task. Tasks are units of work that can be dispatched to worker agents running in Orca terminals, with optional dependencies forming a DAG. Returns the task id.",
+    promptSnippet: "Create an Orca orchestration task",
+    promptGuidelines: [
+      "Use Orca orchestration tools to coordinate multiple worker agents when running inside an Orca session: create tasks, dispatch them to terminals, and wait for results.",
+      "Model dependencies with `deps` (array of task ids) so Orca only marks a task ready once its dependencies complete.",
+    ],
+    parameters: Type.Object({
+      spec: Type.String({ description: "Full task specification / instructions for the worker" }),
+      title: Type.Optional(Type.String({ description: "Concise task title" })),
+      displayName: Type.Optional(Type.String({ description: "UI label for the dispatched worker row" })),
+      deps: Type.Optional(Type.Array(Type.String(), { description: "Task ids this task depends on" })),
+      parent: Type.Optional(Type.String({ description: "Parent task id" })),
+    }),
+    async execute(_id, params) {
+      if (!isOrcaSession()) return notInOrca();
+      const args = ["orchestration", "task-create", "--spec", params.spec];
+      if (params.title) args.push("--task-title", params.title);
+      if (params.displayName) args.push("--display-name", params.displayName);
+      if (params.deps?.length) args.push("--deps", JSON.stringify(params.deps));
+      if (params.parent) args.push("--parent", params.parent);
+      const r = runOrca<any>(args);
+      if (!r.ok) return { content: [{ type: "text", text: `task-create failed: ${r.error}` }], details: {} };
+      const taskId = r.result?.task?.id || r.result?.id;
+      return { content: [{ type: "text", text: `Created task ${taskId}${params.title ? ` (${params.title})` : ""}` }], details: r.result || {} };
+    },
+  });
+
+  pi.registerTool({
+    name: "orca_task_list",
+    label: "Orca Task List",
+    description: "List Orca orchestration tasks, optionally filtered by status or restricted to ready (unblocked) tasks.",
+    promptSnippet: "List Orca orchestration tasks",
+    parameters: Type.Object({
+      status: Type.Optional(Type.String({ description: "Filter by status (e.g. pending, in_progress, completed)" })),
+      ready: Type.Optional(Type.Boolean({ description: "Only tasks whose dependencies are satisfied" })),
+    }),
+    async execute(_id, params) {
+      if (!isOrcaSession()) return notInOrca();
+      const args = ["orchestration", "task-list"];
+      if (params.status) args.push("--status", params.status);
+      if (params.ready) args.push("--ready");
+      const r = runOrca<any>(args);
+      if (!r.ok) return { content: [{ type: "text", text: `task-list failed: ${r.error}` }], details: {} };
+      const tasks = r.result?.tasks || [];
+      if (tasks.length === 0) return { content: [{ type: "text", text: "No tasks." }], details: { tasks: [] } };
+      const lines = tasks.map((t: any) => `${t.id} [${t.status}] ${t.title || t.displayName || ""}`);
+      return { content: [{ type: "text", text: lines.join("\n") }], details: { tasks } };
+    },
+  });
+
+  pi.registerTool({
+    name: "orca_task_update",
+    label: "Orca Task Update",
+    description: "Update the status of an Orca orchestration task, optionally attaching a JSON result payload.",
+    promptSnippet: "Update an Orca task status",
+    parameters: Type.Object({
+      id: Type.String({ description: "Task id" }),
+      status: Type.String({ description: "New status (e.g. in_progress, completed, blocked)" }),
+      result: Type.Optional(Type.Record(Type.String(), Type.Any(), { description: "Result payload attached to the task" })),
+    }),
+    async execute(_id, params) {
+      if (!isOrcaSession()) return notInOrca();
+      const args = ["orchestration", "task-update", "--id", params.id, "--status", params.status];
+      if (params.result) args.push("--result", JSON.stringify(params.result));
+      const r = runOrca<any>(args);
+      if (!r.ok) return { content: [{ type: "text", text: `task-update failed: ${r.error}` }], details: {} };
+      return { content: [{ type: "text", text: `Task ${params.id} \u2192 ${params.status}` }], details: r.result || {} };
+    },
+  });
+
+  pi.registerTool({
+    name: "orca_task_dispatch",
+    label: "Orca Task Dispatch",
+    description:
+      "Dispatch an Orca task to a worker terminal (created with orca_terminal_start). Injects the task spec into the target agent. Returns dispatch context.",
+    promptSnippet: "Dispatch an Orca task to a worker terminal",
+    parameters: Type.Object({
+      task: Type.String({ description: "Task id to dispatch" }),
+      to: Type.String({ description: "Target terminal handle (the worker)" }),
+      from: Type.Optional(Type.String({ description: "Sender terminal handle (the coordinator)" })),
+      inject: Type.Optional(Type.Boolean({ description: "Inject the spec directly into the worker terminal input" })),
+    }),
+    async execute(_id, params) {
+      if (!isOrcaSession()) return notInOrca();
+      const args = ["orchestration", "dispatch", "--task", params.task, "--to", params.to];
+      if (params.from) args.push("--from", params.from);
+      if (params.inject) args.push("--inject");
+      const r = runOrca<any>(args);
+      if (!r.ok) return { content: [{ type: "text", text: `dispatch failed: ${r.error}` }], details: {} };
+      return { content: [{ type: "text", text: `Dispatched task ${params.task} to ${params.to}` }], details: r.result || {} };
+    },
+  });
+
+  pi.registerTool({
+    name: "orca_msg_send",
+    label: "Orca Message Send",
+    description: "Send an inter-agent orchestration message to a worker/coordinator terminal.",
+    promptSnippet: "Send an inter-agent Orca message",
+    parameters: Type.Object({
+      to: Type.String({ description: "Recipient terminal handle" }),
+      subject: Type.String({ description: "Message subject" }),
+      body: Type.Optional(Type.String({ description: "Message body" })),
+      from: Type.Optional(Type.String({ description: "Sender terminal handle" })),
+      type: Type.Optional(Type.String({ description: "Message type" })),
+      priority: Type.Optional(Type.String({ description: "Priority level" })),
+      threadId: Type.Optional(Type.String({ description: "Thread id to continue a conversation" })),
+    }),
+    async execute(_id, params) {
+      if (!isOrcaSession()) return notInOrca();
+      const args = ["orchestration", "send", "--to", params.to, "--subject", params.subject];
+      if (params.body) args.push("--body", params.body);
+      if (params.from) args.push("--from", params.from);
+      if (params.type) args.push("--type", params.type);
+      if (params.priority) args.push("--priority", params.priority);
+      if (params.threadId) args.push("--thread-id", params.threadId);
+      const r = runOrca<any>(args);
+      if (!r.ok) return { content: [{ type: "text", text: `send failed: ${r.error}` }], details: {} };
+      return { content: [{ type: "text", text: `Message sent to ${params.to}` }], details: r.result || {} };
+    },
+  });
+
+  pi.registerTool({
+    name: "orca_msg_check",
+    label: "Orca Message Check",
+    description:
+      "Check orchestration messages for a terminal. By default returns unread messages and marks them read. Can optionally block until a message arrives.",
+    promptSnippet: "Check Orca orchestration messages",
+    parameters: Type.Object({
+      terminal: Type.Optional(Type.String({ description: "Terminal handle to check (omit for active)" })),
+      all: Type.Optional(Type.Boolean({ description: "Return all messages instead of only unread" })),
+      types: Type.Optional(Type.Array(Type.String(), { description: "Filter by message types" })),
+      wait: Type.Optional(Type.Boolean({ description: "Block until a message arrives" })),
+      timeoutMs: Type.Optional(Type.Number({ description: "Max wait when wait=true (default 60000)" })),
+    }),
+    async execute(_id, params) {
+      if (!isOrcaSession()) return notInOrca();
+      const timeout = params.timeoutMs ?? 60000;
+      const args = ["orchestration", "check"];
+      if (params.terminal) args.push("--terminal", params.terminal);
+      if (params.all) args.push("--all");
+      else args.push("--unread");
+      if (params.types?.length) args.push("--types", params.types.join(","));
+      if (params.wait) args.push("--wait", "--timeout-ms", String(timeout));
+      const r = runOrca<any>(args, params.wait ? timeout + 5000 : 30000);
+      if (!r.ok) return { content: [{ type: "text", text: `check failed: ${r.error}` }], details: {} };
+      const msgs = r.result?.messages || [];
+      if (msgs.length === 0) return { content: [{ type: "text", text: "No messages." }], details: { messages: [] } };
+      const lines = msgs.map((m: any) => `[${m.id}] from ${m.from || "?"}: ${m.subject}${m.body ? ` \u2014 ${m.body}` : ""}`);
+      return { content: [{ type: "text", text: lines.join("\n") }], details: { messages: msgs } };
+    },
+  });
+
+  pi.registerTool({
+    name: "orca_msg_reply",
+    label: "Orca Message Reply",
+    description: "Reply to an orchestration message by id.",
+    promptSnippet: "Reply to an Orca orchestration message",
+    parameters: Type.Object({
+      id: Type.String({ description: "Message id to reply to" }),
+      body: Type.String({ description: "Reply body" }),
+      from: Type.Optional(Type.String({ description: "Sender terminal handle" })),
+    }),
+    async execute(_id, params) {
+      if (!isOrcaSession()) return notInOrca();
+      const args = ["orchestration", "reply", "--id", params.id, "--body", params.body];
+      if (params.from) args.push("--from", params.from);
+      const r = runOrca<any>(args);
+      if (!r.ok) return { content: [{ type: "text", text: `reply failed: ${r.error}` }], details: {} };
+      return { content: [{ type: "text", text: `Replied to ${params.id}` }], details: r.result || {} };
+    },
+  });
+
+  pi.registerTool({
+    name: "orca_gate_create",
+    label: "Orca Gate Create",
+    description:
+      "Create a decision gate that blocks an Orca task until a human/coordinator resolves it. Use for approvals or branching decisions in an orchestration flow.",
+    promptSnippet: "Create an Orca decision gate",
+    parameters: Type.Object({
+      task: Type.String({ description: "Task id the gate blocks" }),
+      question: Type.String({ description: "Question presented at the gate" }),
+      options: Type.Optional(Type.Array(Type.String(), { description: "Answer options" })),
+    }),
+    async execute(_id, params) {
+      if (!isOrcaSession()) return notInOrca();
+      const args = ["orchestration", "gate-create", "--task", params.task, "--question", params.question];
+      if (params.options?.length) args.push("--options", JSON.stringify(params.options));
+      const r = runOrca<any>(args);
+      if (!r.ok) return { content: [{ type: "text", text: `gate-create failed: ${r.error}` }], details: {} };
+      const gateId = r.result?.gate?.id || r.result?.id;
+      return { content: [{ type: "text", text: `Created gate ${gateId} on task ${params.task}` }], details: r.result || {} };
+    },
+  });
+
+  pi.registerTool({
+    name: "orca_gate_resolve",
+    label: "Orca Gate Resolve",
+    description: "Resolve a pending Orca decision gate, unblocking its task.",
+    promptSnippet: "Resolve an Orca decision gate",
+    parameters: Type.Object({
+      id: Type.String({ description: "Gate id" }),
+      resolution: Type.String({ description: "Chosen resolution / answer" }),
+    }),
+    async execute(_id, params) {
+      if (!isOrcaSession()) return notInOrca();
+      const r = runOrca<any>(["orchestration", "gate-resolve", "--id", params.id, "--resolution", params.resolution]);
+      if (!r.ok) return { content: [{ type: "text", text: `gate-resolve failed: ${r.error}` }], details: {} };
+      return { content: [{ type: "text", text: `Resolved gate ${params.id}` }], details: r.result || {} };
+    },
+  });
+
+  pi.registerTool({
+    name: "orca_gate_list",
+    label: "Orca Gate List",
+    description: "List Orca decision gates, optionally filtered by task or status.",
+    promptSnippet: "List Orca decision gates",
+    parameters: Type.Object({
+      task: Type.Optional(Type.String({ description: "Filter by task id" })),
+      status: Type.Optional(Type.String({ description: "Filter by gate status" })),
+    }),
+    async execute(_id, params) {
+      if (!isOrcaSession()) return notInOrca();
+      const args = ["orchestration", "gate-list"];
+      if (params.task) args.push("--task", params.task);
+      if (params.status) args.push("--status", params.status);
+      const r = runOrca<any>(args);
+      if (!r.ok) return { content: [{ type: "text", text: `gate-list failed: ${r.error}` }], details: {} };
+      const gates = r.result?.gates || [];
+      if (gates.length === 0) return { content: [{ type: "text", text: "No gates." }], details: { gates: [] } };
+      const lines = gates.map((g: any) => `${g.id} [${g.status}] task=${g.taskId || g.task} \u2014 ${g.question}`);
+      return { content: [{ type: "text", text: lines.join("\n") }], details: { gates } };
+    },
+  });
+}

--- a/packages/orca-bridge/src/status-sync.ts
+++ b/packages/orca-bridge/src/status-sync.ts
@@ -1,0 +1,109 @@
+import { runOrca, isOrcaSession, orcaCurrentWorktree } from "./core.js";
+
+interface TodoItem {
+  id: number;
+  subject?: string;
+  status?: string;
+  activeForm?: string;
+}
+
+let lastComment = "";
+let lastStatus = "";
+let syncEnabled = true;
+
+export function setStatusSyncEnabled(v: boolean): void {
+  syncEnabled = v;
+}
+
+export function isStatusSyncEnabled(): boolean {
+  return syncEnabled;
+}
+
+function extractTodos(result: any): TodoItem[] {
+  const candidates = [result?.details?.tasks, result?.details?.todos, result?.tasks, result?.todos];
+  for (const c of candidates) {
+    if (Array.isArray(c)) return c as TodoItem[];
+  }
+  return [];
+}
+
+function truncate(s: string, max: number): string {
+  return s.length > max ? s.slice(0, max - 1) + "\u2026" : s;
+}
+
+function buildCommentFromTodos(todos: TodoItem[]): { comment: string; status: string } | null {
+  if (todos.length === 0) return null;
+  const active = todos.find((t) => t.status === "in_progress");
+  const completed = todos.filter((t) => t.status === "completed").length;
+  const total = todos.length;
+
+  let comment: string;
+  let status: string;
+
+  if (active) {
+    const label = active.activeForm || active.subject || `task #${active.id}`;
+    comment = `\ud83e\udd16 ${label} (${completed}/${total})`;
+    status = "in-progress";
+  } else if (completed === total) {
+    comment = `\u2705 All ${total} tasks done`;
+    status = "in-review";
+  } else {
+    comment = `\u23f8 ${completed}/${total} tasks done, none active`;
+    status = "in-progress";
+  }
+
+  return { comment: truncate(comment, 120), status };
+}
+
+function buildCommentFromGoal(result: any): { comment: string; status: string } | null {
+  const goal = result?.details?.goal || result?.goal;
+  if (!goal) return null;
+  const objective: string = goal.objective || goal.description || "";
+  const goalStatus: string = goal.status || "";
+  if (!objective) return null;
+  const done = goalStatus === "complete" || goalStatus === "completed";
+  return {
+    comment: truncate(`${done ? "\u2705" : "\ud83c\udfaf"} ${objective}`, 120),
+    status: done ? "in-review" : "in-progress",
+  };
+}
+
+function pushToOrca(cwd: string, comment: string, status: string): void {
+  const wt = orcaCurrentWorktree(cwd);
+  if (!wt || wt.isMainWorktree) return;
+  const selector = `id:${wt.id}`;
+
+  if (comment !== lastComment) {
+    const r = runOrca(["worktree", "set", "--worktree", selector, "--comment", comment]);
+    if (r.ok) lastComment = comment;
+  }
+  if (status && status !== lastStatus) {
+    const r = runOrca(["worktree", "set", "--worktree", selector, "--workspace-status", status]);
+    if (r.ok) lastStatus = status;
+  }
+}
+
+export function syncStatusFromTool(toolName: string, result: any, cwd: string): void {
+  if (!syncEnabled || !isOrcaSession()) return;
+
+  let derived: { comment: string; status: string } | null = null;
+  if (toolName === "todo") derived = buildCommentFromTodos(extractTodos(result));
+  else if (toolName === "create_goal" || toolName === "update_goal") derived = buildCommentFromGoal(result);
+
+  if (derived) pushToOrca(cwd, derived.comment, derived.status);
+}
+
+export function pushManualStatus(cwd: string, comment: string, status?: string): { ok: boolean; message: string } {
+  if (!isOrcaSession()) return { ok: false, message: "Not running inside an Orca session" };
+  const wt = orcaCurrentWorktree(cwd);
+  if (!wt || wt.isMainWorktree) return { ok: false, message: "No active non-main Orca worktree for the current directory" };
+  const selector = `id:${wt.id}`;
+
+  const args = ["worktree", "set", "--worktree", selector, "--comment", comment];
+  if (status) args.push("--workspace-status", status);
+  const r = runOrca(args);
+  if (!r.ok) return { ok: false, message: `Orca set failed: ${r.error || "unknown error"}` };
+  lastComment = comment;
+  if (status) lastStatus = status;
+  return { ok: true, message: `Updated Orca card${status ? ` (${status})` : ""}: ${comment}` };
+}

--- a/packages/orca-bridge/src/terminal.ts
+++ b/packages/orca-bridge/src/terminal.ts
@@ -1,0 +1,160 @@
+import { Type } from "@earendil-works/pi-ai";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { runOrca, isOrcaSession } from "./core.js";
+
+interface TerminalCreateResult {
+  terminal?: { handle?: string; id?: string; title?: string };
+  handle?: string;
+}
+
+function terminalHandle(r: any): string | undefined {
+  return r?.terminal?.handle || r?.terminal?.id || r?.handle || r?.id;
+}
+
+export function registerTerminalTools(pi: ExtensionAPI): void {
+  pi.registerTool({
+    name: "orca_terminal_start",
+    label: "Orca Terminal Start",
+    description:
+      "Start a long-running command in a visible, persistent Orca terminal tab (dev server, watch, migrations, tunnels). The terminal survives the pi session and is visible in the Orca UI. Returns a terminal handle to use with orca_terminal_read / orca_terminal_wait / orca_terminal_stop. Use this instead of bash for processes that should keep running in the background.",
+    promptSnippet: "Start a long-running job in an Orca terminal",
+    promptGuidelines: [
+      "Use `orca_terminal_start` (not `bash`) for long-running processes like dev servers, watchers, and migrations when running inside an Orca session.",
+      "Capture the returned `handle` and poll output with `orca_terminal_read` using the `cursor` from the previous read to get only new lines.",
+      "Use `orca_terminal_wait` with `for: tui-idle` to wait until a dev server is ready, or `for: exit` for one-shot commands.",
+    ],
+    parameters: Type.Object({
+      command: Type.String({ description: "Command to run on terminal startup (e.g. 'pnpm dev')" }),
+      title: Type.Optional(Type.String({ description: "Custom title for the terminal tab" })),
+      worktree: Type.Optional(Type.String({ description: "Worktree selector (default: active). E.g. active, path:/abs/path, name:foo" })),
+      focus: Type.Optional(Type.Boolean({ description: "Reveal/switch to the terminal in the Orca UI (default false)" })),
+    }),
+    async execute(_id, params) {
+      if (!isOrcaSession()) {
+        return { content: [{ type: "text", text: "Not running inside an Orca session; use bash instead." }], details: {} };
+      }
+      const args = ["terminal", "create", "--worktree", params.worktree || "active", "--command", params.command];
+      if (params.title) args.push("--title", params.title);
+      if (params.focus) args.push("--focus");
+      const r = runOrca<TerminalCreateResult>(args);
+      if (!r.ok) return { content: [{ type: "text", text: `Failed to start terminal: ${r.error}` }], details: {} };
+      const handle = terminalHandle(r.result);
+      return {
+        content: [{ type: "text", text: `Started terminal ${handle ? `(handle: ${handle})` : ""} running: ${params.command}` }],
+        details: { handle, ...r.result },
+      };
+    },
+  });
+
+  pi.registerTool({
+    name: "orca_terminal_read",
+    label: "Orca Terminal Read",
+    description:
+      "Read bounded output from an Orca terminal. Pass the cursor returned by a previous read to get only new output since then. Omit the handle to read the active terminal in the current worktree.",
+    promptSnippet: "Read output from an Orca terminal",
+    parameters: Type.Object({
+      handle: Type.Optional(Type.String({ description: "Terminal handle from orca_terminal_start (omit for active terminal)" })),
+      cursor: Type.Optional(Type.Number({ description: "Line cursor from a previous read; returns only new output" })),
+      limit: Type.Optional(Type.Number({ description: "Max rows to return" })),
+    }),
+    async execute(_id, params) {
+      if (!isOrcaSession()) return { content: [{ type: "text", text: "Not in an Orca session." }], details: {} };
+      const args = ["terminal", "read"];
+      if (params.handle) args.push("--terminal", params.handle);
+      if (typeof params.cursor === "number") args.push("--cursor", String(params.cursor));
+      if (typeof params.limit === "number") args.push("--limit", String(params.limit));
+      const r = runOrca<any>(args);
+      if (!r.ok) return { content: [{ type: "text", text: `Read failed: ${r.error}` }], details: {} };
+      const rows = r.result?.rows ?? r.result?.lines ?? r.result?.output ?? "";
+      const text = Array.isArray(rows) ? rows.join("\n") : String(rows);
+      return {
+        content: [{ type: "text", text: text || "(no output)" }],
+        details: { nextCursor: r.result?.nextCursor, oldestCursor: r.result?.oldestCursor },
+      };
+    },
+  });
+
+  pi.registerTool({
+    name: "orca_terminal_wait",
+    label: "Orca Terminal Wait",
+    description:
+      "Wait for an Orca terminal condition: 'exit' (command finished) or 'tui-idle' (interactive process stopped producing output, e.g. dev server ready). Returns when the condition is met or the timeout elapses.",
+    promptSnippet: "Wait for an Orca terminal to finish or go idle",
+    parameters: Type.Object({
+      handle: Type.Optional(Type.String({ description: "Terminal handle (omit for active terminal)" })),
+      for: Type.Union([Type.Literal("exit"), Type.Literal("tui-idle")], { description: "Condition to wait for" }),
+      timeoutMs: Type.Optional(Type.Number({ description: "Max wait in ms (default 60000)" })),
+    }),
+    async execute(_id, params) {
+      if (!isOrcaSession()) return { content: [{ type: "text", text: "Not in an Orca session." }], details: {} };
+      const timeout = params.timeoutMs ?? 60000;
+      const args = ["terminal", "wait", "--for", params.for, "--timeout-ms", String(timeout)];
+      if (params.handle) args.push("--terminal", params.handle);
+      const r = runOrca<any>(args, timeout + 5000);
+      if (!r.ok) return { content: [{ type: "text", text: `Wait failed or timed out: ${r.error}` }], details: r.result || {} };
+      return { content: [{ type: "text", text: `Condition '${params.for}' met.` }], details: r.result || {} };
+    },
+  });
+
+  pi.registerTool({
+    name: "orca_terminal_send",
+    label: "Orca Terminal Send",
+    description: "Send input (text and/or Enter) to a live Orca terminal. Use to answer prompts or drive a REPL/TUI running in a terminal.",
+    promptSnippet: "Send input to an Orca terminal",
+    parameters: Type.Object({
+      handle: Type.Optional(Type.String({ description: "Terminal handle (omit for active terminal)" })),
+      text: Type.Optional(Type.String({ description: "Text to send" })),
+      enter: Type.Optional(Type.Boolean({ description: "Append Enter after the text (default true when text is present)" })),
+      interrupt: Type.Optional(Type.Boolean({ description: "Send an interrupt (Ctrl-C style) instead of text" })),
+    }),
+    async execute(_id, params) {
+      if (!isOrcaSession()) return { content: [{ type: "text", text: "Not in an Orca session." }], details: {} };
+      const args = ["terminal", "send"];
+      if (params.handle) args.push("--terminal", params.handle);
+      if (params.interrupt) {
+        args.push("--interrupt");
+      } else {
+        if (params.text) args.push("--text", params.text);
+        if (params.enter !== false) args.push("--enter");
+      }
+      const r = runOrca(args);
+      if (!r.ok) return { content: [{ type: "text", text: `Send failed: ${r.error}` }], details: {} };
+      return { content: [{ type: "text", text: "Sent." }], details: {} };
+    },
+  });
+
+  pi.registerTool({
+    name: "orca_terminal_list",
+    label: "Orca Terminal List",
+    description: "List live Orca-managed terminals for a worktree (default: active).",
+    promptSnippet: "List Orca terminals",
+    parameters: Type.Object({
+      worktree: Type.Optional(Type.String({ description: "Worktree selector (default: active)" })),
+    }),
+    async execute(_id, params) {
+      if (!isOrcaSession()) return { content: [{ type: "text", text: "Not in an Orca session." }], details: {} };
+      const r = runOrca<any>(["terminal", "list", "--worktree", params.worktree || "active"]);
+      if (!r.ok) return { content: [{ type: "text", text: `List failed: ${r.error}` }], details: {} };
+      const terms = r.result?.terminals || [];
+      if (terms.length === 0) return { content: [{ type: "text", text: "No live terminals." }], details: { terminals: [] } };
+      const lines = terms.map((t: any) => `${t.handle || t.id} \u2014 ${t.title || "(untitled)"}${t.command ? ` [${t.command}]` : ""}`);
+      return { content: [{ type: "text", text: lines.join("\n") }], details: { terminals: terms } };
+    },
+  });
+
+  pi.registerTool({
+    name: "orca_terminal_stop",
+    label: "Orca Terminal Stop",
+    description: "Stop all Orca terminals for a worktree (default: active). Use to tear down dev servers/watchers started with orca_terminal_start.",
+    promptSnippet: "Stop Orca terminals for a worktree",
+    parameters: Type.Object({
+      worktree: Type.Optional(Type.String({ description: "Worktree selector (default: active)" })),
+    }),
+    async execute(_id, params) {
+      if (!isOrcaSession()) return { content: [{ type: "text", text: "Not in an Orca session." }], details: {} };
+      const r = runOrca(["terminal", "stop", "--worktree", params.worktree || "active"]);
+      if (!r.ok) return { content: [{ type: "text", text: `Stop failed: ${r.error}` }], details: {} };
+      return { content: [{ type: "text", text: "Stopped terminals." }], details: {} };
+    },
+  });
+}

--- a/packages/orca-bridge/tsconfig.json
+++ b/packages/orca-bridge/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -247,6 +247,21 @@ importers:
         specifier: ^5.3.0
         version: 5.9.3
 
+  packages/orca-bridge:
+    devDependencies:
+      '@earendil-works/pi-ai':
+        specifier: latest
+        version: 0.80.3(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-coding-agent':
+        specifier: latest
+        version: 0.80.3(ws@8.20.0)(zod@4.4.3)
+      '@types/node':
+        specifier: ^20.10.0
+        version: 20.19.39
+      typescript:
+        specifier: ^5.3.0
+        version: 5.9.3
+
   packages/pi-codebase-index:
     dependencies:
       '@tree-sitter-grammars/tree-sitter-kotlin':
@@ -3566,13 +3581,13 @@ snapshots:
 
   '@slack/logger@4.0.1':
     dependencies:
-      '@types/node': 20.19.39
+      '@types/node': 22.20.0
 
   '@slack/socket-mode@2.0.7':
     dependencies:
       '@slack/logger': 4.0.1
       '@slack/web-api': 7.17.0
-      '@types/node': 20.19.39
+      '@types/node': 22.20.0
       '@types/ws': 8.18.1
       eventemitter3: 5.0.4
       ws: 8.20.0
@@ -3588,7 +3603,7 @@ snapshots:
     dependencies:
       '@slack/logger': 4.0.1
       '@slack/types': 2.21.1
-      '@types/node': 20.19.39
+      '@types/node': 22.20.0
       '@types/retry': 0.12.0
       axios: 1.18.1
       eventemitter3: 5.0.4
@@ -3680,7 +3695,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 20.19.39
+      '@types/node': 22.20.0
 
   '@typescript-eslint/eslint-plugin@8.59.3(@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.4.0(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
@@ -4406,7 +4421,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.1
-      '@types/node': 20.19.39
+      '@types/node': 22.20.0
       long: 5.3.2
 
   proxy-from-env@2.1.0: {}


### PR DESCRIPTION
## O que muda

Novo pacote **`@arvoretech/pi-orca-bridge`** — uma extensão pi que faz a ponte entre o pi e o `orca-cli`. Todas as capacidades ficam ativas **apenas dentro de uma sessão Orca** (detectada via `$ORCA_WORKTREE_ID` + binário `orca`); fora do Orca, as tools respondem com no-op explicativo e o hook de status não faz nada.

Quatro frentes:

**1. Status sync (automático)**
- Hook em `tool_execution_end` que espelha o estado do pi no card do Orca quando as tools `todo`/`create_goal`/`update_goal` executam, via `orca worktree set --comment` + `--workspace-status`.
- `todo` com task `in_progress` → comment `🤖 <activeForm> (concluídas/total)` + status `in-progress`; todas concluídas → `in-review`.
- `update_goal` completo → `✅ <objetivo>` + `in-review`.
- Tool manual `orca_set_status` para controle explícito e command `/orca-status-sync [on|off]` para ligar/desligar.
- Best-effort: qualquer erro é engolido, nunca quebra o turn. Main worktree é ignorado.

**2. Terminal (long-running jobs)**
- `orca_terminal_start` (create + command em terminal Orca visível/persistente), `orca_terminal_read` (com cursor incremental), `orca_terminal_wait` (`exit`/`tui-idle`), `orca_terminal_send`, `orca_terminal_list`, `orca_terminal_stop`.
- Pro pi subir dev server/watch/migration num terminal que sobrevive à sessão e aparece na UI do Orca.

**3. Orquestração (tools finas sobre o CLI)**
- Tasks: `orca_task_create`/`orca_task_list`/`orca_task_update`/`orca_task_dispatch`.
- Mensagens inter-agente: `orca_msg_send`/`orca_msg_check` (com `--wait`)/`orca_msg_reply`.
- Decision gates: `orca_gate_create`/`orca_gate_resolve`/`orca_gate_list`.
- O pi coordena a coreografia com o próprio raciocínio; sem daemon/coordinator loop.

**4. Computer use**
- `orca_computer_list_apps`/`list_windows`/`app_state` (snapshot de acessibilidade com índices de elemento) e ações `click`/`type`/`key` (auto-detecta hotkey por `+`)/`set_value`/`scroll`.
- Usa `--no-screenshot` por padrão pra reduzir ruído; retorna árvore de acessibilidade resumida.

Core compartilhado (`runOrca`, `isOrcaSession`, `orcaResolveRepoSelector`, `orcaCurrentWorktree`) isolado em `core.ts`, com `runOrca` tratando timeout, ausência de output e o envelope JSON `{ ok, result, error }`.

## Contexto

Sem task Linear. É o follow-up da integração do worktree com o Orca (PR #112): em vez de só o ciclo de vida de worktree, expõe ao pi as outras superfícies do `orca-cli` (status do card, terminais, orquestração multi-agente e computer use). Pacote separado pra não inchar o `worktree` e manter as 4 frentes coesas atrás de um core único.

Nota de ordem de merge: o `worktree` (no #112) tem sua própria cópia de `runOrca`/`isOrcaSession`. A deduplicação — worktree importando o core do `orca-bridge` — fica como follow-up **após** o #112 mergear, pra evitar conflito de ordem entre os PRs. Por isso o core aparece duplicado por enquanto (~80 linhas).

## Validação

- `lsp_diagnostics`: 0 erros/warnings nos 6 arquivos (`core`, `status-sync`, `terminal`, `orchestration`, `computer`, `index`).
- `pnpm build` (`tsc`): sucesso.
- **Teste de integração real** carregando o `dist/index.js` num mock de `ExtensionAPI`, dentro desta sessão Orca:
  - Detecção Orca ON; 25 tools + 1 command registrados sem erro; hook `tool_execution_end` presente.
  - Chamadas read-only reais: `orca_terminal_list` (terminal real), `orca_task_list`, `orca_computer_list_apps` (13 apps reais) — parsing OK.
  - **Status sync ponta a ponta**: criei um worktree Orca de teste, disparei o hook com um `todo` (task in_progress) e um `update_goal` completo, e confirmei via `orca worktree show` que o card recebeu `comment: ✅ Integrar orca-cli` e `status: in-review`. Worktree de teste removido ao final (`orca worktree rm`), ambiente limpo.
- Fora do Orca: todas as tools retornam no-op explicativo; hook não escreve nada.
