### PR TITLE
refactor(worktree): importar core compartilhado do orca-bridge (dedup)

### DIFF
--- a/packages/orca-bridge/package.json
+++ b/packages/orca-bridge/package.json
@@ -1,10 +1,20 @@
 {
   "name": "@arvoretech/pi-orca-bridge",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "PI extension bridging pi to orca-cli: worktree status sync, long-running terminals, orchestration, and computer use",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./core": {
+      "types": "./dist/core.d.ts",
+      "default": "./dist/core.js"
+    }
+  },
   "files": [
     "dist"
   ],

--- a/packages/worktree/package.json
+++ b/packages/worktree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-worktree",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "PI extension to manage git worktrees across multi-repo workspaces with tree-themed names",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -15,6 +15,9 @@
   },
   "peerDependencies": {
     "@earendil-works/pi-coding-agent": ">=0.74.0"
+  },
+  "dependencies": {
+    "@arvoretech/pi-orca-bridge": "workspace:^"
   },
   "devDependencies": {
     "@earendil-works/pi-coding-agent": "latest",

--- a/packages/worktree/src/index.ts
+++ b/packages/worktree/src/index.ts
@@ -3,6 +3,12 @@ import { Type } from "@earendil-works/pi-ai";
 import { execSync, spawnSync, spawn } from "node:child_process";
 import { existsSync, readFileSync, appendFileSync, readdirSync, statSync, symlinkSync, writeFileSync, mkdirSync, openSync, closeSync } from "node:fs";
 import { join, resolve, basename } from "node:path";
+import {
+  isOrcaSession,
+  runOrca,
+  orcaResolveRepoSelector,
+  type OrcaWorktreeInfo as OrcaWorktree,
+} from "@arvoretech/pi-orca-bridge/core";
 
 let activeWorktree: string | null = null;
 let activeWorktreePaths: Map<string, string> = new Map();
@@ -24,67 +30,6 @@ const TREE_NAMES = [
 
 const WORKTREES_DIR = ".worktrees";
 const SETUP_DIR = ".pi/worktree-setup";
-
-let orcaAvailability: boolean | null = null;
-
-function orcaBinary(): string {
-  return process.env.ORCA_CLI_BIN || (process.platform === "linux" ? "orca-ide" : "orca");
-}
-
-function hasBinary(bin: string): boolean {
-  const result = spawnSync(bin, ["--version"], { encoding: "utf-8", stdio: ["ignore", "ignore", "ignore"] });
-  return !result.error;
-}
-
-function isOrcaSession(): boolean {
-  if (!process.env.ORCA_WORKTREE_ID) return false;
-  if (orcaAvailability === null) orcaAvailability = hasBinary(orcaBinary());
-  return orcaAvailability;
-}
-
-interface OrcaResult<T = any> {
-  ok: boolean;
-  result?: T;
-  error?: string;
-}
-
-function runOrca<T = any>(args: string[]): OrcaResult<T> {
-  const result = spawnSync(orcaBinary(), [...args, "--json"], { encoding: "utf-8" });
-  if (result.error) return { ok: false, error: result.error.message };
-  const raw = (result.stdout || "").trim();
-  if (!raw) {
-    return { ok: result.status === 0, error: result.stderr?.trim() || `orca ${args[0]} produced no output` };
-  }
-  try {
-    const parsed = JSON.parse(raw) as { ok?: boolean; result?: T; error?: any };
-    if (parsed.ok === false) {
-      const err = typeof parsed.error === "string" ? parsed.error : JSON.stringify(parsed.error);
-      return { ok: false, error: err || "orca reported failure" };
-    }
-    return { ok: true, result: parsed.result as T };
-  } catch {
-    return { ok: result.status === 0, error: result.status === 0 ? undefined : raw };
-  }
-}
-
-function orcaResolveRepoSelector(repoPath: string): string | null {
-  const listed = runOrca<{ repos?: Array<{ id: string; path: string }> }>(["repo", "list"]);
-  const match = listed.result?.repos?.find((r) => resolve(r.path) === resolve(repoPath));
-  if (match) return `id:${match.id}`;
-
-  const added = runOrca<{ repo?: { id: string } }>(["repo", "add", "--path", repoPath]);
-  if (added.ok && added.result?.repo?.id) return `id:${added.result.repo.id}`;
-
-  return null;
-}
-
-interface OrcaWorktree {
-  id: string;
-  path: string;
-  displayName?: string;
-  branch?: string;
-  isMainWorktree?: boolean;
-}
 
 function orcaCreateWorktree(repoPath: string, name: string, branch?: string): { ok: boolean; message: string; path?: string } {
   const selector = orcaResolveRepoSelector(repoPath);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -532,6 +532,10 @@ importers:
         version: 5.9.3
 
   packages/worktree:
+    dependencies:
+      '@arvoretech/pi-orca-bridge':
+        specifier: workspace:^
+        version: link:../orca-bridge
     devDependencies:
       '@earendil-works/pi-ai':
         specifier: latest


### PR DESCRIPTION
## O que muda

Follow-up de dedup após os PRs #112 (worktree ↔ orca-cli) e #115 (orca-bridge). O pacote `worktree` tinha uma **cópia** dos primitivos do orca-cli que o `orca-bridge` também define. Este PR remove essa duplicação:

- **`orca-bridge`**: expõe o core via subpath export `@arvoretech/pi-orca-bridge/core` (`exports["./core"]` → `dist/core.js`/`dist/core.d.ts`). Bump `1.0.0 → 1.1.0` (feature: novo entry point público).
- **`worktree`**: passa a depender de `@arvoretech/pi-orca-bridge` (via `workspace:^`, reescrito pra `^1.1.0` no publish) e importa `isOrcaSession`, `runOrca`, `orcaResolveRepoSelector` e o tipo `OrcaWorktreeInfo` (alias `OrcaWorktree`) do core. Remove ~63 linhas duplicadas (`orcaBinary`/`hasBinary`/`isOrcaSession`/`OrcaResult`/`runOrca`/`orcaResolveRepoSelector`/`interface OrcaWorktree`/`orcaAvailability`). Bump `1.10.0 → 1.11.0`.

As funções específicas do worktree (`orcaCreateWorktree`/`orcaRemoveWorktree`/`orcaListWorktrees`/`orcaFindWorktree`) permanecem no pacote — elas são lógica de worktree, não primitivos —, agora usando os primitivos importados.

## Contexto

Na época do #115, o `worktree` em main ainda não tinha código Orca (o #112 não havia mergeado), então o core foi duplicado de propósito pra evitar dependência de ordem entre os PRs. Com os dois mergeados e `pi-worktree@1.10.0` + `pi-orca-bridge@1.0.0` publicados, dá pra fazer a dedup sem risco de ordem. Fonte única de verdade pros primitivos do orca-cli, menos superfície pra divergir.

## Validação

- `lsp_diagnostics` no `worktree/src/index.ts`: 0 erros, 0 warnings (os hints "declared but never read" são pré-existentes, fora do diff).
- `pnpm build` (`tsc`) nos dois pacotes: sucesso; `orca-bridge/dist/core.d.ts` gerado.
- Resolução de dependência: `workspace:^` linka o pacote **local** (confirmado que o symlink aponta pra `packages/orca-bridge`, não pro tarball do registry).
- Smoke test em runtime: `worktree/dist/index.js` carrega, registra as 7 tools e resolve `isOrcaSession` importado do core; detecção Orca OK.

## Ordem de merge / publish

O `worktree@1.11.0` importa `@arvoretech/pi-orca-bridge/core`, que só existe a partir do `orca-bridge@1.1.0`. O CI publica ambos no mesmo push pós-merge; como o `worktree` declara `^1.1.0`, o npm resolve a versão nova. Não há dependência de ordem entre repositórios além disso.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new Orca bridge entry point and core subpath, improving package access for consumers.
  * Updated the worktree package to use the latest bridge package version.

* **Refactor**
  * Streamlined worktree handling to rely on shared Orca utilities, helping keep behavior consistent across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->