### PR TITLE
fix(worktree): chain Herdr pane splits off newest pane

### DIFF
--- a/packages/worktree/package.json
+++ b/packages/worktree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-worktree",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "PI extension to manage git worktrees across multi-repo workspaces with tree-themed names",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/worktree/src/index.ts
+++ b/packages/worktree/src/index.ts
@@ -990,7 +990,7 @@ export default function worktreeExtension(pi: ExtensionAPI): void {
           const paths = [...activeWorktreePaths.values()];
 
           if (inHerdr) {
-            const sourcePane = process.env.HERDR_PANE_ID;
+            let sourcePane = process.env.HERDR_PANE_ID;
             for (let i = 0; i < paths.length; i++) {
               const args = ["pane", "split", "--direction", i === 0 ? "right" : "down", "--cwd", paths[i], "--no-focus"];
               if (sourcePane) args.splice(2, 0, sourcePane);
@@ -998,6 +998,14 @@ export default function worktreeExtension(pi: ExtensionAPI): void {
               if (result.status !== 0) {
                 ctx.ui.notify(`herdr pane split failed: ${result.stderr?.trim() || result.error?.message || "unknown error"}`, "error");
                 return;
+              }
+              if (i > 0) {
+                try {
+                  const parsed = JSON.parse(result.stdout || "");
+                  const newPaneId = parsed?.result?.pane?.pane_id;
+                  if (newPaneId) sourcePane = newPaneId;
+                } catch {
+                }
               }
             }
           } else {


### PR DESCRIPTION
## Summary
- `/worktree shell` in Herdr always split off the original pane (`HERDR_PANE_ID`) for every repo, instead of chaining off the newly created pane.
- This meant repos 2+ kept re-splitting the original pane rather than cascading, producing a layout that looked axis-inverted compared to the tmux integration (which naturally splits off the active pane).
- Fix: after each split (i > 0), parse the JSON stdout from `herdr pane split` and update `sourcePane` to the new pane's `pane_id`, so subsequent splits stack correctly — first split creates a vertical divide (side-by-side), remaining splits stack horizontally under the first, matching tmux's cascade.
- Bumped `@arvoretech/pi-worktree` 1.11.0 → 1.11.1 (patch).

## Testing
- Manually reproduced the split sequence with live `herdr pane split` calls against a real pane, confirmed via `herdr pane layout` that panes now stack correctly under the first split instead of all re-splitting the original pane.
- `lsp_diagnostics` clean on the edited file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pane splitting in the `/worktree shell` flow so newly created panes are used as the reference for later splits, making pane layout behavior more consistent.
* **Chores**
  * Bumped the package version to `1.11.1`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->