### PR TITLE
feat(design-copilot): design-system aware find_icon/find_asset (bonsai | superautor)

### DIFF
--- a/packages/design-copilot/README.md
+++ b/packages/design-copilot/README.md
@@ -1,24 +1,41 @@
 # @arvoretech/pi-design-copilot
 
-Extension do Pi que torna o modelo muito melhor em trabalho de UI da Árvore. Quatro capacidades que se reforçam:
+Extension do Pi que torna o modelo muito melhor em trabalho de UI da Árvore e do SuperAutor. Quatro capacidades que se reforçam.
+
+> **Dois design systems, sem mistura.** As tools `find_icon`/`find_asset` exigem o parâmetro `designSystem: 'bonsai' | 'superautor'`. Cada valor resolve um registry **separado** — uma tela Bonsai (Árvore) nunca recebe asset/ícone do SuperAutor e vice-versa.
+
+| designSystem | Projeto | Ícones | Assets |
+|---|---|---|---|
+| `bonsai` | Árvore (frontend-arvore-nextjs) | React, `@/components/icons` | `design/design-system/assets` |
+| `superautor` | SuperAutor (superautor-sistema) | Rails SVG, `render_svg 'icones/...'` | `design/superautor-design-system/assets` |
 
 ## 1. `find_icon` — índice pesquisável de ícones
-O modelo não consegue "ver" centenas de arquivos de ícone. Esta tool busca por conceito (PT **ou** EN) e devolve o nome exato do componente + a linha de import pronta.
+Busca por conceito (PT **ou** EN) no design system indicado e devolve o nome exato + snippet de uso pronto.
 
 ```
-find_icon({ concept: "adicionar aluno" })
+find_icon({ designSystem: "bonsai", concept: "adicionar aluno" })
 → AddIcon, ... + import { AddIcon } from '@/components/icons'
+
+find_icon({ designSystem: "superautor", concept: "troféu" })
+→ trophy + <%= render_svg 'icones/trophy' %>
 ```
 
-**Os dados vivem no workspace consumidor, não neste pacote OSS.** A tool resolve o manifest nesta ordem:
+**Os dados vivem no workspace consumidor, não neste pacote OSS.** A tool resolve o manifest:
 
-1. Env var `ARVORE_ICONS_MANIFEST` apontando pro arquivo `icons.manifest.json` (override explícito).
-2. Fallback: sobe a árvore de diretórios a partir do cwd procurando `design/design-system/icons.manifest.json`.
+1. Env var (`ARVORE_ICONS_MANIFEST` para bonsai, `SUPERAUTOR_ICONS_MANIFEST` para superautor) — override explícito.
+2. Fallback: sobe a árvore de diretórios procurando `design/design-system/icons.manifest.json` (bonsai) ou `design/superautor-design-system/icons.manifest.json` (superautor).
 
-No `arvore-hub` o manifest é gerado por `scripts/build-icon-manifest.mjs` (varre `frontend-arvore-nextjs/src/components/icons`) e commitado em `design/design-system/icons.manifest.json`. Assim o pacote publicado não carrega dados proprietários.
+No `arvore-hub` os manifests são gerados por scripts e commitados. Assim o pacote publicado não carrega dados proprietários.
 
 ## 2. `find_asset` — registry de assets de marca
-Busca no registry curado (`design/design-system/assets/assets.manifest.json` no hub) por intenção. Quando existe thumbnail local leve, devolve o `path` para o modelo **ver a imagem** com a tool `read`; senão devolve `source_url` (Figma/Drive) + descrição. Ver `design/design-system/assets/README.md` para curar.
+Busca no registry curado do design system indicado por intenção. Quando existe thumbnail local leve, devolve o `path` para o modelo **ver a imagem** com a tool `read`; senão devolve `source_url` + descrição.
+
+```
+find_asset({ designSystem: "bonsai", intent: "otto celebração" })
+find_asset({ designSystem: "superautor", intent: "sticker campeão" })
+```
+
+Resolução análoga à dos ícones (env `ARVORE_ASSETS_MANIFEST` / `SUPERAUTOR_ASSETS_MANIFEST`, ou walk-up).
 
 ## 3. `/design-brief` — brief obrigatório com hard gate
 Antes de gerar UI, `edit`/`write` em `.tsx/.jsx/.css/.scss/.vue` ficam **bloqueados** até o brief ser definido. `/design-brief` pergunta persona, UX infantil, alvos responsivos, cobertura de estados e necessidade de assets, e injeta o resultado no contexto. Escape: `/skip-brief`.

--- a/packages/design-copilot/package.json
+++ b/packages/design-copilot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-design-copilot",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "PI extension that makes the model much better at Árvore UI work: searchable icon index (find_icon), brand asset registry (find_asset), a mandatory design brief with a hard gate before generating UI, and a heuristics review sub-agent gate. Data (icon manifest, asset registry) lives in the consuming workspace, resolved via ARVORE_ICONS_MANIFEST or a design/design-system path.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/design-copilot/src/assets.ts
+++ b/packages/design-copilot/src/assets.ts
@@ -1,7 +1,8 @@
 import { existsSync, readFileSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { join } from "node:path";
 import { Type } from "@earendil-works/pi-ai";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { type DesignSystem, dsConfig, resolveAssetsManifest } from "./ds.js";
 
 interface AssetEntry {
   id: string;
@@ -28,8 +29,6 @@ interface FindAssetDetails {
   viewable?: number;
 }
 
-const MANIFEST_REL = "design/design-system/assets/assets.manifest.json";
-
 function normalize(s: string): string {
   return s
     .toLowerCase()
@@ -38,23 +37,18 @@ function normalize(s: string): string {
     .trim();
 }
 
-function findManifest(cwd: string): { dir: string; manifest: AssetManifest } | null {
-  let dir = resolve(cwd);
-  for (let i = 0; i < 8; i++) {
-    const candidate = join(dir, MANIFEST_REL);
-    if (existsSync(candidate)) {
-      try {
-        const manifest = JSON.parse(readFileSync(candidate, "utf-8")) as AssetManifest;
-        return { dir: join(dir, "design/design-system/assets"), manifest };
-      } catch {
-        return null;
-      }
-    }
-    const parent = resolve(dir, "..");
-    if (parent === dir) break;
-    dir = parent;
+function findManifest(
+  ds: DesignSystem,
+  cwd: string,
+): { dir: string; manifest: AssetManifest } | null {
+  const resolved = resolveAssetsManifest(ds, cwd);
+  if (!resolved) return null;
+  try {
+    const manifest = JSON.parse(readFileSync(resolved.manifestPath, "utf-8")) as AssetManifest;
+    return { dir: resolved.assetsDir, manifest };
+  } catch {
+    return null;
   }
-  return null;
 }
 
 function scoreAsset(asset: AssetEntry, terms: string[]): number {
@@ -83,30 +77,36 @@ export function registerAssetTool(pi: ExtensionAPI): void {
     name: "find_asset",
     label: "Find Brand Asset",
     description:
-      "Search the Árvore curated brand/marketing asset registry (Otto mascot, illustrations, empty-state art, campaign assets). Returns the best matches with usage rules and, when a local thumbnail exists, its path so you can view it with the read tool before choosing. Use before adding any illustration or mascot to generated UI.",
+      "Search a design system's curated brand/asset registry (illustrations, mascots, stickers, logos, campaign art) and get usage rules plus, when a local thumbnail exists, its path to view with the read tool. designSystem is REQUIRED: 'bonsai' = Árvore (Otto, ilustrações, empty states), 'superautor' = SuperAutor (stickers, campeões, personagens). Use before adding any illustration/mascot/sticker to generated UI. NEVER mix assets across design systems.",
     promptSnippet:
-      "find_asset — search Árvore's curated brand asset registry (Otto, illustrations, empty states) with usage rules and viewable thumbnails.",
+      "find_asset — search a design system's asset registry (designSystem: 'bonsai' | 'superautor') with usage rules and viewable thumbnails.",
     promptGuidelines: [
-      "Before adding any illustration, mascot (Otto), or campaign art to generated UI, call find_asset and reuse an existing asset instead of inventing new art.",
-      "When a returned asset has a local `path`, read it with the read tool to actually see the image before using it. Respect the asset's `persona` and `quando_usar` rules.",
+      "Before adding any illustration, mascot, sticker or campaign art to generated UI, call find_asset with the correct designSystem for the project ('bonsai' for Árvore, 'superautor' for SuperAutor) and reuse an existing asset instead of inventing new art.",
+      "Never mix design systems: a Bonsai screen uses only bonsai assets, a SuperAutor screen uses only superautor assets. When a returned asset has a local `path`, read it with the read tool to actually see the image before using it. Respect the asset's `persona` and `quando_usar` rules.",
     ],
     parameters: Type.Object({
+      designSystem: Type.Union([Type.Literal("bonsai"), Type.Literal("superautor")], {
+        description:
+          "Which design system's assets to search. 'bonsai' = Árvore. 'superautor' = SuperAutor. REQUIRED.",
+      }),
       intent: Type.String({
         description:
-          "What you need the asset for, in PT or EN (e.g. 'empty state de aluno', 'celebração', 'otto onboarding').",
+          "What you need the asset for, in PT or EN (e.g. 'empty state de aluno', 'celebração', 'sticker campeão').",
       }),
       limit: Type.Optional(Type.Number({ description: "Max results (default 5)." })),
     }),
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
       const cwd = (ctx as { cwd?: string } | undefined)?.cwd ?? process.cwd();
-      const found = findManifest(cwd);
+      const ds = params.designSystem as DesignSystem;
+      const cfg = dsConfig(ds);
+      const found = findManifest(ds, cwd);
       if (!found) {
         const details: FindAssetDetails = { error: "manifest_missing" };
         return {
           content: [
             {
               type: "text",
-              text: `Asset manifest not found (looked for ${MANIFEST_REL} up the tree from ${cwd}). Make sure the arvore-hub design-system folder is present.`,
+              text: `Asset manifest for ${cfg.label} not found (looked for ${cfg.assetsManifestRel} up the tree from ${cwd}, or set ${cfg.assetsEnv}). Make sure the arvore-hub design-system folder is present.`,
             },
           ],
           details,
@@ -127,7 +127,7 @@ export function registerAssetTool(pi: ExtensionAPI): void {
           content: [
             {
               type: "text",
-              text: `No asset matched "${params.intent}". Registry has ${found.manifest.assets.length} entries. You can add one via ${MANIFEST_REL}.`,
+              text: `No ${cfg.label} asset matched "${params.intent}". Registry has ${found.manifest.assets.length} entries.`,
             },
           ],
           details,

--- a/packages/design-copilot/src/ds.ts
+++ b/packages/design-copilot/src/ds.ts
@@ -1,0 +1,72 @@
+import { existsSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+export type DesignSystem = "bonsai" | "superautor";
+
+interface DsPaths {
+  label: string;
+  root: string;
+  assetsDir: string;
+  assetsManifestRel: string;
+  iconsManifestRel: string;
+  iconsEnv: string;
+  assetsEnv: string;
+}
+
+const DS: Record<DesignSystem, DsPaths> = {
+  bonsai: {
+    label: "Bonsai (Árvore)",
+    root: "design/design-system",
+    assetsDir: "design/design-system/assets",
+    assetsManifestRel: "design/design-system/assets/assets.manifest.json",
+    iconsManifestRel: "design/design-system/icons.manifest.json",
+    iconsEnv: "ARVORE_ICONS_MANIFEST",
+    assetsEnv: "ARVORE_ASSETS_MANIFEST",
+  },
+  superautor: {
+    label: "SuperAutor",
+    root: "design/superautor-design-system",
+    assetsDir: "design/superautor-design-system/assets",
+    assetsManifestRel: "design/superautor-design-system/assets/assets.manifest.json",
+    iconsManifestRel: "design/superautor-design-system/icons.manifest.json",
+    iconsEnv: "SUPERAUTOR_ICONS_MANIFEST",
+    assetsEnv: "SUPERAUTOR_ASSETS_MANIFEST",
+  },
+};
+
+export function dsConfig(ds: DesignSystem): DsPaths {
+  return DS[ds];
+}
+
+function walkUp(cwd: string, rel: string): string | null {
+  let dir = resolve(cwd);
+  for (let i = 0; i < 8; i++) {
+    const candidate = join(dir, rel);
+    if (existsSync(candidate)) return candidate;
+    const parent = resolve(dir, "..");
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+export function resolveIconsManifest(ds: DesignSystem, cwd: string): string | null {
+  const cfg = DS[ds];
+  const override = process.env[cfg.iconsEnv];
+  if (override && existsSync(override)) return override;
+  return walkUp(cwd, cfg.iconsManifestRel);
+}
+
+export function resolveAssetsManifest(
+  ds: DesignSystem,
+  cwd: string,
+): { manifestPath: string; assetsDir: string } | null {
+  const cfg = DS[ds];
+  const override = process.env[cfg.assetsEnv];
+  if (override && existsSync(override)) {
+    return { manifestPath: override, assetsDir: resolve(override, "..") };
+  }
+  const manifestPath = walkUp(cwd, cfg.assetsManifestRel);
+  if (!manifestPath) return null;
+  return { manifestPath, assetsDir: resolve(manifestPath, "..") };
+}

--- a/packages/design-copilot/src/icons.ts
+++ b/packages/design-copilot/src/icons.ts
@@ -1,7 +1,7 @@
-import { existsSync, readFileSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { readFileSync } from "node:fs";
 import { Type } from "@earendil-works/pi-ai";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { type DesignSystem, dsConfig, resolveIconsManifest } from "./ds.js";
 
 interface IconEntry {
   name: string;
@@ -12,6 +12,7 @@ interface IconEntry {
 interface IconManifest {
   count: number;
   importPath: string;
+  usage?: string;
   icons: IconEntry[];
 }
 
@@ -21,32 +22,16 @@ interface FindIconDetails {
   top?: string;
 }
 
-const MANIFEST_REL = "design/design-system/icons.manifest.json";
+const cache: Partial<Record<DesignSystem, IconManifest>> = {};
 
-let cache: IconManifest | null = null;
-
-function resolveManifestPath(cwd: string): string | null {
-  const override = process.env.ARVORE_ICONS_MANIFEST;
-  if (override && existsSync(override)) return override;
-
-  let dir = resolve(cwd);
-  for (let i = 0; i < 8; i++) {
-    const candidate = join(dir, MANIFEST_REL);
-    if (existsSync(candidate)) return candidate;
-    const parent = resolve(dir, "..");
-    if (parent === dir) break;
-    dir = parent;
-  }
-  return null;
-}
-
-function loadManifest(cwd: string): IconManifest | null {
-  if (cache) return cache;
-  const path = resolveManifestPath(cwd);
+function loadManifest(ds: DesignSystem, cwd: string): IconManifest | null {
+  if (cache[ds]) return cache[ds] ?? null;
+  const path = resolveIconsManifest(ds, cwd);
   if (!path) return null;
   try {
-    cache = JSON.parse(readFileSync(path, "utf-8")) as IconManifest;
-    return cache;
+    const parsed = JSON.parse(readFileSync(path, "utf-8")) as IconManifest;
+    cache[ds] = parsed;
+    return parsed;
   } catch {
     return null;
   }
@@ -88,16 +73,20 @@ function scoreIcon(icon: IconEntry, terms: string[]): number {
 export function registerIconTool(pi: ExtensionAPI): void {
   pi.registerTool({
     name: "find_icon",
-    label: "Find Bonsai Icon",
+    label: "Find Icon",
     description:
-      "Search the Árvore custom icon set (~966 icons in frontend-arvore-nextjs/src/components/icons) by concept in PT or EN. Returns the matching icon component names and a ready-to-paste import. ALWAYS use this to pick an icon instead of guessing a name or using lucide-react/react-icons.",
+      "Search a design system's icon set by concept in PT or EN and get the exact icon name + ready-to-use usage snippet. designSystem is REQUIRED: 'bonsai' = Árvore/Bonsai React icons (frontend-arvore-nextjs), 'superautor' = SuperAutor Rails SVG icons (superautor-sistema). ALWAYS use this to pick an icon instead of guessing a name or using lucide-react/react-icons. NEVER mix icons across design systems.",
     promptSnippet:
-      "find_icon — search the Árvore custom icon set by concept and get the exact component name + import line.",
+      "find_icon — search a design system's icon set (designSystem: 'bonsai' | 'superautor') and get the exact name + usage snippet.",
     promptGuidelines: [
-      "When you need an icon in any Árvore frontend, call find_icon with the concept (e.g. 'delete', 'aluno', 'livro') and use one of the returned components — never guess an icon name and never import lucide-react or react-icons.",
-      "Icons come from '@/components/icons'. Never use emojis in generated UI; use a system icon instead.",
+      "When you need an icon, call find_icon with the correct designSystem for the project you are in ('bonsai' for Árvore/frontend-arvore-nextjs, 'superautor' for SuperAutor/superautor-sistema) and use one of the returned icons — never guess a name and never import lucide-react or react-icons.",
+      "Never mix design systems: a Bonsai screen uses only bonsai icons, a SuperAutor screen uses only superautor icons. Never use emojis in generated UI; use a system icon instead.",
     ],
     parameters: Type.Object({
+      designSystem: Type.Union([Type.Literal("bonsai"), Type.Literal("superautor")], {
+        description:
+          "Which design system's icons to search. 'bonsai' = Árvore (React, @/components/icons). 'superautor' = SuperAutor (Rails SVG, icones/). REQUIRED.",
+      }),
       concept: Type.String({
         description: "What the icon should represent, in PT or EN (e.g. 'adicionar aluno', 'trash', 'livro').",
       }),
@@ -107,14 +96,16 @@ export function registerIconTool(pi: ExtensionAPI): void {
     }),
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
       const cwd = (ctx as { cwd?: string } | undefined)?.cwd ?? process.cwd();
-      const manifest = loadManifest(cwd);
+      const ds = params.designSystem as DesignSystem;
+      const cfg = dsConfig(ds);
+      const manifest = loadManifest(ds, cwd);
       if (!manifest) {
         const details: FindIconDetails = { error: "manifest_missing" };
         return {
           content: [
             {
               type: "text",
-              text: "Icon manifest not found. Set ARVORE_ICONS_MANIFEST to the icons.manifest.json path, or run it from a workspace that contains design/design-system/icons.manifest.json (generated in arvore-hub via scripts/build-icon-manifest.mjs).",
+              text: `Icon manifest for ${cfg.label} not found. Set ${cfg.iconsEnv} to the icons.manifest.json path, or run from a workspace that contains ${cfg.iconsManifestRel} (generated in arvore-hub).`,
             },
           ],
           details,
@@ -154,17 +145,25 @@ export function registerIconTool(pi: ExtensionAPI): void {
       }
 
       const names = ranked.map((r) => r.icon.name);
-      const importLine = `import { ${names.join(", ")} } from '${manifest.importPath}'`;
       const list = ranked
         .map((r) => `- ${r.icon.name}  (file: ${r.icon.file})`)
         .join("\n");
+
+      let usage: string;
+      if (ds === "superautor") {
+        const use = manifest.usage ?? "Rails: <%= render_svg 'icones/<file>' %>";
+        usage = `Uso (${cfg.label}): ${use}\nEx: <%= render_svg '${manifest.importPath}${ranked[0].icon.file}' %>`;
+      } else {
+        const importLine = `import { ${names.join(", ")} } from '${manifest.importPath}'`;
+        usage = `Import:\n${importLine}\n\nUsage: <${names[0]} className="size-5" />`;
+      }
 
       const details: FindIconDetails = { count: ranked.length, top: names[0] };
       return {
         content: [
           {
             type: "text",
-            text: `Matches for "${params.concept}":\n${list}\n\nImport:\n${importLine}\n\nUsage: <${names[0]} className="size-5" />`,
+            text: `Matches for "${params.concept}" in ${cfg.label}:\n${list}\n\n${usage}`,
           },
         ],
         details,


### PR DESCRIPTION
## Summary

Makes `find_icon` and `find_asset` **design-system aware** so Árvore (Bonsai) and SuperAutor never mix in a UI.

**BREAKING:** both tools now require a `designSystem` param — `'bonsai' | 'superautor'`. Each value resolves a completely separate registry.

| designSystem | Projeto | Ícones | Assets |
|---|---|---|---|
| `bonsai` | Árvore (frontend-arvore-nextjs) | React, @/components/icons | design/design-system/assets |
| `superautor` | SuperAutor (superautor-sistema) | Rails SVG, render_svg | design/superautor-design-system/assets |

## Changes

- **ds.ts (new)** — centralizes per-design-system path resolution (root, assets dir, icon/asset manifests) with env overrides (ARVORE_* for bonsai, SUPERAUTOR_* for superautor) and walk-up fallback.
- **icons.ts** — designSystem param; per-DS manifest cache (fixes a latent cross-DS cache leak); usage hint adapts to the DS: React import for bonsai, Rails render_svg for superautor.
- **assets.ts** — designSystem param; resolves the matching registry via ds.ts.
- Bumped to **0.2.0**.

## Testing

- pnpm build + pnpm lint (tsc) green.
- Resolution verified against the real hub: bonsai to design/design-system/*, superautor to design/superautor-design-system/*.
- No cross-DS leakage: find_icon(superautor, "troféu") to trophy; find_icon(bonsai, "troféu") to empty (correct, that icon doesn't exist in Bonsai). find_asset(superautor, "campeão") to SuperAutor champion stickers; bonsai to Otto/3D medals.

## Dependency

Companion arvore-hub PR adds the SuperAutor manifests + assets (icons.manifest.json, assets.manifest.json, 170 stickers, 20 icons) and updates the superautor-design-system skill. This package must be published (0.2.0) for the hub npm: ref to pick it up.

## Note

Supersedes the single-DS behavior shipped in #117. Existing callers must add designSystem.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting between two design systems when finding icons and assets.
  * Search results now return design-system-specific matches, snippets, and file references.

* **Bug Fixes**
  * Improved lookup reliability by using design-system-aware manifest resolution and clearer missing-file guidance.

* **Chores**
  * Updated the package version to `0.2.0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->