### PR TITLE
fix(codebase-index): guard status updates against stale ctx after session resume

### DIFF
--- a/packages/pi-codebase-index/package.json
+++ b/packages/pi-codebase-index/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-codebase-index",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "PI extension for semantic codebase search (vendor-neutral backend contract)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/pi-codebase-index/src/index.ts
+++ b/packages/pi-codebase-index/src/index.ts
@@ -82,6 +82,14 @@ function login(): Promise<{
   });
 }
 
+function safeSetStatus(ctx: { ui: { setStatus: (key: string, text: string) => void } }, text: string): void {
+  try {
+    ctx.ui.setStatus("codebase", text);
+  } catch {
+    // ctx went stale after a session resume/replace/reload; ignore.
+  }
+}
+
 function restoreHiddenState(entries: unknown[]): void {
   for (const entry of entries) {
     const typed = entry as { type?: string; customType?: string; data?: { hidden?: boolean } };
@@ -120,14 +128,14 @@ export default function piCodebaseIndexExtension(pi: ExtensionAPI): void {
 
     const creds = await getCredentials();
     if (!hidden) {
-      ctx.ui.setStatus(
-        "codebase",
+      safeSetStatus(
+        ctx,
         creds ? "codebase: starting sync…" : "codebase: not logged in"
       );
     }
 
     if (creds) {
-      void triggerSync(pi, ctx.cwd, (text) => ctx.ui.setStatus("codebase", text));
+      void triggerSync(pi, ctx.cwd, (text) => safeSetStatus(ctx, text));
     }
   });
 
@@ -144,7 +152,7 @@ export default function piCodebaseIndexExtension(pi: ExtensionAPI): void {
         });
         ctx.ui.setStatus("codebase", `codebase: ${result.username}`);
         ctx.ui.notify(`Logged in as ${result.username}`, "info");
-        void triggerSync(pi, ctx.cwd, (text) => ctx.ui.setStatus("codebase", text));
+        void triggerSync(pi, ctx.cwd, (text) => safeSetStatus(ctx, text));
       } catch (error) {
         ctx.ui.notify(
           `Login failed: ${error instanceof Error ? error.message : String(error)}`,
@@ -194,7 +202,7 @@ export default function piCodebaseIndexExtension(pi: ExtensionAPI): void {
     description: "Force a fresh sync of the workspace into the codebase index",
     handler: async (_args, ctx) => {
       ctx.ui.notify("Re-syncing codebase index…", "info");
-      await triggerSync(pi, ctx.cwd, (text) => ctx.ui.setStatus("codebase", text));
+      await triggerSync(pi, ctx.cwd, (text) => safeSetStatus(ctx, text));
     },
   });
 


### PR DESCRIPTION
## Summary

Fixes an `uncaughtException` that crashes the entire pi process when a session is resumed while the codebase index is still syncing in the background.

## Root cause

`session_start` fires `triggerSync` as fire-and-forget (`void`) with a callback that captures `ctx` and later calls `ctx.ui.setStatus`. When the session is resumed/replaced (e.g. memory hydration triggers a session replacement), that captured `ctx` goes stale. The still-running background sync then calls `ctx.ui.setStatus` on the stale ctx, pi throws:

```
Error: This extension ctx is stale after session replacement or reload.
    at ExtensionRunner.assertActive (.../runner.js:331:19)
    at get ui (.../runner.js:416:24)
    at .../@arvoretech/pi-codebase-index/dist/index.js:107:57  (the setStatus callback)
```

Because it's an unhandled async callback, it takes down the whole process.

## Fix

Introduce `safeSetStatus(ctx, text)` which wraps `ctx.ui.setStatus` in try/catch — a stale ctx becomes a no-op instead of a fatal crash. Route every status update through it (`session_start`, `codebase-login`, `codebase-reindex`).

Bump to **0.1.6**.

## Testing

- `pnpm build` (tsc) green.
- Verified no unguarded `ctx.ui.setStatus(..., text)` callsite remains in the sync path.
