### PR TITLE
fix(pi-codebase-index): guard status updates against stale ctx during sync

### DIFF
--- a/packages/pi-codebase-index/package.json
+++ b/packages/pi-codebase-index/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-codebase-index",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "PI extension for semantic codebase search (vendor-neutral backend contract)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/pi-codebase-index/src/index.ts
+++ b/packages/pi-codebase-index/src/index.ts
@@ -99,12 +99,19 @@ async function triggerSync(pi: ExtensionAPI, cwd: string, setStatus: (text: stri
   if (!creds) return;
 
   syncing = true;
-  const status = hidden ? () => {} : setStatus;
+  const safeSetStatus = (text: string) => {
+    try {
+      setStatus(text);
+    } catch {
+      void 0;
+    }
+  };
+  const status = hidden ? () => {} : safeSetStatus;
   try {
     await runSync(cwd, status);
   } catch (error) {
     if (!hidden) {
-      setStatus(`codebase: sync failed`);
+      safeSetStatus(`codebase: sync failed`);
     }
     void error;
   } finally {


### PR DESCRIPTION
## Summary

Fix a crash in the `pi-codebase-index` extension where the Node process dies with:

> Error: This extension ctx is stale after session replacement or reload.

## Root cause

`triggerSync` runs asynchronously (`void triggerSync(...)`) and receives a `setStatus` closure that captures the session `ctx` (`(text) => ctx.ui.setStatus(...)`). If the session is replaced/reloaded (`newSession`/`fork`/`switchSession`/`reload`) while a sync is still in flight, `ctx` becomes stale and accessing `ctx.ui` throws.

Worse, the `catch` block called `setStatus("codebase: sync failed")` again with the same stale closure. That throw happened outside any `try/catch`, and since the call was fire-and-forget (`void`), it surfaced as an unhandled rejection that crashed the whole Node process.

## Fix

Wrap all status updates inside `triggerSync` in a `safeSetStatus` helper that swallows stale-ctx errors, so a session swap during an in-flight sync can no longer crash the process.

## Testing

- `lsp_diagnostics`: 0 errors, 0 warnings on the changed file (pre-existing unused-`pi` hint unrelated to this change).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sync status updates so errors in the status display no longer interrupt the sync process.
  * Made failure notifications more resilient while continuing to keep hidden syncs silent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->