### PR TITLE
fix(widget-wrangler): honor hidden state for widgets rendered before the patch

### DIFF
--- a/packages/widget-wrangler/package.json
+++ b/packages/widget-wrangler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-widget-wrangler",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "PI extension that corrals widgets and footer statuses from every extension into one panel where you show or hide each one 🤠",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/widget-wrangler/src/index.ts
+++ b/packages/widget-wrangler/src/index.ts
@@ -104,7 +104,7 @@ export default function widgetWranglerExtension(pi: ExtensionAPI) {
     if (isEnabled(key) && record.content !== undefined) {
       originalSetWidget(key, record.content as never, record.options);
       record.rendered = true;
-    } else if (record.rendered) {
+    } else {
       originalSetWidget(key, undefined, record.options);
       record.rendered = false;
     }
@@ -121,9 +121,30 @@ export default function widgetWranglerExtension(pi: ExtensionAPI) {
     if (isEnabled(statusToggleKey(key)) && record.text !== undefined) {
       originalSetStatus(key, record.text);
       record.rendered = true;
-    } else if (record.rendered) {
+    } else {
       originalSetStatus(key, undefined);
       record.rendered = false;
+    }
+  }
+
+  function forceHideDisabled() {
+    if (originalSetWidget) {
+      for (const key of disabled) {
+        if (key.startsWith(STATUS_PREFIX)) continue;
+        if (key === OWN_WIDGET_KEY) continue;
+        originalSetWidget(key, undefined);
+        const record = registry.get(key);
+        if (record) record.rendered = false;
+      }
+    }
+    if (originalSetStatus) {
+      for (const key of disabled) {
+        if (!key.startsWith(STATUS_PREFIX)) continue;
+        const statusKey = key.slice(STATUS_PREFIX.length);
+        originalSetStatus(statusKey, undefined);
+        const record = statusRegistry.get(statusKey);
+        if (record) record.rendered = false;
+      }
     }
   }
 
@@ -302,6 +323,7 @@ export default function widgetWranglerExtension(pi: ExtensionAPI) {
     if (!ctx.hasUI) return;
     patchSetWidget(ctx.ui);
     restoreConfig(ctx);
+    forceHideDisabled();
     for (const key of registry.keys()) applyWidget(key);
     for (const key of statusRegistry.keys()) applyStatus(key);
   });
@@ -310,6 +332,7 @@ export default function widgetWranglerExtension(pi: ExtensionAPI) {
     if (!ctx.hasUI) return;
     patchSetWidget(ctx.ui);
     restoreConfig(ctx);
+    forceHideDisabled();
     for (const key of registry.keys()) applyWidget(key);
     for (const key of statusRegistry.keys()) applyStatus(key);
   });


### PR DESCRIPTION
## Summary

Fixes hidden widgets/footer statuses (e.g. `pi-memory`, `catch-the-fox`) reappearing after a session resume, even though the disabled list persisted correctly to `~/.pi/agent/widget-wrangler.json`.

## Root cause

Two bugs stacked on top of each other:

**1. Load order.** In `settings.json`, `pi-memory` loads *before* `pi-widget-wrangler`. On `session_start`, memory calls `ctx.ui.setWidget("pi-memory", ...)` **before** wrangler monkey-patches `ui.setWidget`. That first render bypasses the wrapper entirely, so the widget is never recorded in wrangler's registry and its `rendered` flag stays `false`.

**2. `applyWidget`/`applyStatus` only hid in the `else if (record.rendered)` branch.** Because the pre-patch render left `rendered = false`, the hide was **never emitted** — the widget stayed visible forever despite being in the persisted `disabled` set.

Net effect: you hide `memory`/`fox`, the config saves fine, but on the next resume they come right back.

## Fix

- `applyWidget` / `applyStatus` now always emit `setWidget/setStatus(undefined)` when a key is disabled, regardless of the `rendered` flag (idempotent hide).
- New `forceHideDisabled()`, called after `restoreConfig` on both `session_start` and `session_tree`, proactively hides every disabled key through the **original** `setWidget/setStatus` — covering widgets that were rendered before the patch was in place.

Bump to **1.1.1**.

## Testing

- `pnpm build` (tsc) green.
- Verified the persisted config (`~/.pi/agent/widget-wrangler.json`) already contained the hidden keys — confirming save works and the bug was purely in restore/re-hide.
- Patched the installed copy locally and confirmed `forceHideDisabled` is wired into both session handlers.
