### PR TITLE
feat(monitor): pi-monitor extension for background process notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Monorepo for custom PI extensions used across Arvore projects.
 | `@arvoretech/pi-plan-mode` | Cursor-style plan mode with read-only exploration and manual /build approval |
 | `@arvoretech/pi-team-memory` | Team memory with proactive capture hooks |
 | `@arvoretech/pi-memory` | Cloud-based memory with RAG (Qdrant + GitHub OAuth) |
+| `@arvoretech/pi-monitor` | Watches a background process and pushes matching output lines to the agent as notifications (no polling) |
 | `@arvoretech/pi-warp-tab-title` | Renames Warp terminal tab to reflect current task focus |
 | `@arvoretech/pi-worktree` | Manages git worktrees across multi-repo workspaces with tree-themed names |
 

--- a/packages/monitor/README.md
+++ b/packages/monitor/README.md
@@ -1,0 +1,42 @@
+# @arvoretech/pi-monitor
+
+Watch a long-running background process and push each matching output line to the agent as a notification — no polling. Inspired by Claude Code's Monitor tool, with stderr + exit-code capture and flood protection on top.
+
+## How it works
+
+```
+monitor_start → spawn(command, shell) → readline(stdout/stderr)
+                        │
+              line matches include/exclude filter
+                        │
+        pi.sendUserMessage(line, { deliverAs: "steer" })  → agent reacts mid-conversation
+```
+
+The agent keeps working and is interrupted only when a matching line arrives. Monitors are session-scoped and are killed on `session_shutdown`.
+
+## Tools
+
+- `monitor_start` — start a background monitor. Params: `id`, `command`, `cwd?`, `include?` (regex), `exclude?` (regex), `captureStderr?` (default true), `reportExit?` (default true), `deliverAs?` (`steer` | `followUp`, default `steer`), `maxEventsPerWindow?` (default 40 / 60s).
+- `monitor_stop` — stop by `id`, or `all: true`.
+- `monitor_list` — list running monitors with uptime and event counts.
+
+## Command
+
+- `/monitors` — list running monitors.
+
+## Notes vs Claude Code Monitor
+
+- Captures **stderr and exit code** (Claude's forwards stdout only, so silent failures look healthy).
+- **Filter is applied in-process** via `include`/`exclude` regex to avoid flooding context.
+- **Flood guard**: a monitor emitting more than `maxEventsPerWindow` matching lines per 60s window auto-stops and tells the agent to restart with a tighter filter.
+- Pipe-buffering caveat still applies to your command: use `grep --line-buffered` when filtering upstream.
+
+## Usage
+
+Add to `.pi/settings.json`:
+```json
+{ "packages": ["npm:@arvoretech/pi-monitor"] }
+```
+
+Then ask in natural language:
+> Run `docker compose up --build` in the background and tell me the moment any line contains "error" or when a service reports "healthy".

--- a/packages/monitor/README.md
+++ b/packages/monitor/README.md
@@ -22,7 +22,11 @@ The agent keeps working and is interrupted only when a matching line arrives. Mo
 
 ## Command
 
-- `/monitors` — list running monitors.
+- `/monitors` — abre o painel de logs (monitores ativos + eventos recentes). Esc fecha.
+
+## Footer
+
+Enquanto houver monitores rodando, um item aparece no rodapé (`1 monitor ativo · /monitors p/ logs`). Ele some sozinho quando o último monitor termina, e pode ser escondido pela extensão `widget-wrangler` (`/wrangle`).
 
 ## Notes vs Claude Code Monitor
 

--- a/packages/monitor/package.json
+++ b/packages/monitor/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "@earendil-works/pi-coding-agent": "latest",
     "@earendil-works/pi-ai": "latest",
+    "@earendil-works/pi-tui": "latest",
     "@types/node": "^20.10.0",
     "typescript": "^5.3.0"
   },

--- a/packages/monitor/package.json
+++ b/packages/monitor/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@arvoretech/pi-monitor",
+  "version": "1.0.0",
+  "description": "PI extension that watches a background process and pushes matching output lines to the agent as notifications (no polling)",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "lint": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": ">=0.74.0"
+  },
+  "devDependencies": {
+    "@earendil-works/pi-coding-agent": "latest",
+    "@earendil-works/pi-ai": "latest",
+    "@types/node": "^20.10.0",
+    "typescript": "^5.3.0"
+  },
+  "pi": {
+    "extensions": [
+      "./dist/index.js"
+    ]
+  },
+  "keywords": [
+    "pi-package",
+    "pi",
+    "extension",
+    "monitor",
+    "background-process",
+    "streaming"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/arvoreeducacao/arvore-pi-extensions.git",
+    "directory": "packages/monitor"
+  },
+  "author": "Arvore",
+  "license": "MIT"
+}

--- a/packages/monitor/src/index.ts
+++ b/packages/monitor/src/index.ts
@@ -1,5 +1,6 @@
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { Type } from "@earendil-works/pi-ai";
+import { Container, Text } from "@earendil-works/pi-tui";
 import {
   listMonitors,
   safeRegExp,
@@ -11,23 +12,125 @@ import {
 
 const DEFAULT_MAX_EVENTS = 40;
 const DEFAULT_WINDOW_MS = 60_000;
+const STATUS_KEY = "monitor";
+const MAX_LOG_LINES = 200;
+
+type UIRef = {
+  setStatus: (key: string, text: string | undefined) => void;
+};
+
+function kindTag(kind: MonitorEvent["kind"]): string {
+  switch (kind) {
+    case "exit":
+      return "exit";
+    case "flood":
+      return "flood";
+    case "stderr":
+      return "err";
+    default:
+      return "out";
+  }
+}
 
 function formatEvent(event: MonitorEvent): string {
-  const tag =
-    event.kind === "exit"
-      ? "🏁"
-      : event.kind === "flood"
-        ? "🚱"
-        : event.kind === "stderr"
-          ? "⚠️"
-          : "📡";
-  return `${tag} [monitor:${event.monitorId}] ${event.line}`;
+  return `[monitor:${event.monitorId}] (${kindTag(event.kind)}) ${event.line}`;
 }
 
 export default function extension(pi: ExtensionAPI): void {
+  let ui: UIRef | undefined;
+  const logBuffer: MonitorEvent[] = [];
+
+  const refreshStatus = () => {
+    if (!ui) return;
+    const active = listMonitors().length;
+    if (active === 0) {
+      ui.setStatus(STATUS_KEY, undefined);
+      return;
+    }
+    const label = active === 1 ? "1 monitor ativo" : `${active} monitores ativos`;
+    ui.setStatus(STATUS_KEY, `${label} · /monitors p/ logs`);
+  };
+
+  const recordEvent = (event: MonitorEvent) => {
+    logBuffer.push(event);
+    while (logBuffer.length > MAX_LOG_LINES) logBuffer.shift();
+    refreshStatus();
+  };
+
   const pushEvent = (event: MonitorEvent, deliverAs: "steer" | "followUp") => {
+    recordEvent(event);
     pi.sendUserMessage(formatEvent(event), { deliverAs });
   };
+
+  const captureUI = (ctx: { ui?: UIRef }) => {
+    if (ctx.ui) ui = ctx.ui;
+  };
+
+  const openLogPanel = async (ctx: ExtensionContext) => {
+    if (ctx.mode !== "tui") {
+      ctx.ui.notify("O painel de logs precisa do modo TUI.", "error");
+      return;
+    }
+    const running = listMonitors();
+    if (running.length === 0 && logBuffer.length === 0) {
+      ctx.ui.notify("Nenhum monitor ativo e nenhum log recente.", "info");
+      return;
+    }
+
+    await ctx.ui.custom<void>((tui, theme, _kb, done) => {
+      const container = new Container();
+      const activeLabel =
+        running.length === 0
+          ? "sem monitores ativos"
+          : running.map((m) => m.id).join(", ");
+      container.addChild(
+        new Text(
+          `${theme.fg("accent", theme.bold("monitor logs"))}  ${theme.fg("muted", `${activeLabel} · esc fecha`)}`,
+          1,
+          1,
+        ),
+      );
+      const recent = logBuffer.slice(-40);
+      if (recent.length === 0) {
+        container.addChild(new Text(theme.fg("muted", "  (sem eventos ainda)"), 0, 1));
+      }
+      for (const e of recent) {
+        const prefix = theme.fg("muted", `[${e.monitorId}] `);
+        const body = e.line;
+        let line: string;
+        if (e.kind === "stderr" || e.kind === "flood") {
+          line = prefix + theme.fg("warning", body);
+        } else if (e.kind === "exit") {
+          line = prefix + theme.fg("success", body);
+        } else {
+          line = prefix + body;
+        }
+        container.addChild(new Text(line, 0, 0));
+      }
+
+      return {
+        render: (width: number) => container.render(width),
+        invalidate: () => container.invalidate(),
+        handleInput: (data: string) => {
+          if (data === "\x1b" || data === "q") {
+            done(undefined);
+            return;
+          }
+          tui.requestRender();
+        },
+      };
+    }, { overlay: true });
+  };
+
+  pi.on("session_start", async (_event, ctx) => {
+    captureUI(ctx as unknown as { ui?: UIRef });
+    refreshStatus();
+  });
+
+  pi.on("session_tree", async (_event, ctx) => {
+    captureUI(ctx as unknown as { ui?: UIRef });
+    refreshStatus();
+  });
 
   pi.registerTool({
     name: "monitor_start",
@@ -81,7 +184,8 @@ export default function extension(pi: ExtensionAPI): void {
         }),
       ),
     }),
-    async execute(_toolCallId, params) {
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      captureUI(ctx as unknown as { ui?: UIRef });
       const deliverAs = params.deliverAs ?? "steer";
       try {
         const handle = startMonitor(
@@ -98,6 +202,7 @@ export default function extension(pi: ExtensionAPI): void {
           },
           (event) => pushEvent(event, deliverAs),
         );
+        refreshStatus();
         return {
           content: [
             {
@@ -130,6 +235,7 @@ export default function extension(pi: ExtensionAPI): void {
     async execute(_toolCallId, params) {
       if (params.all) {
         const count = stopAllMonitors();
+        refreshStatus();
         return {
           content: [{ type: "text", text: `Stopped ${count} monitor(s).` }],
           details: { stopped: count } as Record<string, unknown>,
@@ -142,6 +248,7 @@ export default function extension(pi: ExtensionAPI): void {
         };
       }
       const ok = stopMonitor(params.id, "manual");
+      refreshStatus();
       return {
         content: [
           { type: "text", text: ok ? `Stopped monitor "${params.id}".` : `No monitor "${params.id}" running.` },
@@ -172,21 +279,16 @@ export default function extension(pi: ExtensionAPI): void {
   });
 
   pi.registerCommand("monitors", {
-    description: "List running background monitors.",
+    description: "Open the monitor log panel (running monitors + recent events). Esc to close.",
     handler: async (_args, ctx) => {
-      const running = listMonitors();
-      if (running.length === 0) {
-        ctx.ui.notify("No monitors running.", "info");
-        return;
-      }
-      ctx.ui.notify(
-        running.map((m) => `${m.id}: ${m.command} (${m.eventCount} events)`).join("\n"),
-        "info",
-      );
+      captureUI(ctx as unknown as { ui?: UIRef });
+      await openLogPanel(ctx);
     },
   });
 
   pi.on("session_shutdown", async () => {
     stopAllMonitors();
+    logBuffer.length = 0;
+    ui?.setStatus(STATUS_KEY, undefined);
   });
 }

--- a/packages/monitor/src/index.ts
+++ b/packages/monitor/src/index.ts
@@ -1,0 +1,192 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Type } from "@earendil-works/pi-ai";
+import {
+  listMonitors,
+  safeRegExp,
+  startMonitor,
+  stopAllMonitors,
+  stopMonitor,
+  type MonitorEvent,
+} from "./monitor.js";
+
+const DEFAULT_MAX_EVENTS = 40;
+const DEFAULT_WINDOW_MS = 60_000;
+
+function formatEvent(event: MonitorEvent): string {
+  const tag =
+    event.kind === "exit"
+      ? "🏁"
+      : event.kind === "flood"
+        ? "🚱"
+        : event.kind === "stderr"
+          ? "⚠️"
+          : "📡";
+  return `${tag} [monitor:${event.monitorId}] ${event.line}`;
+}
+
+export default function extension(pi: ExtensionAPI): void {
+  const pushEvent = (event: MonitorEvent, deliverAs: "steer" | "followUp") => {
+    pi.sendUserMessage(formatEvent(event), { deliverAs });
+  };
+
+  pi.registerTool({
+    name: "monitor_start",
+    label: "Start Monitor",
+    description:
+      "Watch a long-running background process and receive each matching output line as a push notification (no polling). Use for tailing deploy/CI/test logs, file watchers, or any process that emits progress over time. The command runs in a shell in the background and this tool returns immediately.",
+    promptSnippet:
+      "Start a background monitor that pushes matching stdout/stderr lines back to you as they happen",
+    promptGuidelines: [
+      "Use monitor_start when the user asks to watch/tail a long-running process (deploy, CI, tests, build, file changes) and react to its output without blocking the conversation.",
+      "Always set an include or exclude regex on monitor_start for verbose processes — an unfiltered monitor of a chatty process will be auto-stopped for flooding.",
+      "Set reportExit=true on monitor_start when you need to know if the process fails silently; monitor also forwards stderr by default.",
+      "Stop a monitor with monitor_stop once its purpose is served; monitors are session-scoped and die on shutdown.",
+    ],
+    parameters: Type.Object({
+      id: Type.String({
+        description: "Short unique name for this monitor (e.g. 'deploy', 'ci', 'tests').",
+      }),
+      command: Type.String({
+        description: "Shell command to run in the background (e.g. 'docker compose up --build').",
+      }),
+      cwd: Type.Optional(
+        Type.String({ description: "Working directory for the command. Defaults to session cwd." }),
+      ),
+      include: Type.Optional(
+        Type.String({
+          description:
+            "Case-insensitive regex; only lines matching it are pushed. Omit to push all lines.",
+        }),
+      ),
+      exclude: Type.Optional(
+        Type.String({
+          description: "Case-insensitive regex; lines matching it are dropped. Applied before include.",
+        }),
+      ),
+      captureStderr: Type.Optional(
+        Type.Boolean({ description: "Forward stderr lines too. Default true." }),
+      ),
+      reportExit: Type.Optional(
+        Type.Boolean({ description: "Notify when the process exits (with its code). Default true." }),
+      ),
+      deliverAs: Type.Optional(
+        Type.Union([Type.Literal("steer"), Type.Literal("followUp")], {
+          description:
+            "'steer' (default) reacts mid-conversation; 'followUp' waits until you finish the current turn.",
+        }),
+      ),
+      maxEventsPerWindow: Type.Optional(
+        Type.Number({
+          description: `Auto-stop the monitor if it emits more than this many matching lines per window. Default ${DEFAULT_MAX_EVENTS}.`,
+        }),
+      ),
+    }),
+    async execute(_toolCallId, params) {
+      const deliverAs = params.deliverAs ?? "steer";
+      try {
+        const handle = startMonitor(
+          {
+            id: params.id,
+            command: params.command,
+            cwd: params.cwd,
+            include: safeRegExp(params.include),
+            exclude: safeRegExp(params.exclude),
+            captureStderr: params.captureStderr ?? true,
+            reportExit: params.reportExit ?? true,
+            maxEventsPerWindow: params.maxEventsPerWindow ?? DEFAULT_MAX_EVENTS,
+            windowMs: DEFAULT_WINDOW_MS,
+          },
+          (event) => pushEvent(event, deliverAs),
+        );
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Monitor "${handle.config.id}" started: \`${handle.config.command}\`. Matching lines will be pushed to you as they arrive (delivery: ${deliverAs}). Continue working; you'll be notified on new output.`,
+            },
+          ],
+          details: { id: handle.config.id, command: handle.config.command, deliverAs } as Record<string, unknown>,
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          content: [{ type: "text", text: `Failed to start monitor: ${message}` }],
+          details: { error: message } as Record<string, unknown>,
+        };
+      }
+    },
+  });
+
+  pi.registerTool({
+    name: "monitor_stop",
+    label: "Stop Monitor",
+    description: "Stop a running background monitor by id, or all monitors.",
+    parameters: Type.Object({
+      id: Type.Optional(
+        Type.String({ description: "Monitor id to stop. Omit and pass all=true to stop everything." }),
+      ),
+      all: Type.Optional(Type.Boolean({ description: "Stop every running monitor." })),
+    }),
+    async execute(_toolCallId, params) {
+      if (params.all) {
+        const count = stopAllMonitors();
+        return {
+          content: [{ type: "text", text: `Stopped ${count} monitor(s).` }],
+          details: { stopped: count } as Record<string, unknown>,
+        };
+      }
+      if (!params.id) {
+        return {
+          content: [{ type: "text", text: "Provide a monitor id or set all=true." }],
+          details: { error: "missing-id" } as Record<string, unknown>,
+        };
+      }
+      const ok = stopMonitor(params.id, "manual");
+      return {
+        content: [
+          { type: "text", text: ok ? `Stopped monitor "${params.id}".` : `No monitor "${params.id}" running.` },
+        ],
+        details: { stopped: ok } as Record<string, unknown>,
+      };
+    },
+  });
+
+  pi.registerTool({
+    name: "monitor_list",
+    label: "List Monitors",
+    description: "List currently running background monitors with uptime and event counts.",
+    parameters: Type.Object({}),
+    async execute() {
+      const running = listMonitors();
+      if (running.length === 0) {
+        return { content: [{ type: "text", text: "No monitors running." }], details: { monitors: [] } };
+      }
+      const text = running
+        .map(
+          (m) =>
+            `• ${m.id}: \`${m.command}\` — up ${Math.round(m.uptimeMs / 1000)}s, ${m.eventCount} event(s) pushed`,
+        )
+        .join("\n");
+      return { content: [{ type: "text", text }], details: { monitors: running } };
+    },
+  });
+
+  pi.registerCommand("monitors", {
+    description: "List running background monitors.",
+    handler: async (_args, ctx) => {
+      const running = listMonitors();
+      if (running.length === 0) {
+        ctx.ui.notify("No monitors running.", "info");
+        return;
+      }
+      ctx.ui.notify(
+        running.map((m) => `${m.id}: ${m.command} (${m.eventCount} events)`).join("\n"),
+        "info",
+      );
+    },
+  });
+
+  pi.on("session_shutdown", async () => {
+    stopAllMonitors();
+  });
+}

--- a/packages/monitor/src/monitor.ts
+++ b/packages/monitor/src/monitor.ts
@@ -1,0 +1,182 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { createInterface, type Interface } from "node:readline";
+
+export type StreamKind = "stdout" | "stderr";
+
+export interface MonitorConfig {
+  id: string;
+  command: string;
+  cwd?: string;
+  include?: RegExp;
+  exclude?: RegExp;
+  captureStderr: boolean;
+  reportExit: boolean;
+  maxEventsPerWindow: number;
+  windowMs: number;
+}
+
+export interface MonitorEvent {
+  monitorId: string;
+  command: string;
+  kind: StreamKind | "exit" | "flood";
+  line: string;
+}
+
+export interface MonitorHandle {
+  config: MonitorConfig;
+  startedAt: number;
+  eventCount: number;
+  stop(reason: string): void;
+}
+
+type Emit = (event: MonitorEvent) => void;
+
+interface RunningMonitor extends MonitorHandle {
+  child: ChildProcessWithoutNullStreams;
+  stdoutReader: Interface;
+  stderrReader?: Interface;
+  windowStart: number;
+  windowCount: number;
+  stopped: boolean;
+}
+
+const monitors = new Map<string, RunningMonitor>();
+
+function matches(line: string, include?: RegExp, exclude?: RegExp): boolean {
+  if (exclude && exclude.test(line)) return false;
+  if (include) return include.test(line);
+  return true;
+}
+
+export function startMonitor(config: MonitorConfig, emit: Emit): MonitorHandle {
+  if (monitors.has(config.id)) {
+    throw new Error(`A monitor with id "${config.id}" is already running.`);
+  }
+
+  const child = spawn(config.command, {
+    cwd: config.cwd,
+    shell: true,
+    env: process.env,
+  }) as ChildProcessWithoutNullStreams;
+
+  const handle: RunningMonitor = {
+    config,
+    startedAt: Date.now(),
+    eventCount: 0,
+    child,
+    stdoutReader: createInterface({ input: child.stdout }),
+    windowStart: Date.now(),
+    windowCount: 0,
+    stopped: false,
+    stop(reason: string) {
+      stopMonitor(config.id, reason);
+    },
+  };
+
+  const onLine = (kind: StreamKind) => (raw: string) => {
+    if (handle.stopped) return;
+    const line = raw.trimEnd();
+    if (!line) return;
+    if (!matches(line, config.include, config.exclude)) return;
+
+    const now = Date.now();
+    if (now - handle.windowStart > config.windowMs) {
+      handle.windowStart = now;
+      handle.windowCount = 0;
+    }
+    handle.windowCount += 1;
+
+    if (handle.windowCount > config.maxEventsPerWindow) {
+      emit({
+        monitorId: config.id,
+        command: config.command,
+        kind: "flood",
+        line: `Monitor "${config.id}" exceeded ${config.maxEventsPerWindow} events in ${Math.round(config.windowMs / 1000)}s and was auto-stopped. Restart it with a tighter include/exclude filter.`,
+      });
+      stopMonitor(config.id, "flood");
+      return;
+    }
+
+    handle.eventCount += 1;
+    emit({ monitorId: config.id, command: config.command, kind, line });
+  };
+
+  handle.stdoutReader.on("line", onLine("stdout"));
+
+  if (config.captureStderr) {
+    handle.stderrReader = createInterface({ input: child.stderr });
+    handle.stderrReader.on("line", onLine("stderr"));
+  }
+
+  child.on("exit", (code, signal) => {
+    if (handle.stopped) return;
+    handle.stopped = true;
+    handle.stdoutReader.close();
+    handle.stderrReader?.close();
+    monitors.delete(config.id);
+    if (config.reportExit) {
+      const status = signal ? `killed by signal ${signal}` : `exit code ${code}`;
+      emit({
+        monitorId: config.id,
+        command: config.command,
+        kind: "exit",
+        line: `Process finished (${status}).`,
+      });
+    }
+  });
+
+  child.on("error", (err) => {
+    if (handle.stopped) return;
+    handle.stopped = true;
+    monitors.delete(config.id);
+    emit({
+      monitorId: config.id,
+      command: config.command,
+      kind: "exit",
+      line: `Process failed to start: ${err.message}`,
+    });
+  });
+
+  monitors.set(config.id, handle);
+  return handle;
+}
+
+export function stopMonitor(id: string, _reason: string): boolean {
+  const handle = monitors.get(id);
+  if (!handle) return false;
+  handle.stopped = true;
+  handle.stdoutReader.close();
+  handle.stderrReader?.close();
+  try {
+    handle.child.kill("SIGTERM");
+  } catch {
+    // process already gone
+  }
+  monitors.delete(id);
+  return true;
+}
+
+export function listMonitors(): Array<{
+  id: string;
+  command: string;
+  uptimeMs: number;
+  eventCount: number;
+}> {
+  return [...monitors.values()].map((m) => ({
+    id: m.config.id,
+    command: m.config.command,
+    uptimeMs: Date.now() - m.startedAt,
+    eventCount: m.eventCount,
+  }));
+}
+
+export function stopAllMonitors(): number {
+  const ids = [...monitors.keys()];
+  for (const id of ids) stopMonitor(id, "shutdown");
+  return ids.length;
+}
+
+export function safeRegExp(source: string | undefined, flags = "i"): RegExp | undefined {
+  if (!source) return undefined;
+  return new RegExp(source, flags);
+}

--- a/packages/monitor/src/monitor.ts
+++ b/packages/monitor/src/monitor.ts
@@ -57,7 +57,11 @@ export function startMonitor(config: MonitorConfig, emit: Emit): MonitorHandle {
     cwd: config.cwd,
     shell: true,
     env: process.env,
+    detached: process.platform !== "win32",
   }) as ChildProcessWithoutNullStreams;
+
+  const maxEventsPerWindow =
+    config.maxEventsPerWindow > 0 ? config.maxEventsPerWindow : 1;
 
   const handle: RunningMonitor = {
     config,
@@ -86,12 +90,12 @@ export function startMonitor(config: MonitorConfig, emit: Emit): MonitorHandle {
     }
     handle.windowCount += 1;
 
-    if (handle.windowCount > config.maxEventsPerWindow) {
+    if (handle.windowCount > maxEventsPerWindow) {
       emit({
         monitorId: config.id,
         command: config.command,
         kind: "flood",
-        line: `Monitor "${config.id}" exceeded ${config.maxEventsPerWindow} events in ${Math.round(config.windowMs / 1000)}s and was auto-stopped. Restart it with a tighter include/exclude filter.`,
+        line: `Monitor "${config.id}" exceeded ${maxEventsPerWindow} events in ${Math.round(config.windowMs / 1000)}s and was auto-stopped. Restart it with a tighter include/exclude filter.`,
       });
       stopMonitor(config.id, "flood");
       return;
@@ -106,6 +110,8 @@ export function startMonitor(config: MonitorConfig, emit: Emit): MonitorHandle {
   if (config.captureStderr) {
     handle.stderrReader = createInterface({ input: child.stderr });
     handle.stderrReader.on("line", onLine("stderr"));
+  } else {
+    child.stderr.resume();
   }
 
   child.on("exit", (code, signal) => {
@@ -128,6 +134,8 @@ export function startMonitor(config: MonitorConfig, emit: Emit): MonitorHandle {
   child.on("error", (err) => {
     if (handle.stopped) return;
     handle.stopped = true;
+    handle.stdoutReader.close();
+    handle.stderrReader?.close();
     monitors.delete(config.id);
     emit({
       monitorId: config.id,
@@ -147,13 +155,27 @@ export function stopMonitor(id: string, _reason: string): boolean {
   handle.stopped = true;
   handle.stdoutReader.close();
   handle.stderrReader?.close();
-  try {
-    handle.child.kill("SIGTERM");
-  } catch {
-    // process already gone
-  }
+  killProcessTree(handle.child);
   monitors.delete(id);
   return true;
+}
+
+function killProcessTree(child: ChildProcessWithoutNullStreams): void {
+  const pid = child.pid;
+  if (pid === undefined) return;
+  try {
+    if (process.platform !== "win32") {
+      process.kill(-pid, "SIGTERM");
+    } else {
+      child.kill("SIGTERM");
+    }
+  } catch {
+    try {
+      child.kill("SIGTERM");
+    } catch {
+      // process already gone
+    }
+  }
 }
 
 export function listMonitors(): Array<{

--- a/packages/monitor/tsconfig.json
+++ b/packages/monitor/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -261,6 +261,9 @@ importers:
       '@earendil-works/pi-coding-agent':
         specifier: latest
         version: 0.80.3(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-tui':
+        specifier: 0.79.5
+        version: 0.79.5
       '@types/node':
         specifier: ^20.10.0
         version: 20.19.39

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -253,6 +253,21 @@ importers:
         specifier: ^5.3.0
         version: 5.9.3
 
+  packages/monitor:
+    devDependencies:
+      '@earendil-works/pi-ai':
+        specifier: latest
+        version: 0.80.3(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-coding-agent':
+        specifier: latest
+        version: 0.80.3(ws@8.20.0)(zod@4.4.3)
+      '@types/node':
+        specifier: ^20.10.0
+        version: 20.19.39
+      typescript:
+        specifier: ^5.3.0
+        version: 5.9.3
+
   packages/open-editor:
     devDependencies:
       '@earendil-works/pi-ai':


### PR DESCRIPTION
## Resumo

Adiciona a extensão `@arvoretech/pi-monitor`, que replica (e melhora) o **Monitor tool** do Claude Code no pi.

Lança um processo em background e **empurra** cada linha de output relevante direto pro agente via `pi.sendUserMessage(..., { deliverAs: "steer" })` — entregando no meio da conversa e acordando o agente se estiver idle. Zero polling.

```
monitor_start → spawn(command, shell) → readline(stdout/stderr)
                        │
              linha casa filtro include/exclude
                        │
        pi.sendUserMessage(linha, { deliverAs }) → agente reage na hora
```

## Tools

- `monitor_start` — `id`, `command`, `cwd?`, `include?`/`exclude?` (regex), `captureStderr?` (default true), `reportExit?` (default true), `deliverAs?` (`steer`/`followUp`), `maxEventsPerWindow?` (default 40/60s)
- `monitor_stop` — por `id` ou `all: true`
- `monitor_list` + comando `/monitors`

## Melhorias sobre o Monitor do Claude

- **stderr + exit code** — o Claude só captura stdout, então falha silenciosa parecia saudável. Aqui reporta `exit code N`.
- **Filtro in-process** (`include`/`exclude` regex) para não inundar o contexto.
- **Flood-guard** — auto-mata o monitor se passar de `maxEventsPerWindow` eventos/janela e instrui o agente a reiniciar com filtro mais estrito.
- **Session-scoped** — mata todos os processos no `session_shutdown`.

## Como testei

- `lsp_diagnostics` limpo em `index.ts` e `monitor.ts`
- `pnpm --filter @arvoretech/pi-monitor build` gera `dist/` ok
- Smoke test real com `spawn`:
  - Filtro `include` funcionou (2 de 4 linhas passaram; stderr não-casante filtrado)
  - `exit code 3` reportado corretamente
  - Cleanup no exit (0 monitores rodando após término)
  - Flood-guard parou exatamente em 10 eventos e limpou o processo

## Notas

- `sendUserMessage` já dispara turno automaticamente quando idle, por isso não uso `triggerTurn` (que só existe em `sendMessage`).
- Segue as convenções do repo: sem build step commitado (`dist/` gitignored, publicado via CI), `package.json`/`tsconfig.json` espelhando `pi-ci-watch`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new monitor extension that watches long-running commands and sends matching output as notifications.
  * Added tools to start, stop, and list active monitors, plus automatic cleanup when a session ends.
  * Added documentation for setup, usage, and behavior details, including filtering, stderr capture, and event limits.

* **Bug Fixes**
  * Improved handling for high-volume output by adding flood protection and safer shutdown behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->