### PR TITLE
feat(slack-bridge): botões interativos, resultado de tool inline, sem emoji

### DIFF
--- a/packages/slack-bridge/README.md
+++ b/packages/slack-bridge/README.md
@@ -30,16 +30,17 @@ O que vier primeiro define a thread. A partir daí o vínculo é fixo: só mensa
 
 ### Status nativo (animação)
 
-Durante um turno a extensão usa o status nativo de Assistant do Slack (`assistant.threads.setStatus`) — a animação "is typing…" com o passo atual (ex: `:wrench: bash: pnpm test`). Ao postar a resposta final, o status é limpo. Requer um app com scope `assistant:write`.
+Durante um turno a extensão usa o status nativo de Assistant do Slack (`assistant.threads.setStatus`) — a animação "is typing…" com o passo atual (ex: `bash: pnpm test`). Ao postar a resposta final, o status é limpo. Requer um app com scope `assistant:write`.
 
 ### Markdown
 
-Toda mensagem do agente e do terminal passa por [`slackify-markdown`](https://www.npmjs.com/package/slackify-markdown) antes de ser postada, convertendo Markdown/GFM (headings, `**negrito**`, listas, links `[texto](url)`, blocos de código) para o mrkdwn do Slack (`*negrito*`, `<url|texto>`, `•`). Prefixos decorativos da própria bridge (ex: `:bust_in_silhouette: *terminal*`) já são mrkdwn e não são convertidos.
+Toda mensagem do agente e do terminal passa por [`slackify-markdown`](https://www.npmjs.com/package/slackify-markdown) antes de ser postada, convertendo Markdown/GFM (headings, `**negrito**`, listas, links `[texto](url)`, blocos de código) para o mrkdwn do Slack (`*negrito*`, `<url|texto>`, `•`). As mensagens não usam emoji decorativo.
 
 ### Tool calls e perguntas
 
-- Cada chamada de tool vira uma linha na thread com emoji + nome + um resumo do argumento principal, além de atualizar o status nativo.
-- Quando o agente chama uma tool de pergunta (`ask_user_question` ou `questionnaire`), a bridge posta o enunciado com as opções numeradas e fica aguardando. Você responde pela thread com o número (`1`) ou texto livre; para uma única pergunta o número é resolvido para o rótulo da opção antes de voltar ao agente. Perguntas com múltiplos itens mandam o texto cru (ex: `1.2`) para o agente interpretar.
+- Cada chamada de tool vira uma linha na thread com o nome da tool e um resumo do argumento principal (ex: `` `bash` pnpm test ``). Quando a tool termina, essa mesma mensagem é editada com o resultado (`> ok: …` ou `> erro: …`), então você acompanha início e fim de cada passo sem poluir a thread.
+- Quando o agente chama uma tool de pergunta (`ask_user_question` ou `questionnaire`), a bridge posta o enunciado com as opções como **botões** (Block Kit). Ao clicar, a mensagem é atualizada mostrando `Respondido: *opção*` e a escolha volta pro agente automaticamente. Também é possível responder por texto na thread (útil para múltipla escolha ou resposta livre). Perguntas com vários itens só voltam pro agente quando todas forem respondidas.
+- Os botões exigem **Interactivity** habilitado no app do Slack (o manifest já inclui). Como a bridge roda em Socket Mode, não é preciso configurar Request URL.
 
 ## Setup
 

--- a/packages/slack-bridge/package.json
+++ b/packages/slack-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-slack-bridge",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "PI extension that bridges the active Pi session to a Slack thread: mirrors messages both ways, one Slack thread per Pi session",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/slack-bridge/slack-app-manifest.yaml
+++ b/packages/slack-bridge/slack-app-manifest.yaml
@@ -34,7 +34,7 @@ settings:
       - message.channels
       - message.groups
   interactivity:
-    is_enabled: false
+    is_enabled: true
   socket_mode_enabled: true
   org_deploy_enabled: false
   token_rotation_enabled: false

--- a/packages/slack-bridge/src/bridge.ts
+++ b/packages/slack-bridge/src/bridge.ts
@@ -1,11 +1,18 @@
 import type { ExtensionAPI, ExtensionContext, CustomEntry } from "@earendil-works/pi-coding-agent";
 import type { SlackBridgeConfig } from "./config.js";
-import { SlackGateway, type InboundHandler, type InboundMessage } from "./slack.js";
 import {
+  SlackGateway,
+  type InboundHandler,
+  type InboundMessage,
+  type ActionHandler,
+  type BlockAction,
+} from "./slack.js";
+import {
+  buildQuestionBlocks,
+  consolidateAnswers,
   isQuestionTool,
+  parseActionId,
   parseQuestions,
-  renderQuestions,
-  resolveAnswer,
   toSlackMarkdown,
   type NormalizedQuestion,
 } from "./format.js";
@@ -15,6 +22,9 @@ export interface SlackTransport {
   stop(): Promise<void>;
   postRoot(text: string): Promise<string | undefined>;
   postToThread(threadTs: string, text: string): Promise<string | undefined>;
+  postBlocks(threadTs: string, text: string, blocks: unknown[]): Promise<string | undefined>;
+  updateBlocks(ts: string, text: string, blocks: unknown[]): Promise<void>;
+  updateText(ts: string, text: string): Promise<void>;
   setStatus(threadTs: string, status: string): Promise<void>;
   clearStatus(threadTs: string): Promise<void>;
   resolveBotUserId(): Promise<string | undefined>;
@@ -23,10 +33,11 @@ export interface SlackTransport {
 export type TransportFactory = (
   config: SlackBridgeConfig,
   onInbound: InboundHandler,
+  onAction: ActionHandler,
 ) => SlackTransport;
 
-const defaultTransportFactory: TransportFactory = (config, onInbound) =>
-  new SlackGateway(config, onInbound);
+const defaultTransportFactory: TransportFactory = (config, onInbound, onAction) =>
+  new SlackGateway(config, onInbound, onAction);
 
 const ENTRY_TYPE = "slack-bridge-thread";
 
@@ -58,26 +69,38 @@ function truncate(value: string, max: number): string {
 
 const TOOL_HINT_FIELDS = ["command", "path", "pattern", "query", "url", "content", "prompt", "objective"] as const;
 
-const TOOL_EMOJI: Record<string, string> = {
-  bash: ":computer:",
-  read: ":page_facing_up:",
-  edit: ":pencil2:",
-  write: ":memo:",
-  ffgrep: ":mag:",
-  fffind: ":mag_right:",
-  search_codebase: ":mag:",
-};
-
 function summarizeTool(toolName: string, args: unknown): string {
-  const emoji = TOOL_EMOJI[toolName] ?? ":wrench:";
   const a = (args ?? {}) as Record<string, unknown>;
   for (const field of TOOL_HINT_FIELDS) {
     const value = a[field];
     if (typeof value === "string" && value) {
-      return `${emoji} \`${toolName}\` ${truncate(value, 100)}`;
+      return `\`${toolName}\` ${truncate(value, 120)}`;
     }
   }
-  return `${emoji} \`${toolName}\``;
+  return `\`${toolName}\``;
+}
+
+function summarizeResult(result: unknown): string {
+  if (result == null) return "";
+  if (typeof result === "string") return truncate(result, 160);
+  const r = result as Record<string, unknown>;
+  const candidate = r.output ?? r.content ?? r.text ?? r.message ?? r.stdout;
+  if (typeof candidate === "string") return truncate(candidate, 160);
+  if (Array.isArray(candidate)) {
+    const joined = candidate
+      .map((block) => {
+        if (typeof block === "string") return block;
+        const b = block as { text?: unknown };
+        return typeof b?.text === "string" ? b.text : "";
+      })
+      .join(" ");
+    if (joined.trim()) return truncate(joined, 160);
+  }
+  try {
+    return truncate(JSON.stringify(result), 160);
+  } catch {
+    return "";
+  }
 }
 
 export class SlackBridge {
@@ -92,6 +115,9 @@ export class SlackBridge {
   private statusPromise: Promise<void> = Promise.resolve();
   private turnActive = false;
   private pendingQuestions: NormalizedQuestion[] | undefined;
+  private questionAnswers = new Map<number, string>();
+  private questionMessageTs: string | undefined;
+  private readonly toolMessages = new Map<string, { ts: string; summary: string }>();
 
   constructor(
     pi: ExtensionAPI,
@@ -118,7 +144,11 @@ export class SlackBridge {
   }
 
   async start(): Promise<void> {
-    this.gateway = this.transportFactory(this.config, (message) => this.handleInbound(message));
+    this.gateway = this.transportFactory(
+      this.config,
+      (message) => this.handleInbound(message),
+      (action) => this.handleAction(action),
+    );
     this.botUserId = await this.gateway.resolveBotUserId();
     await this.gateway.start();
   }
@@ -133,8 +163,8 @@ export class SlackBridge {
     if (!this.gateway) return undefined;
     if (!this.rootPromise) {
       const header = seedText
-        ? `:robot_face: Pi session\n> ${seedText.slice(0, 200)}`
-        : ":robot_face: Pi session";
+        ? `*Pi session*\n> ${seedText.slice(0, 200)}`
+        : "*Pi session*";
       this.rootPromise = this.gateway.postRoot(header).then((ts) => {
         if (ts) this.adoptThread(ts);
       });
@@ -153,17 +183,17 @@ export class SlackBridge {
     const existed = this.threadTs !== undefined;
     const thread = await this.ensureThread(trimmed);
     if (!thread || !this.gateway || !existed) return;
-    await this.gateway.postToThread(thread, `:bust_in_silhouette: *terminal*\n${toSlackMarkdown(trimmed)}`);
+    await this.gateway.postToThread(thread, `*terminal*\n${toSlackMarkdown(trimmed)}`);
   }
 
   async beginTurn(): Promise<void> {
     const thread = await this.ensureThread();
     if (!thread) return;
     this.turnActive = true;
-    this.pushStatus(":hourglass_flowing_sand: pensando\u2026");
+    this.pushStatus("pensando\u2026");
   }
 
-  async recordTool(toolName: string, args: unknown): Promise<void> {
+  async recordTool(toolCallId: string, toolName: string, args: unknown): Promise<void> {
     if (!this.threadTs || !this.gateway) return;
     if (isQuestionTool(toolName)) {
       await this.postQuestions(args);
@@ -173,22 +203,89 @@ export class SlackBridge {
     this.pushStatus(summary);
     const thread = this.threadTs;
     const gateway = this.gateway;
-    this.enqueueStatus(() => gateway.postToThread(thread, summary).then(() => {}));
+    this.enqueueStatus(async () => {
+      const ts = await gateway.postToThread(thread, summary);
+      if (ts) this.toolMessages.set(toolCallId, { ts, summary });
+    });
+  }
+
+  async recordToolResult(toolCallId: string, result: unknown, isError: boolean): Promise<void> {
+    const entry = this.toolMessages.get(toolCallId);
+    if (!entry || !this.gateway) return;
+    this.toolMessages.delete(toolCallId);
+    const gateway = this.gateway;
+    const preview = summarizeResult(result);
+    const status = isError ? "erro" : "ok";
+    const body = preview
+      ? `${entry.summary}\n> ${status}: ${preview}`
+      : `${entry.summary}\n> ${status}`;
+    this.enqueueStatus(() => gateway.updateText(entry.ts, body));
   }
 
   private async postQuestions(args: unknown): Promise<void> {
     const questions = parseQuestions(args);
     if (questions.length === 0) return;
     this.pendingQuestions = questions;
+    this.questionAnswers = new Map();
+    this.questionMessageTs = undefined;
     const thread = this.threadTs;
     const gateway = this.gateway;
     if (!thread || !gateway) return;
-    const body = renderQuestions(questions);
+    const { text, blocks } = buildQuestionBlocks(questions, this.questionAnswers);
     this.enqueueStatus(async () => {
-      await gateway.postToThread(thread, body);
-      await gateway.setStatus(thread, ":question: aguardando sua resposta\u2026");
+      const ts = await gateway.postBlocks(thread, text, blocks);
+      this.questionMessageTs = ts;
+      await gateway.setStatus(thread, "aguardando sua resposta\u2026");
     });
     await this.statusPromise;
+  }
+
+  private async handleAction(action: BlockAction): Promise<void> {
+    if (action.channel !== this.config.channel) return;
+    if (!this.pendingQuestions || !this.gateway) return;
+    if (this.questionMessageTs && action.messageTs !== this.questionMessageTs) return;
+    const parsed = parseActionId(action.actionId);
+    if (!parsed) return;
+    const question = this.pendingQuestions[parsed.questionIndex];
+    const option = question?.options[parsed.optionIndex];
+    if (!option) return;
+
+    this.questionAnswers.set(parsed.questionIndex, option.label);
+    const questions = this.pendingQuestions;
+    const answers = this.questionAnswers;
+    const gateway = this.gateway;
+    const messageTs = this.questionMessageTs;
+    if (messageTs) {
+      const { text, blocks } = buildQuestionBlocks(questions, answers);
+      this.enqueueStatus(() => gateway.updateBlocks(messageTs, text, blocks));
+    }
+
+    const allAnswered = questions.every((_, i) => answers.has(i));
+    if (!allAnswered) return;
+
+    const outgoing = consolidateAnswers(questions, answers);
+    this.finalizeQuestions();
+    this.dispatch(outgoing);
+  }
+
+  private finalizeQuestions(): void {
+    this.pendingQuestions = undefined;
+    this.questionMessageTs = undefined;
+    this.questionAnswers = new Map();
+    const thread = this.threadTs;
+    if (thread && this.gateway) {
+      const gateway = this.gateway;
+      this.enqueueStatus(() => gateway.clearStatus(thread));
+    }
+  }
+
+  private dispatch(text: string): void {
+    const ctx = this.getContext?.();
+    if (!ctx || ctx.isIdle()) {
+      this.pi.sendUserMessage(text);
+    } else {
+      this.pi.sendUserMessage(text, { deliverAs: "steer" });
+    }
   }
 
   async finishTurn(message: unknown): Promise<void> {
@@ -197,7 +294,7 @@ export class SlackBridge {
     const thread = await this.ensureThread(text);
     if (!thread || !this.gateway) return;
     const gateway = this.gateway;
-    const body = text ? toSlackMarkdown(text) : ":white_check_mark: conclu\u00eddo";
+    const body = text ? toSlackMarkdown(text) : "conclu\u00eddo";
     this.enqueueStatus(async () => {
       await gateway.postToThread(thread, body);
       if (!this.pendingQuestions) await gateway.clearStatus(thread);
@@ -232,23 +329,9 @@ export class SlackBridge {
       this.adoptThread(message.threadTs ?? message.ts);
     }
 
-    let outgoing = text;
-    if (this.pendingQuestions) {
-      outgoing = resolveAnswer(this.pendingQuestions, text);
-      this.pendingQuestions = undefined;
-      const thread = this.threadTs;
-      if (thread && this.gateway) {
-        const gateway = this.gateway;
-        this.enqueueStatus(() => gateway.clearStatus(thread));
-      }
-    }
+    if (this.pendingQuestions) this.finalizeQuestions();
 
-    const ctx = this.getContext?.();
-    if (!ctx || ctx.isIdle()) {
-      this.pi.sendUserMessage(outgoing);
-    } else {
-      this.pi.sendUserMessage(outgoing, { deliverAs: "steer" });
-    }
+    this.dispatch(text);
   }
 
   private adoptThread(ts: string): void {

--- a/packages/slack-bridge/src/format.ts
+++ b/packages/slack-bridge/src/format.ts
@@ -10,6 +10,11 @@ export function toSlackMarkdown(text: string): string {
   }
 }
 
+function truncate(value: string, max: number): string {
+  const clean = value.replace(/\s+/g, " ").trim();
+  return clean.length > max ? `${clean.slice(0, max - 1)}\u2026` : clean;
+}
+
 const QUESTION_TOOLS = new Set(["ask_user_question", "questionnaire"]);
 
 export function isQuestionTool(toolName: string): boolean {
@@ -61,42 +66,83 @@ export function parseQuestions(args: unknown): NormalizedQuestion[] {
   return questions;
 }
 
-export function renderQuestions(questions: NormalizedQuestion[]): string {
-  const parts: string[] = [":question: *Preciso da sua resposta:*"];
-  const single = questions.length === 1;
-  questions.forEach((q, qi) => {
-    const heading = single ? `*${q.prompt}*` : `*${qi + 1}. ${q.prompt}*`;
-    parts.push("");
-    parts.push(heading);
-    q.options.forEach((opt, oi) => {
-      const num = single ? `${oi + 1}` : `${qi + 1}.${oi + 1}`;
-      const desc = opt.description ? ` — ${opt.description}` : "";
-      parts.push(`  \`${num}\` ${opt.label}${desc}`);
-    });
-    if (q.multiSelect) parts.push("  _(pode escolher mais de uma, separe por vírgula)_");
-  });
-  parts.push("");
-  parts.push(
-    single
-      ? "_Responda com o número da opção ou escreva sua resposta._"
-      : "_Responda com os números (ex: `1.2`) ou escreva sua resposta._",
-  );
-  return parts.join("\n");
+export const QUESTION_ACTION_PREFIX = "sbq";
+
+export function buildActionId(questionIndex: number, optionIndex: number): string {
+  return `${QUESTION_ACTION_PREFIX}_${questionIndex}_${optionIndex}`;
 }
 
-export function resolveAnswer(questions: NormalizedQuestion[], reply: string): string {
-  const text = reply.trim();
-  if (questions.length !== 1) return text;
-  const options = questions[0].options;
-  const parts = text.split(",").map((p) => p.trim()).filter(Boolean);
-  const labels: string[] = [];
-  for (const part of parts) {
-    const idx = Number.parseInt(part, 10);
-    if (Number.isInteger(idx) && idx >= 1 && idx <= options.length && String(idx) === part) {
-      labels.push(options[idx - 1].label);
-    } else {
-      return text;
+export function parseActionId(actionId: string): { questionIndex: number; optionIndex: number } | undefined {
+  const match = /^sbq_(\d+)_(\d+)$/.exec(actionId);
+  if (!match) return undefined;
+  return { questionIndex: Number(match[1]), optionIndex: Number(match[2]) };
+}
+
+function chunk<T>(items: T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size) out.push(items.slice(i, i + size));
+  return out;
+}
+
+export interface QuestionRender {
+  text: string;
+  blocks: unknown[];
+}
+
+export function buildQuestionBlocks(
+  questions: NormalizedQuestion[],
+  answers: Map<number, string>,
+): QuestionRender {
+  const blocks: unknown[] = [];
+  const single = questions.length === 1;
+
+  questions.forEach((q, qi) => {
+    const heading = single ? q.prompt : `${qi + 1}. ${q.prompt}`;
+    blocks.push({ type: "section", text: { type: "mrkdwn", text: `*${heading}*` } });
+
+    const descriptions = q.options
+      .filter((opt) => opt.description)
+      .map((opt) => `- *${opt.label}* — ${opt.description}`);
+    if (descriptions.length > 0) {
+      blocks.push({ type: "section", text: { type: "mrkdwn", text: descriptions.join("\n") } });
     }
-  }
-  return labels.length > 0 ? labels.join(", ") : text;
+
+    const answered = answers.get(qi);
+    if (answered !== undefined) {
+      blocks.push({
+        type: "context",
+        elements: [{ type: "mrkdwn", text: `Respondido: *${answered}*` }],
+      });
+      return;
+    }
+
+    const buttons = q.options.map((opt, oi) => ({
+      type: "button",
+      text: { type: "plain_text", text: truncate(opt.label, 75), emoji: false },
+      action_id: buildActionId(qi, oi),
+      value: `${qi}:${oi}`,
+    }));
+    for (const group of chunk(buttons, 5)) {
+      blocks.push({ type: "actions", elements: group });
+    }
+    if (q.multiSelect) {
+      blocks.push({
+        type: "context",
+        elements: [{ type: "mrkdwn", text: "Pode escolher mais de uma respondendo por texto." }],
+      });
+    }
+  });
+
+  blocks.push({
+    type: "context",
+    elements: [{ type: "mrkdwn", text: "Clique numa opção ou responda por texto." }],
+  });
+
+  const text = questions.map((q) => q.prompt).join(" / ");
+  return { text, blocks };
+}
+
+export function consolidateAnswers(questions: NormalizedQuestion[], answers: Map<number, string>): string {
+  if (questions.length === 1) return answers.get(0) ?? "";
+  return questions.map((_, i) => `${i + 1}. ${answers.get(i) ?? ""}`).join("\n");
 }

--- a/packages/slack-bridge/src/index.ts
+++ b/packages/slack-bridge/src/index.ts
@@ -64,7 +64,13 @@ export default function (pi: ExtensionAPI): void {
   pi.on("tool_execution_start", async (event, ctx) => {
     captureContext(ctx);
     if (!bridge) return;
-    await bridge.recordTool(event.toolName, event.args).catch(() => {});
+    await bridge.recordTool(event.toolCallId, event.toolName, event.args).catch(() => {});
+  });
+
+  pi.on("tool_execution_end", async (event, ctx) => {
+    captureContext(ctx);
+    if (!bridge) return;
+    await bridge.recordToolResult(event.toolCallId, event.result, event.isError).catch(() => {});
   });
 
   pi.on("turn_end", async (event, ctx) => {

--- a/packages/slack-bridge/src/slack.ts
+++ b/packages/slack-bridge/src/slack.ts
@@ -11,7 +11,17 @@ export interface InboundMessage {
   botId?: string;
 }
 
+export interface BlockAction {
+  actionId: string;
+  value: string;
+  userId: string;
+  channel: string;
+  messageTs: string;
+  threadTs?: string;
+}
+
 export type InboundHandler = (message: InboundMessage) => void | Promise<void>;
+export type ActionHandler = (action: BlockAction) => void | Promise<void>;
 
 export class SlackGateway {
   private readonly web: WebClient;
@@ -19,7 +29,7 @@ export class SlackGateway {
   private readonly config: SlackBridgeConfig;
   private started = false;
 
-  constructor(config: SlackBridgeConfig, onInbound: InboundHandler) {
+  constructor(config: SlackBridgeConfig, onInbound: InboundHandler, onAction?: ActionHandler) {
     this.config = config;
     this.web = new WebClient(config.botToken);
     this.socket = new SocketModeClient({ appToken: config.appToken });
@@ -40,6 +50,26 @@ export class SlackGateway {
         threadTs: typeof event.thread_ts === "string" ? event.thread_ts : undefined,
         botId: typeof event.bot_id === "string" ? event.bot_id : undefined,
       });
+    });
+
+    this.socket.on("interactive", async ({ body, ack }: { body: Record<string, unknown>; ack: () => Promise<void> }) => {
+      await ack();
+      if (!onAction) return;
+      if (body?.type !== "block_actions") return;
+      const actions = Array.isArray(body.actions) ? body.actions : [];
+      const first = actions[0] as Record<string, unknown> | undefined;
+      if (!first) return;
+      const user = body.user as Record<string, unknown> | undefined;
+      const channelObj = body.channel as Record<string, unknown> | undefined;
+      const messageObj = body.message as Record<string, unknown> | undefined;
+      const actionId = typeof first.action_id === "string" ? first.action_id : "";
+      const value = typeof first.value === "string" ? first.value : "";
+      const userId = typeof user?.id === "string" ? user.id : "";
+      const channel = typeof channelObj?.id === "string" ? channelObj.id : "";
+      const messageTs = typeof messageObj?.ts === "string" ? messageObj.ts : "";
+      const threadTs = typeof messageObj?.thread_ts === "string" ? messageObj.thread_ts : undefined;
+      if (!actionId || !channel || !messageTs) return;
+      await onAction({ actionId, value, userId, channel, messageTs, threadTs });
     });
   }
 
@@ -70,6 +100,29 @@ export class SlackGateway {
       mrkdwn: true,
     });
     return typeof res.ts === "string" ? res.ts : undefined;
+  }
+
+  async postBlocks(threadTs: string, text: string, blocks: unknown[]): Promise<string | undefined> {
+    const res = await this.web.chat.postMessage({
+      channel: this.config.channel,
+      thread_ts: threadTs,
+      text,
+      blocks: blocks as never,
+    });
+    return typeof res.ts === "string" ? res.ts : undefined;
+  }
+
+  async updateBlocks(ts: string, text: string, blocks: unknown[]): Promise<void> {
+    await this.web.chat.update({
+      channel: this.config.channel,
+      ts,
+      text,
+      blocks: blocks as never,
+    });
+  }
+
+  async updateText(ts: string, text: string): Promise<void> {
+    await this.web.chat.update({ channel: this.config.channel, ts, text });
   }
 
   async setStatus(threadTs: string, status: string): Promise<void> {


### PR DESCRIPTION
## Contexto

Feedback do teste real da bridge (#127) apontou três problemas visíveis no Slack:
1. Mensagens cheias de emoji decorativo.
2. Chamadas de tool apareciam, mas o **resultado** da tool nunca aparecia.
3. A tool de pergunta saía como texto numerado — sem botões e sem marcar como respondido.

## Mudanças

- **Botões de verdade (Block Kit)**: `ask_user_question`/`questionnaire` agora renderizam as opções como botões. Ao clicar, a mensagem é editada para `Respondido: *opção*` e a escolha volta pro agente automaticamente. Resposta por texto na thread continua funcionando (múltipla escolha / resposta livre). Perguntas com vários itens só voltam pro agente quando todas forem respondidas.
- **Interactivity via Socket Mode**: cliques chegam pelo envelope `interactive` (`block_actions`) do `@slack/socket-mode`. `interactivity.is_enabled` habilitado no `slack-app-manifest.yaml`.
- **Resultado da tool inline**: em `tool_execution_end`, a mesma mensagem da tool é editada com o resultado (`> ok: …` ou `> erro: …`), acompanhando início e fim de cada passo sem poluir a thread. Usa `chat.update` + `toolCallId` pra casar chamada e resultado.
- **Zero emoji**: removido todo emoji decorativo das mensagens e do status nativo.
- Bump `1.1.0` → `1.2.0`.

## Como testei

- `lsp_diagnostics` limpo em `bridge.ts`, `format.ts`, `slack.ts`, `index.ts`
- `pnpm build` (tsc) ok
- Teste funcional do `format.js`: conversão markdown sem emoji, `buildQuestionBlocks` (estado inicial com botões e estado "Respondido" via context block), `parseActionId`/`buildActionId` roundtrip, `consolidateAnswers`
- Confirmado na doc/fonte do `@slack/socket-mode` que o envelope de `block_actions` é emitido como evento `interactive`

## Ação manual necessária no app do Slack

Mudar o manifest no repo **não** altera o app já instalado. Para os botões funcionarem é preciso, no app real: **Interactivity & Shortcuts → Interactivity → On** (com Socket Mode não precisa de Request URL) e reinstalar se o Slack pedir. Sem isso, os `block_actions` não chegam e só a resposta por texto funciona.
