### PR TITLE
feat(git-review): PR merge + admin override, /review <pr> deep link, prs-tracker integration

### DIFF
--- a/packages/git-review/README.md
+++ b/packages/git-review/README.md
@@ -15,6 +15,8 @@ a user message. The agent's answers appear in your terminal (PI TUI).
               │  GET /api/pr-comments→ PR review + conversation comments (REST + GraphQL)
               │  POST /api/pr-comment→ new inline review comment
               │  POST /api/pr-reply  → reply to a review thread
+              │  GET /api/pr-merge-status → mergeability + your repo permission (`gh pr view`/`gh repo view`)
+              │  POST /api/pr-merge  → merge the PR (`gh pr merge`, optional `--admin`)
               │  WS /ws              → you send { file, lines, code, question },
               │                        a pr_context primer, or comment_thread/comment_batch
               ▼
@@ -34,6 +36,8 @@ a user message. The agent's answers appear in your terminal (PI TUI).
 /review branch          # current branch vs `main`
 /review branch develop  # current branch vs `develop`
 /review prs             # list open PRs across all repos and review them
+/review 1234            # open PR #1234 directly in the reviewer
+/review #1234           # same, leading # is accepted
 ```
 
 The scope and base can also be changed live from the toolbar in the browser tab. The
@@ -78,6 +82,22 @@ any successful post or reply.
 > Posting comments and replies requires the `gh` CLI to be authenticated with write access
 > to the repo.
 
+#### Merging a PR
+
+The PR banner has a **Merge…** button that opens a dialog. It first calls
+`/api/pr-merge-status` (`gh pr view` for `mergeable`/`mergeStateStatus`/`isDraft` and
+`gh repo view` for your `viewerPermission`) and shows whether the PR is ready, blocked,
+conflicting, or a draft. You choose the method (merge commit / squash / rebase) and whether
+to delete the branch, then confirm — this runs `gh pr merge <n> --<method>` in the repo.
+
+When the PR is **not** cleanly mergeable **and** you have `ADMIN` permission on the repo,
+an **Override with admin privileges** checkbox appears, adding `--admin` to bypass branch
+protection. The option is hidden entirely when you lack admin rights, so it never offers a
+permission you don't have.
+
+> Merging requires the `gh` CLI authenticated with write (and, for the override, admin)
+> access to the repo.
+
 > Requires the [`gh` CLI](https://cli.github.com) installed and authenticated
 > (`gh auth status`).
 
@@ -90,6 +110,16 @@ In the tab:
 
 It scans the workspace for git repos (`.git` up to depth 4, pruning `node_modules`) and aggregates their diffs,
 prefixing paths per repo — so it works in a multi-repo workspace too.
+
+## Discovery (prs-tracker integration)
+
+While the reviewer server is running, git-review writes its `{ baseUrl, token, port }` to a
+per-process file in the OS temp dir (`pi-git-review-<pid>.json`) and removes it on session
+shutdown. This lets sibling extensions in the same Pi process — notably
+[`@arvoretech/pi-prs-tracker`](../prs-tracker) — build deep links straight into a PR
+(`…?token=…&mode=prs&pr=<number>`). The file carries the same session token used in the URL,
+so treat it as local-only (it lives under your user's temp dir, same trust model as the
+browser URL).
 
 ## Security
 

--- a/packages/git-review/package.json
+++ b/packages/git-review/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-git-review",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "PI extension that opens a browser-based git diff reviewer; selected code + comments are sent to the agent in real time",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/git-review/src/index.ts
+++ b/packages/git-review/src/index.ts
@@ -1,4 +1,7 @@
 import { platform } from "node:os";
+import { tmpdir } from "node:os";
+import { writeFileSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { WebSocket } from "ws";
 import {
@@ -16,6 +19,30 @@ import {
 const PORT_RANGE_START = 9890;
 const PORT_RANGE_END = 9899;
 
+const DISCOVERY_FILE = join(tmpdir(), `pi-git-review-${process.pid}.json`);
+
+function publishServerInfo(srv: { url: string; token: string; port: number }): void {
+  try {
+    writeFileSync(
+      DISCOVERY_FILE,
+      JSON.stringify({
+        pid: process.pid,
+        port: srv.port,
+        token: srv.token,
+        baseUrl: `http://127.0.0.1:${srv.port}`,
+        url: srv.url,
+        ts: Date.now(),
+      }),
+    );
+  } catch {}
+}
+
+function unpublishServerInfo(): void {
+  try {
+    unlinkSync(DISCOVERY_FILE);
+  } catch {}
+}
+
 function openBrowser(pi: ExtensionAPI, url: string): void {
   const opener =
     platform() === "darwin" ? "open" : platform() === "win32" ? "cmd" : "xdg-open";
@@ -24,12 +51,13 @@ function openBrowser(pi: ExtensionAPI, url: string): void {
 }
 
 const VALID_SCOPES = ["working", "staged", "branch"] as const;
-const USAGE = "Usage: /review [working|staged|branch [base] | prs]";
+const USAGE = "Usage: /review [<pr-number> | working|staged|branch [base] | prs]";
 
 function parseScopeArgs(args: string): {
   mode: "diff" | "prs";
   scope: DiffScope;
   base: string;
+  prNumber?: number;
   error?: string;
 } {
   const parts = args.trim().split(/\s+/).filter(Boolean);
@@ -37,6 +65,9 @@ function parseScopeArgs(args: string): {
   const first = parts[0].toLowerCase();
   if (first === "prs" || first === "pr") {
     return { mode: "prs", scope: "working", base: "main" };
+  }
+  if (/^#?\d+$/.test(first)) {
+    return { mode: "prs", scope: "working", base: "main", prNumber: Number(first.replace(/^#/, "")) };
   }
   const scopeArg = first as DiffScope;
   if (!(VALID_SCOPES as readonly string[]).includes(scopeArg)) {
@@ -202,6 +233,7 @@ export default function (pi: ExtensionAPI) {
     for (let port = PORT_RANGE_START; port <= PORT_RANGE_END; port++) {
       try {
         server = await startGitReviewServer(port, pi, clients, handleMessage);
+        publishServerInfo(server);
         return server;
       } catch {}
     }
@@ -211,7 +243,7 @@ export default function (pi: ExtensionAPI) {
 
   pi.registerCommand("review", {
     description:
-      "Open a browser-based git diff & PR reviewer. Usage: /review [working|staged|branch [base] | prs]",
+      "Open a browser-based git diff & PR reviewer. Usage: /review [<pr-number> | working|staged|branch [base] | prs]",
     handler: async (args, ctx) => {
       isIdle = () => ctx.isIdle();
       if (!ctx.hasUI) {
@@ -219,7 +251,7 @@ export default function (pi: ExtensionAPI) {
         return;
       }
 
-      const { mode, scope, base, error } = parseScopeArgs(args);
+      const { mode, scope, base, prNumber, error } = parseScopeArgs(args);
       if (error) {
         ctx.ui.notify(error, "error");
         return;
@@ -229,7 +261,7 @@ export default function (pi: ExtensionAPI) {
       if (!srv) return;
       const url =
         mode === "prs"
-          ? `${srv.url}&mode=prs`
+          ? `${srv.url}&mode=prs${prNumber ? `&pr=${prNumber}` : ""}`
           : `${srv.url}&scope=${scope}&base=${encodeURIComponent(base)}`;
       openBrowser(pi, url);
       ctx.ui.notify(
@@ -244,6 +276,7 @@ export default function (pi: ExtensionAPI) {
   });
 
   pi.on("session_shutdown", async () => {
+    unpublishServerInfo();
     server?.close();
     server = null;
   });

--- a/packages/git-review/src/index.ts
+++ b/packages/git-review/src/index.ts
@@ -33,6 +33,7 @@ function publishServerInfo(srv: { url: string; token: string; port: number }): v
         url: srv.url,
         ts: Date.now(),
       }),
+      { mode: 0o600 },
     );
   } catch {}
 }

--- a/packages/git-review/src/server.ts
+++ b/packages/git-review/src/server.ts
@@ -744,6 +744,82 @@ async function replyToComment(
   return { htmlUrl: parsed.html_url || "" };
 }
 
+export type MergeMethod = "merge" | "squash" | "rebase";
+
+export interface MergeStatus {
+  state: string;
+  mergeable: string;
+  mergeStateStatus: string;
+  isDraft: boolean;
+  viewerPermission: string;
+  canAdmin: boolean;
+}
+
+async function collectMergeStatus(
+  pi: ExtensionAPI,
+  repo: string,
+  prNumber: number,
+): Promise<MergeStatus | null> {
+  const repos = await findRepoDirs(pi);
+  const dir = repoDirForLabel(repos, repo);
+  if (!dir) return null;
+
+  const { stdout } = await pi.exec(
+    "gh",
+    ["pr", "view", String(prNumber), "--json", "state,mergeable,mergeStateStatus,isDraft"],
+    { cwd: dir },
+  );
+  const view = JSON.parse(stdout) as {
+    state?: string;
+    mergeable?: string;
+    mergeStateStatus?: string;
+    isDraft?: boolean;
+  };
+
+  let viewerPermission = "";
+  try {
+    const { stdout: permOut } = await pi.exec("gh", ["repo", "view", "--json", "viewerPermission"], {
+      cwd: dir,
+    });
+    viewerPermission = (JSON.parse(permOut) as { viewerPermission?: string }).viewerPermission || "";
+  } catch {}
+
+  return {
+    state: view.state || "UNKNOWN",
+    mergeable: view.mergeable || "UNKNOWN",
+    mergeStateStatus: view.mergeStateStatus || "UNKNOWN",
+    isDraft: Boolean(view.isDraft),
+    viewerPermission,
+    canAdmin: viewerPermission === "ADMIN",
+  };
+}
+
+async function mergePullRequest(
+  pi: ExtensionAPI,
+  repo: string,
+  prNumber: number,
+  opts: { method: MergeMethod; deleteBranch?: boolean; admin?: boolean },
+): Promise<{ ok: true }> {
+  const repos = await findRepoDirs(pi);
+  const dir = repoDirForLabel(repos, repo);
+  if (!dir) throw new Error("repo not found");
+
+  const args = ["pr", "merge", String(prNumber), `--${opts.method}`];
+  if (opts.deleteBranch) args.push("--delete-branch");
+  if (opts.admin) args.push("--admin");
+
+  try {
+    await pi.exec("gh", args, { cwd: dir });
+  } catch (err) {
+    const detail =
+      err && typeof err === "object"
+        ? String((err as { stderr?: string; message?: string }).stderr || (err as Error).message || err)
+        : String(err);
+    throw new Error(detail.trim() || "merge failed");
+  }
+  return { ok: true };
+}
+
 function sendJson(res: ServerResponse, status: number, body: unknown): void {
   const payload = JSON.stringify(body);
   res.writeHead(status, {
@@ -951,6 +1027,57 @@ export function startGitReviewServer(
           sendJson(res, 200, { ok: true, htmlUrl: result.htmlUrl });
         } catch (err) {
           sendJson(res, 500, { error: String(err) });
+        }
+        return;
+      }
+
+      if (url.pathname === "/api/pr-merge-status") {
+        if (url.searchParams.get("token") !== token) {
+          sendJson(res, 403, { error: "forbidden" });
+          return;
+        }
+        const repo = url.searchParams.get("repo") || ".";
+        const number = Number(url.searchParams.get("number"));
+        if (!Number.isInteger(number) || number <= 0) {
+          sendJson(res, 400, { error: "invalid pr number" });
+          return;
+        }
+        try {
+          const status = await collectMergeStatus(pi, repo, number);
+          if (!status) {
+            sendJson(res, 404, { error: "repo not found" });
+            return;
+          }
+          sendJson(res, 200, { status });
+        } catch (err) {
+          sendJson(res, 500, { error: String(err) });
+        }
+        return;
+      }
+
+      if (url.pathname === "/api/pr-merge" && req.method === "POST") {
+        if ((req.headers["x-token"] as string) !== token) {
+          sendJson(res, 403, { error: "forbidden" });
+          return;
+        }
+        try {
+          const body = await readJsonBody(req);
+          const repo = String(body.repo || ".");
+          const number = Number(body.number);
+          const method: MergeMethod =
+            body.method === "squash" || body.method === "rebase" ? body.method : "merge";
+          if (!Number.isInteger(number) || number <= 0) {
+            sendJson(res, 400, { error: "invalid pr number" });
+            return;
+          }
+          await mergePullRequest(pi, repo, number, {
+            method,
+            deleteBranch: Boolean(body.deleteBranch),
+            admin: Boolean(body.admin),
+          });
+          sendJson(res, 200, { ok: true });
+        } catch (err) {
+          sendJson(res, 500, { error: err instanceof Error ? err.message : String(err) });
         }
         return;
       }

--- a/packages/git-review/src/server.ts
+++ b/packages/git-review/src/server.ts
@@ -1064,16 +1064,32 @@ export function startGitReviewServer(
           const body = await readJsonBody(req);
           const repo = String(body.repo || ".");
           const number = Number(body.number);
-          const method: MergeMethod =
-            body.method === "squash" || body.method === "rebase" ? body.method : "merge";
+          if (body.method !== "merge" && body.method !== "squash" && body.method !== "rebase") {
+            sendJson(res, 400, { error: "invalid merge method" });
+            return;
+          }
+          const method: MergeMethod = body.method;
           if (!Number.isInteger(number) || number <= 0) {
             sendJson(res, 400, { error: "invalid pr number" });
             return;
           }
+          const admin = Boolean(body.admin);
+          if (admin) {
+            const status = await collectMergeStatus(pi, repo, number);
+            if (!status) {
+              sendJson(res, 404, { error: "repo not found" });
+              return;
+            }
+            const clean = status.mergeable === "MERGEABLE" && status.mergeStateStatus === "CLEAN";
+            if (!status.canAdmin || clean) {
+              sendJson(res, 403, { error: "admin override not allowed" });
+              return;
+            }
+          }
           await mergePullRequest(pi, repo, number, {
             method,
             deleteBranch: Boolean(body.deleteBranch),
-            admin: Boolean(body.admin),
+            admin,
           });
           sendJson(res, 200, { ok: true });
         } catch (err) {

--- a/packages/git-review/web/index.html
+++ b/packages/git-review/web/index.html
@@ -220,6 +220,75 @@
       .pr-banner a:hover {
         text-decoration: underline;
       }
+      .merge-overlay {
+        position: fixed;
+        inset: 0;
+        background: rgba(0, 0, 0, 0.55);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        z-index: 1000;
+      }
+      .merge-dialog {
+        background: var(--bg-elev);
+        border: 1px solid var(--border);
+        border-radius: var(--radius);
+        padding: 20px;
+        width: 380px;
+        max-width: calc(100vw - 32px);
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+      .merge-title {
+        font-size: 15px;
+        font-weight: 600;
+      }
+      .merge-sub {
+        font-size: 12px;
+        color: var(--fg-dim);
+        margin-top: -8px;
+      }
+      .merge-status {
+        font-size: 12px;
+        padding: 8px 10px;
+        border-radius: 6px;
+        border: 1px solid var(--border);
+      }
+      .merge-status.ok {
+        color: var(--fg);
+        border-color: var(--accent);
+      }
+      .merge-status.warn {
+        color: var(--fg);
+        border-color: #b8860b;
+      }
+      .merge-status.err {
+        color: var(--fg);
+        border-color: var(--error);
+      }
+      .merge-field {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        font-size: 12px;
+        color: var(--fg-dim);
+      }
+      .merge-check {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-size: 13px;
+      }
+      .merge-check.hidden {
+        display: none;
+      }
+      .merge-actions {
+        display: flex;
+        justify-content: flex-end;
+        gap: 8px;
+        margin-top: 4px;
+      }
       .status {
         font-size: 12px;
         color: var(--fg-dim);
@@ -1028,6 +1097,36 @@
         }
       }
 
+      async function openPrByNumber(number) {
+        appMode = "prs";
+        tabDiff.classList.toggle("active", false);
+        tabPrs.classList.toggle("active", true);
+        diffControls.style.display = "none";
+        content.innerHTML = `<div class="empty">Loading PR #${number}…</div>`;
+        try {
+          const res = await fetch(`/api/prs?token=${TOKEN}`);
+          const data = await res.json();
+          if (appMode !== "prs") return;
+          const groups = data.groups || [];
+          let match = null;
+          for (const group of groups) {
+            const found = (group.prs || []).find((pr) => pr.number === number);
+            if (found) {
+              match = found;
+              break;
+            }
+          }
+          if (!match) {
+            content.innerHTML = `<div class="empty">PR #${number} not found among open PRs.<br/>Showing all open PRs instead.</div>`;
+            setMode("prs");
+            return;
+          }
+          openPr(match);
+        } catch (err) {
+          content.innerHTML = `<div class="empty">Failed to load PR #${number}: ${escapeHtml(String(err))}</div>`;
+        }
+      }
+
       function renderPrList(groups) {
         if (!groups.length) {
           content.innerHTML =
@@ -1126,6 +1225,138 @@
         }
       }
 
+      async function openMergeDialog() {
+        if (!currentPr) return;
+        const existing = document.getElementById("merge-overlay");
+        if (existing) existing.remove();
+
+        const overlay = document.createElement("div");
+        overlay.id = "merge-overlay";
+        overlay.className = "merge-overlay";
+        overlay.innerHTML =
+          `<div class="merge-dialog">` +
+          `<div class="merge-title">Merge PR #${currentPr.number}</div>` +
+          `<div class="merge-sub">${escapeHtml(currentPr.headRefName)} → ${escapeHtml(currentPr.baseRefName)}</div>` +
+          `<div id="merge-status" class="merge-status">Checking merge status…</div>` +
+          `<label class="merge-field"><span>Method</span>` +
+          `<select id="merge-method">` +
+          `<option value="merge">Create a merge commit</option>` +
+          `<option value="squash">Squash and merge</option>` +
+          `<option value="rebase">Rebase and merge</option>` +
+          `</select></label>` +
+          `<label class="merge-check"><input type="checkbox" id="merge-delete" checked /> Delete branch after merge</label>` +
+          `<label class="merge-check merge-admin hidden"><input type="checkbox" id="merge-admin" /> Override with admin privileges</label>` +
+          `<div class="merge-actions">` +
+          `<button id="merge-cancel">Cancel</button>` +
+          `<button id="merge-confirm" class="primary">Merge</button>` +
+          `</div></div>`;
+        document.body.appendChild(overlay);
+
+        const close = () => overlay.remove();
+        overlay.addEventListener("click", (e) => {
+          if (e.target === overlay) close();
+        });
+        overlay.querySelector("#merge-cancel").onclick = close;
+        overlay.querySelector("#merge-confirm").onclick = () => confirmMerge(overlay, close);
+
+        try {
+          const res = await fetch(
+            `/api/pr-merge-status?token=${TOKEN}&repo=${encodeURIComponent(currentPr.repo)}&number=${currentPr.number}`,
+          );
+          const data = await res.json();
+          const statusEl = overlay.querySelector("#merge-status");
+          if (!statusEl) return;
+          if (!res.ok || data.error || !data.status) {
+            statusEl.textContent = `Could not load merge status: ${data.error || res.status}`;
+            return;
+          }
+          renderMergeStatus(overlay, data.status);
+        } catch (err) {
+          const statusEl = overlay.querySelector("#merge-status");
+          if (statusEl) statusEl.textContent = `Could not load merge status: ${err}`;
+        }
+      }
+
+      function renderMergeStatus(overlay, status) {
+        const statusEl = overlay.querySelector("#merge-status");
+        const adminField = overlay.querySelector(".merge-admin");
+        const clean = status.mergeable === "MERGEABLE" && status.mergeStateStatus === "CLEAN";
+        const blocked =
+          status.mergeStateStatus === "BLOCKED" ||
+          status.mergeStateStatus === "BEHIND" ||
+          status.mergeStateStatus === "UNSTABLE";
+        let cls = "ok";
+        let msg = "Ready to merge.";
+        if (status.isDraft) {
+          cls = "warn";
+          msg = "This PR is a draft.";
+        } else if (status.mergeable === "CONFLICTING") {
+          cls = "err";
+          msg = "Has conflicts that must be resolved.";
+        } else if (blocked) {
+          cls = "warn";
+          msg = `Merge is blocked (${status.mergeStateStatus.toLowerCase()}). Checks or reviews may be pending.`;
+        } else if (!clean) {
+          cls = "warn";
+          msg = `State: ${status.mergeStateStatus}.`;
+        }
+        statusEl.className = `merge-status ${cls}`;
+        statusEl.textContent = msg;
+
+        if (status.canAdmin && !clean) {
+          adminField.classList.remove("hidden");
+        } else {
+          adminField.classList.add("hidden");
+        }
+      }
+
+      async function confirmMerge(overlay, close) {
+        if (!currentPr) return;
+        const method = overlay.querySelector("#merge-method").value;
+        const deleteBranch = overlay.querySelector("#merge-delete").checked;
+        const adminEl = overlay.querySelector("#merge-admin");
+        const admin = Boolean(adminEl && adminEl.checked && !adminEl.closest(".hidden"));
+        const confirmBtn = overlay.querySelector("#merge-confirm");
+        confirmBtn.disabled = true;
+        confirmBtn.textContent = "Merging…";
+        try {
+          const res = await fetch("/api/pr-merge", {
+            method: "POST",
+            headers: { "Content-Type": "application/json", "X-Token": TOKEN },
+            body: JSON.stringify({
+              repo: currentPr.repo,
+              number: currentPr.number,
+              method,
+              deleteBranch,
+              admin,
+            }),
+          });
+          const data = await res.json();
+          if (!res.ok || data.error) {
+            const statusEl = overlay.querySelector("#merge-status");
+            if (statusEl) {
+              statusEl.className = "merge-status err";
+              statusEl.textContent = `Merge failed: ${data.error || res.status}`;
+            }
+            confirmBtn.disabled = false;
+            confirmBtn.textContent = "Merge";
+            return;
+          }
+          toast(`PR #${currentPr.number}`, null, null, `Merged (${method}) ✓`);
+          close();
+          currentPr = null;
+          loadPrs();
+        } catch (err) {
+          const statusEl = overlay.querySelector("#merge-status");
+          if (statusEl) {
+            statusEl.className = "merge-status err";
+            statusEl.textContent = `Merge failed: ${err}`;
+          }
+          confirmBtn.disabled = false;
+          confirmBtn.textContent = "Merge";
+        }
+      }
+
       function renderPrDiff(pr, groups) {
         content.innerHTML = "";
         const banner = document.createElement("div");
@@ -1138,6 +1369,7 @@
           `<span class="pr-banner-title">${escapeHtml(pr.title)}</span>` +
           `<a href="${escapeHtml(pr.url)}" target="_blank" rel="noreferrer">open on GitHub ↗</a>` +
           `<button id="pr-comments-toggle">Comments</button>` +
+          `<button id="pr-merge">Merge…</button>` +
           `<button id="pr-start" class="${startCls}"${pr.started ? " disabled" : ""}>${startLabel}</button>`;
         content.appendChild(banner);
         banner.querySelector("#pr-back").onclick = () => {
@@ -1145,6 +1377,7 @@
           loadPrs();
         };
         banner.querySelector("#pr-start").onclick = startReview;
+        banner.querySelector("#pr-merge").onclick = openMergeDialog;
         banner.querySelector("#pr-comments-toggle").onclick = () => {
           const panel = document.getElementById("comments-panel");
           if (panel) panel.classList.toggle("collapsed");
@@ -2055,7 +2288,12 @@
 
       connect();
       if (params.get("mode") === "prs") {
-        setMode("prs");
+        const prParam = Number(params.get("pr"));
+        if (Number.isInteger(prParam) && prParam > 0) {
+          openPrByNumber(prParam);
+        } else {
+          setMode("prs");
+        }
       } else {
         loadDiff();
       }

--- a/packages/git-review/web/index.html
+++ b/packages/git-review/web/index.html
@@ -1108,14 +1108,19 @@
           const data = await res.json();
           if (appMode !== "prs") return;
           const groups = data.groups || [];
-          let match = null;
+          const matches = [];
           for (const group of groups) {
             const found = (group.prs || []).find((pr) => pr.number === number);
             if (found) {
-              match = found;
-              break;
+              matches.push(found);
             }
           }
+          if (matches.length > 1) {
+            content.innerHTML = `<div class="empty">PR #${number} exists in multiple repos.<br/>Showing all open PRs instead.</div>`;
+            setMode("prs");
+            return;
+          }
+          const match = matches[0];
           if (!match) {
             content.innerHTML = `<div class="empty">PR #${number} not found among open PRs.<br/>Showing all open PRs instead.</div>`;
             setMode("prs");

--- a/packages/prs-tracker/README.md
+++ b/packages/prs-tracker/README.md
@@ -43,6 +43,19 @@ The production deploy run is matched by the `push` event on the merge commit, pi
 - `/prs show` — re-show the widget
 - `/prs refresh` — force an immediate status refresh
 
+## Git-review integration
+
+If the [`@arvoretech/pi-git-review`](../git-review) extension is loaded **and** its
+reviewer server is running this session (i.e. you ran `/review` at least once), each PR's
+link in the widget is swapped from the GitHub URL to a local **git-review** deep link that
+opens that PR directly in the reviewer UI (`…?token=…&mode=prs&pr=<number>`).
+
+Discovery is automatic: git-review publishes its `{ baseUrl, token, port }` to a
+per-process file in the OS temp dir (`pi-git-review-<pid>.json`) while its server is up and
+removes it on shutdown. When git-review isn't running, the widget falls back to the plain
+GitHub PR URL. The canonical GitHub URL is always what's injected into the AI's context —
+only the clickable widget link changes.
+
 ## Requirements
 
 - GitHub CLI (`gh`) authenticated in the working directory.

--- a/packages/prs-tracker/package.json
+++ b/packages/prs-tracker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-prs-tracker",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "PI extension that keeps open/recently-merged PRs pinned in the chat as a persistent widget",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/prs-tracker/src/index.ts
+++ b/packages/prs-tracker/src/index.ts
@@ -2,6 +2,7 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { execSync } from "node:child_process";
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { join, dirname, basename } from "node:path";
+import { tmpdir } from "node:os";
 
 type CiState = "PENDING" | "PASS" | "FAIL" | "NONE";
 type DeployState = "QUEUED" | "IN_PROGRESS" | "SUCCESS" | "FAILURE" | "SKIPPED" | "NONE";
@@ -87,6 +88,34 @@ function findHubRoot(cwd: string): string | null {
 function getStatePath(cwd: string): string | null {
   const root = findHubRoot(cwd);
   return root ? join(root, STATE_DIR, `${sessionId}.json`) : null;
+}
+
+interface GitReviewInfo {
+  baseUrl: string;
+  token: string;
+  port: number;
+}
+
+function readGitReviewInfo(): GitReviewInfo | null {
+  const path = join(tmpdir(), `pi-git-review-${process.pid}.json`);
+  if (!existsSync(path)) return null;
+  try {
+    const info = JSON.parse(readFileSync(path, "utf-8")) as {
+      baseUrl?: string;
+      token?: string;
+      port?: number;
+    };
+    if (!info.baseUrl || !info.token) return null;
+    return { baseUrl: info.baseUrl, token: info.token, port: info.port ?? 0 };
+  } catch {
+    return null;
+  }
+}
+
+function gitReviewUrlFor(pr: TrackedPr): string | null {
+  const info = readGitReviewInfo();
+  if (!info) return null;
+  return `${info.baseUrl}/?token=${info.token}&mode=prs&pr=${pr.number}`;
 }
 
 function saveState(cwd: string): void {
@@ -506,7 +535,8 @@ function renderWidget(width: number, theme: any): string[] {
     const deploy = deployLine(pr, fg);
     const status = [ci, deploy].filter(Boolean).join(fg("dim", "  ·  "));
     if (status) lines.push(`      ${status}`);
-    lines.push(`      ${fg("mdLinkUrl", trunc(pr.url))}`);
+    const reviewUrl = gitReviewUrlFor(pr);
+    lines.push(`      ${fg("mdLinkUrl", trunc(reviewUrl ?? pr.url))}`);
   }
   if (prs.length > max) lines.push(fg("dim", `   +${prs.length - max} more`));
   return lines;

--- a/packages/prs-tracker/src/index.ts
+++ b/packages/prs-tracker/src/index.ts
@@ -536,7 +536,11 @@ function renderWidget(width: number, theme: any): string[] {
     const status = [ci, deploy].filter(Boolean).join(fg("dim", "  ·  "));
     if (status) lines.push(`      ${status}`);
     const reviewUrl = gitReviewUrlFor(pr);
-    lines.push(`      ${fg("mdLinkUrl", trunc(reviewUrl ?? pr.url))}`);
+    if (reviewUrl) {
+      lines.push(`      ${osc8(reviewUrl, fg("mdLinkUrl", "Open in git-review"))}`);
+    } else {
+      lines.push(`      ${fg("mdLinkUrl", trunc(pr.url))}`);
+    }
   }
   if (prs.length > max) lines.push(fg("dim", `   +${prs.length - max} more`));
   return lines;


### PR DESCRIPTION
## Summary

Adds PR merging to the **git-review** extension and links tracked PRs in **prs-tracker** to the git-review UI.

## git-review (`0.4.1 → 0.5.0`)

- **Merge from the PR review section.** New `Merge…` button in the PR banner opens a dialog to merge the PR (merge commit / squash / rebase, optional delete-branch). Backed by two `gh`-based routes:
  - `GET /api/pr-merge-status` — mergeability + your repo permission (`gh pr view` + `gh repo view --json viewerPermission`).
  - `POST /api/pr-merge` — runs `gh pr merge <n> --<method>`, with optional `--delete-branch` / `--admin`.
- **Admin override.** When the PR is *not* cleanly mergeable **and** you have `ADMIN` on the repo, an "Override with admin privileges" checkbox appears (adds `--admin`). Hidden entirely when you lack admin rights, so it never offers a permission you don't have.
- **`/review <pr-number>`** opens a PR directly in the reviewer (e.g. `/review 1234` or `/review #1234`). No arg → unchanged behavior.
- **Discovery file.** While the server is up, git-review publishes `{ baseUrl, token, port }` to a per-pid temp file so sibling extensions can build deep links; removed on shutdown.

## prs-tracker (`1.5.0 → 1.6.0`)

- When the git-review server is running this session, each PR's link in the widget is swapped to a git-review deep link (`…?token=…&mode=prs&pr=<number>`) that opens that PR in the reviewer UI.
- Falls back to the plain GitHub URL when git-review isn't running.
- The canonical GitHub URL is still what's injected into the AI's context — only the clickable widget link changes.

## Testing

- `pnpm --filter @arvoretech/pi-git-review --filter @arvoretech/pi-prs-tracker build` — both compile clean (`tsc`, exit 0).
- LSP diagnostics clean on all edited `.ts` files.
- Manual UI verification of the merge dialog / deep links not yet performed in a live session.

## Notes

- The discovery file carries the same session token used in the browser URL (local-only, user temp dir — same trust model as the existing token-in-URL).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added direct opening of a specific PR from review commands via PR number.
  * Introduced a “Merge…” dialog with merge method selection, optional branch deletion, and admin override when permitted.
  * Enhanced PR-tracker links to use local git-review deep links while the git-review server is running.
* **Bug Fixes**
  * Improved PR-tracker behavior to fall back to standard GitHub PR URLs when local review links aren’t available.
* **Documentation**
  * Updated git-review README with the new merge workflow, endpoints, and command shorthand.
* **Chores**
  * Version bumps for git-review and prs-tracker packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->