### PR TITLE
feat: fork ask_user_question com resposta externa + codeshot na slack-bridge

### DIFF
--- a/packages/ask-user-question/LICENSE
+++ b/packages/ask-user-question/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 juicesharp
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/ask-user-question/README.md
+++ b/packages/ask-user-question/README.md
@@ -1,0 +1,109 @@
+# rpiv-ask-user-question
+
+<div align="center">
+  <a href="https://github.com/juicesharp/rpiv-mono/tree/main/packages/rpiv-ask-user-question">
+    <picture>
+      <img src="https://raw.githubusercontent.com/juicesharp/rpiv-mono/main/packages/rpiv-ask-user-question/docs/cover.png" alt="rpiv-ask-user-question cover" width="50%">
+    </picture>
+  </a>
+</div>
+
+Let the model ask you structured clarifying questions instead of guessing. `rpiv-ask-user-question` adds the `ask_user_question` tool to [Pi Agent](https://github.com/badlogic/pi-mono) - a tabbed dialog with single- and multi-select questions, side-by-side previews, per-option notes, and a Submit tab that reviews answers before they go back to the model.
+
+![Side-by-side code preview](https://raw.githubusercontent.com/juicesharp/rpiv-mono/main/packages/rpiv-ask-user-question/docs/code-preview.jpg)
+
+## Features
+
+- **Multi-question dialogs** - ask several questions in one turn with a tab bar (`Tab` to switch).
+- **Preview pane** - render an ASCII diagram, code snippet, or markdown next to each option, side-by-side or stacked depending on terminal width.
+- **Per-option notes** - press `n` on a previewed option to attach a free-text note that travels back with the answer.
+- **Multi-select questions** - checkboxes with `Space` to toggle, Enter-as-toggle on rows, a `Next` sentinel to advance, and toggles persisted across tab switches.
+- **Submit tab** - review every answer before submitting; warns about unanswered questions and offers a Submit picker.
+- **Chat row on every tab** - redirect the conversation without leaving the dialog.
+- **Terminal-row-aware overflow scroll** - when the dialog is taller than the terminal, the body scrolls between a sticky heading and sticky hints/border; overflow indicators (↑ / ↓ / ↕) show what's clipped.
+- **"Other" free-text fallback** - type a custom answer when no option fits.
+- **Localized UI** - sentinel rows, hints, submit/cancel labels, review pane, and notes affordance display in the user's chosen language via `@juicesharp/rpiv-i18n`. Ships Deutsch / English / Español / Français / Português (PT) / Português (BR) / Русский / Українська; switch with `/languages` or `pi --locale <code>`. LLM-facing copy (tool description, schemas, errors) stays English by design.
+
+## Screens
+
+| | |
+|---|---|
+| ![Single-question dialog](https://raw.githubusercontent.com/juicesharp/rpiv-mono/main/packages/rpiv-ask-user-question/docs/single-question.jpg) | ![Multi-tab + ASCII preview](https://raw.githubusercontent.com/juicesharp/rpiv-mono/main/packages/rpiv-ask-user-question/docs/multi-tab-preview.jpg) |
+| ![Multi-select with checkboxes](https://raw.githubusercontent.com/juicesharp/rpiv-mono/main/packages/rpiv-ask-user-question/docs/multi-select.jpg) | ![Submit tab review](https://raw.githubusercontent.com/juicesharp/rpiv-mono/main/packages/rpiv-ask-user-question/docs/submit-tab.jpg) |
+| ![Localized UI - German](https://raw.githubusercontent.com/juicesharp/rpiv-mono/main/packages/rpiv-ask-user-question/docs/localized-german-ui.jpg) | |
+
+## Install
+
+```bash
+pi install npm:@juicesharp/rpiv-ask-user-question
+```
+
+Then restart your Pi session.
+
+### Optional: localization
+
+`rpiv-ask-user-question` works standalone - install only this package and you get the full English UI. Install `@juicesharp/rpiv-i18n` alongside it to flip sentinel labels, dialog hints, review-tab heading, and chat-summary lines to your active locale:
+
+```bash
+pi install npm:@juicesharp/rpiv-i18n
+```
+
+With the SDK present, locale resolves from `--locale <code>` → `~/.config/rpiv-i18n/locale.json` → `LANG` / `LC_ALL` → English. The `/languages` interactive picker and `pi --locale <code>` startup flag are also enabled. Without the SDK, the dialog stays online and renders English at every call site - no warning, no crash. Users who installed via `pi install npm:@juicesharp/rpiv-pi` + `/rpiv-setup` get the SDK automatically.
+
+## Tool
+
+- **`ask_user_question`** - present one or more structured questions, each with 2+ options, optional `multiSelect`, optional per-option `preview`, and an optional free-text "Other" fallback. Returns the user's selection(s) plus any notes. See the tool's `promptGuidelines` for usage policy.
+
+### Schema
+
+```ts
+ask_user_question({
+  questions: [
+    {
+      question: string,            // full question text, ends with "?"
+      header: string,              // chip label, max 16 chars
+      options: [
+        {
+          label: string,           // 1-5 words, max 60 chars
+          description: string,     // explains the choice / its trade-off
+          preview?: string,        // optional markdown shown next to options
+        },
+        // … 2-4 options total
+      ],
+      multiSelect?: boolean,       // default false
+    },
+    // … 1-4 questions total
+  ]
+})
+```
+
+Reserved option labels (rejected at validation): `"Other"`, plus the runtime sentinels (`"Type something."`, `"Chat about this"`, `"Next →"`).
+
+Returns:
+
+```ts
+{
+  content: [{ type: "text", text: string }], // human-readable envelope or DECLINE_MESSAGE
+  details: {
+    answers: Array<{
+      questionIndex: number,
+      question: string,
+      kind: "option" | "custom" | "chat" | "multi",
+      answer: string | null,
+      selected?: string[],         // present for multi-select
+      notes?: string,              // free-text note, when typed
+      preview?: string,            // echoed back when option carried a preview
+    }>,
+    cancelled: boolean,
+    error?: "no_ui" | "no_questions" | "empty_options" | "too_many_questions"
+          | "duplicate_question" | "duplicate_option_label" | "reserved_label",
+  }
+}
+```
+
+## License
+
+[![npm version](https://img.shields.io/npm/v/@juicesharp/rpiv-ask-user-question.svg)](https://www.npmjs.com/package/@juicesharp/rpiv-ask-user-question)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+MIT

--- a/packages/ask-user-question/ask-user-question.ts
+++ b/packages/ask-user-question/ask-user-question.ts
@@ -1,0 +1,178 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { loadConfig, validateGuidanceFields } from "./config.js";
+import {
+	ASK_USER_ANSWER_EVENT,
+	ASK_USER_PROMPT_EVENT,
+	type AskUserAnswerEventPayload,
+	type AskUserPromptEventPayload,
+} from "./events.js";
+import { externalAnswerToResult } from "./tool/external-answer.js";
+import { displayLabel } from "./state/i18n-bridge.js";
+import { sentinelsToAppend } from "./state/row-intent.js";
+import { buildQuestionnaireResponse, buildToolResult } from "./tool/response-envelope.js";
+import {
+	MAX_OPTIONS,
+	MAX_QUESTIONS,
+	MIN_OPTIONS,
+	type QuestionData,
+	type QuestionnaireResult,
+	type QuestionParams,
+	QuestionParamsSchema,
+} from "./tool/types.js";
+import { validateQuestionnaire } from "./tool/validate-questionnaire.js";
+import type { WrappingSelectItem } from "./view/components/wrapping-select.js";
+
+function emitAskUserPromptEvent(pi: ExtensionAPI, promptId: string, params: QuestionParams): void {
+	const payload: AskUserPromptEventPayload = {
+		promptId,
+		questions: params.questions.map((q) => ({
+			question: q.question,
+			header: q.header,
+			multiSelect: q.multiSelect ?? false,
+			options: q.options.map((o) => ({
+				label: o.label,
+				description: o.description,
+				hasPreview: typeof o.preview === "string" && o.preview.length > 0,
+			})),
+		})),
+	};
+	pi.events.emit(ASK_USER_PROMPT_EVENT, payload);
+}
+
+const ERROR_NO_UI = "Error: UI not available (running in non-interactive mode)";
+
+export function buildItemsForQuestion(question: QuestionData): WrappingSelectItem[] {
+	const items: WrappingSelectItem[] = question.options.map((o) => ({
+		kind: "option",
+		label: o.label,
+		description: o.description,
+	}));
+	const hasAnyPreview = question.options.some((o) => typeof o.preview === "string" && o.preview.length > 0);
+	for (const kind of sentinelsToAppend(question, hasAnyPreview)) {
+		items.push({ kind, label: displayLabel(kind) });
+	}
+	return items;
+}
+
+export const DEFAULT_PROMPT_SNIPPET = `Ask the user up to ${MAX_QUESTIONS} structured questions (${MIN_OPTIONS}-${MAX_OPTIONS} options each) when requirements are ambiguous`;
+export const DEFAULT_PROMPT_GUIDELINES: string[] = [
+	`Use ask_user_question whenever the user's request is underspecified and you cannot proceed without concrete decisions — you can ask up to ${MAX_QUESTIONS} questions per invocation.`,
+	`Each question MUST have ${MIN_OPTIONS}-${MAX_OPTIONS} options. Every option requires a concise label (1-5 words) and a description explaining what the choice means or its trade-offs. The user can additionally type a custom answer ("Type something." row is appended automatically to single-select questions) or pick "Chat about this" to abandon the questionnaire.`,
+	`Set multiSelect: true when multiple answers are valid; this suppresses the "Type something." row. Provide an options[].preview markdown string when an option benefits from richer side-by-side context (mockups, code snippets, diagrams, configs) — single-select only. NOTE: any non-empty preview on a single-select question ALSO suppresses the "Type something." row (no room in the side-by-side layout); "Chat about this" remains the escape hatch. If you recommend a specific option, make it the first option and append "(Recommended)" to its label.`,
+	"Do not stack multiple ask_user_question calls back-to-back — group all clarifying questions into one invocation.",
+];
+
+export function registerAskUserQuestionTool(pi: ExtensionAPI): void {
+	const guidance = validateGuidanceFields(loadConfig().guidance);
+	pi.registerTool({
+		name: "ask_user_question",
+		label: "Ask User Question",
+		description: `Ask the user one or more structured questions during execution. Use when you need to:
+1. Gather user preferences or requirements
+2. Clarify ambiguous instructions
+3. Get decisions on implementation choices as you work
+4. Offer choices to the user about what direction to take
+
+Usage notes:
+- Users will always be able to type a custom answer ("Type something." row is appended automatically to every single-select question) or pick "Chat about this" to abandon the questionnaire and continue in free-form conversation. Do NOT author "Other" / "Type something." / "Chat about this" labels yourself — duplicates are rejected at runtime.
+- Use multiSelect: true to allow multiple answers to be selected for a question. The "Type something." row is suppressed on multi-select questions, and is ALSO suppressed on single-select questions where any option carries a \`preview\` (the side-by-side layout has no room for inline custom text — "Chat about this" remains as the free-form escape hatch).
+- If you recommend a specific option, make that the first option in the list and add "(Recommended)" at the end of the label.
+
+Preview feature:
+Use the optional \`preview\` field on options when presenting concrete artifacts that users need to visually compare:
+- ASCII mockups of UI layouts or components
+- Code snippets showing different implementations
+- Diagram variations
+- Configuration examples
+
+Preview content is rendered as markdown in a monospace box. Multi-line text with newlines is supported. When any option has a preview, the UI switches to a side-by-side layout with a vertical option list on the left and preview on the right. Do not use previews for simple preference questions where labels and descriptions suffice. Note: previews are only supported for single-select questions (not multiSelect).`,
+		promptSnippet: guidance.promptSnippet ?? DEFAULT_PROMPT_SNIPPET,
+		promptGuidelines: guidance.promptGuidelines ?? DEFAULT_PROMPT_GUIDELINES,
+		parameters: QuestionParamsSchema,
+
+		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+			const typed = params as unknown as QuestionParams;
+			if (!ctx.hasUI) return buildToolResult(ERROR_NO_UI, { answers: [], cancelled: true, error: "no_ui" });
+
+			const validation = validateQuestionnaire(typed);
+			if (!validation.ok) {
+				return buildToolResult(validation.message, {
+					answers: [],
+					cancelled: true,
+					error: validation.error,
+				});
+			}
+
+			// Emit event for external listeners (e.g., Slack bridge). The promptId
+			// correlates an external answer back to this specific invocation.
+			const promptId = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+			emitAskUserPromptEvent(pi, promptId, typed);
+
+			const itemsByTab: WrappingSelectItem[][] = typed.questions.map((q) => buildItemsForQuestion(q));
+
+			// Lazy — QuestionnaireSession pulls the ~560ms view/TUI render graph;
+			// load it only when the tool runs, not at extension registration.
+			const { QuestionnaireSession } = await import("./state/questionnaire-session.js");
+
+			// Race two answer channels: the terminal overlay and an external answer
+			// event (e.g. a Slack button click). Whichever resolves first wins; the
+			// other is torn down (overlay closed / listener removed) so there is no
+			// orphaned overlay and the tool result flows back through the normal path.
+			let hideOverlay: (() => void) | undefined;
+			let unsubscribe: (() => void) | undefined;
+			let settled = false;
+
+			const result = await new Promise<QuestionnaireResult>((resolve) => {
+				const finish = (r: QuestionnaireResult) => {
+					if (settled) return;
+					settled = true;
+					unsubscribe?.();
+					hideOverlay?.();
+					resolve(r);
+				};
+
+				unsubscribe = pi.events.on(ASK_USER_ANSWER_EVENT, (data) => {
+					const payload = data as AskUserAnswerEventPayload;
+					if (!payload || payload.promptId !== promptId) return;
+					finish(externalAnswerToResult(payload, typed));
+				});
+
+				void ctx.ui
+					.custom<QuestionnaireResult>(
+						(tui, theme, _kb, done) => {
+							const session = new QuestionnaireSession({
+								tui,
+								theme,
+								params: typed,
+								itemsByTab,
+								done,
+							});
+							return session.component;
+						},
+						{
+							overlay: true,
+							overlayOptions: {
+								anchor: "bottom-center",
+								width: "100%",
+								maxHeight: "100%",
+								margin: { left: 0, right: 0, bottom: 0 },
+							},
+							onHandle: (handle) => {
+								hideOverlay = () => handle.hide();
+								if (settled) handle.hide();
+							},
+						},
+					)
+					.then((overlayResult) => {
+						if (overlayResult) finish(overlayResult);
+						else finish({ answers: [], cancelled: true });
+					})
+					.catch(() => finish({ answers: [], cancelled: true }));
+			});
+
+			return buildQuestionnaireResponse(result, typed);
+		},
+	});
+}
+
+export { buildQuestionnaireResponse, buildToolResult };

--- a/packages/ask-user-question/config.ts
+++ b/packages/ask-user-question/config.ts
@@ -1,0 +1,51 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export interface GuidanceFields {
+	promptSnippet?: string;
+	promptGuidelines?: string[];
+}
+
+function configPath(name: string, file: string = "config.json"): string {
+	return join(homedir(), ".config", name, file);
+}
+
+function loadJsonConfig<T>(path: string): T {
+	if (!existsSync(path)) return {} as T;
+	try {
+		const parsed = JSON.parse(readFileSync(path, "utf-8")) as unknown;
+		if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) return {} as T;
+		return parsed as T;
+	} catch (err) {
+		console.warn(`ask-user-question: invalid JSON at ${path}, using default ({}) — ${(err as Error).message}`);
+		return {} as T;
+	}
+}
+
+export function validateGuidanceFields(fields: unknown): GuidanceFields {
+	if (!fields || typeof fields !== "object") return {};
+	const g = fields as Record<string, unknown>;
+	const result: GuidanceFields = {};
+	if (typeof g.promptSnippet === "string" && g.promptSnippet.length > 0) {
+		result.promptSnippet = g.promptSnippet;
+	}
+	if (
+		Array.isArray(g.promptGuidelines) &&
+		g.promptGuidelines.length > 0 &&
+		g.promptGuidelines.every((s) => typeof s === "string" && s.length > 0)
+	) {
+		result.promptGuidelines = g.promptGuidelines;
+	}
+	return result;
+}
+
+const CONFIG_PATH = configPath("arvore-ask-user-question");
+
+interface AskUserQuestionConfig {
+	guidance?: GuidanceFields;
+}
+
+export function loadConfig(): AskUserQuestionConfig {
+	return loadJsonConfig<AskUserQuestionConfig>(CONFIG_PATH);
+}

--- a/packages/ask-user-question/events.ts
+++ b/packages/ask-user-question/events.ts
@@ -1,0 +1,72 @@
+/**
+ * Public event contract for @arvoretech/pi-ask-user-question.
+ *
+ * STABILITY POLICY — applies to every event in the `arvore:ask-user:*` namespace.
+ *
+ *   1. Channel names are immutable. Once shipped, never rename.
+ *   2. Payload changes are append-only. Listeners MUST tolerate unknown
+ *      fields. New fields ship as optional (`?:`).
+ *   3. Breaking changes require a NEW channel, e.g. `arvore:ask-user:prompt.v2`,
+ *      with dual-emit during a deprecation window.
+ *   4. No `version` field inside payloads. Version via channel name only.
+ *   5. Payloads must be JSON-safe: primitives, arrays, plain objects.
+ *
+ * Naming: `arvore:<tool>:<phase>`, lowercase, hyphen-separated.
+ */
+
+/** Emitted when the questionnaire opens, for external listeners (e.g. Slack bridge). */
+export const ASK_USER_PROMPT_EVENT = "arvore:ask-user:prompt" as const;
+
+/**
+ * Emitted BY an external listener to answer a pending questionnaire from
+ * outside the terminal (e.g. a Slack button click). The tool races this event
+ * against the terminal overlay: whichever resolves first wins, the other is
+ * cancelled. `promptId` correlates the answer with the prompt event.
+ */
+export const ASK_USER_ANSWER_EVENT = "arvore:ask-user:answer" as const;
+
+export interface AskUserPromptEventPayload {
+	/** Correlation id for this prompt; echo it back in the answer payload. */
+	promptId: string;
+	questions: ReadonlyArray<AskUserPromptQuestion>;
+}
+
+export interface AskUserPromptQuestion {
+	/** The full question text, exactly as the agent authored it. */
+	question: string;
+	/** The short chip/tag shown next to the question. */
+	header: string;
+	/** True iff the user may pick multiple options. Normalized from optional. */
+	multiSelect: boolean;
+	options: ReadonlyArray<AskUserPromptOption>;
+}
+
+export interface AskUserPromptOption {
+	label: string;
+	description: string;
+	/** True iff the option carries rich preview content (content not shipped). */
+	hasPreview: boolean;
+}
+
+/**
+ * Answer payload sent by an external listener. Provide, per question index,
+ * either a chosen option `label` (single-select), an array of `labels`
+ * (multi-select), or free `text`. Questions omitted are treated as unanswered.
+ */
+export interface AskUserAnswerEventPayload {
+	/** Must match the `promptId` from the prompt event; stale answers are ignored. */
+	promptId: string;
+	/** True to cancel/decline the questionnaire entirely. */
+	cancelled?: boolean;
+	answers?: ReadonlyArray<AskUserExternalAnswer>;
+}
+
+export interface AskUserExternalAnswer {
+	questionIndex: number;
+	/** Chosen option label (single-select). */
+	label?: string;
+	/** Chosen option labels (multi-select). */
+	labels?: string[];
+	/** Free-text answer. */
+	text?: string;
+}

--- a/packages/ask-user-question/index.ts
+++ b/packages/ask-user-question/index.ts
@@ -1,0 +1,50 @@
+/**
+ * rpiv-ask-user-question — Pi extension. Registers the `ask_user_question`
+ * tool: a structured option selector with a free-text "Other" fallback.
+ *
+ * Sentinel labels and TUI chrome strings localize at render time via the i18n
+ * bridge. Strings are registered with rpiv-i18n here, once, at module init —
+ * but only when the SDK is actually installed. If `@juicesharp/rpiv-i18n` is
+ * missing (standalone install of just this package), the dynamic-load shim
+ * no-ops and the bridge's `t(key, fallback)` returns the inline English literal
+ * at every call site. The extension stays online either way.
+ *
+ * Adding a locale: drop `locales/<code>.json` next to en.json (mirroring the
+ * key set). No edit needed here — `registerLocalesFromDir` iterates
+ * `SUPPORTED_LOCALES` from the SDK. See `@juicesharp/rpiv-i18n` README →
+ * "Contributing translations" for the full convention.
+ */
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { registerAskUserQuestionTool } from "./ask-user-question.js";
+import { I18N_NAMESPACE } from "./state/i18n-bridge.js";
+
+type I18nLoader = {
+	registerLocalesFromDir: (namespace: string, packageUrl: string, options?: { label?: string }) => void;
+};
+
+// Dynamic import keeps `@juicesharp/rpiv-i18n` a soft optional peer: when the
+// SDK is installed alongside this package the strings register and
+// `/languages` flips them live; when it isn't, the import rejects here, we
+// no-op, and the bridge's English-fallback shim keeps the extension online.
+//
+// The `/loader` subpath is used instead of the SDK entry so the i18n-ui +
+// pi-tui modules are not pulled into our load graph just to register strings.
+try {
+	const i18nModule = "@juicesharp/rpiv-i18n/loader";
+	const sdk = (await import(i18nModule)) as I18nLoader;
+	sdk.registerLocalesFromDir(I18N_NAMESPACE, import.meta.url, { label: "rpiv-ask-user-question" });
+} catch {
+	// SDK absent — extension still loads with English-only UI.
+}
+
+export {
+	ASK_USER_PROMPT_EVENT,
+	type AskUserPromptEventPayload,
+	type AskUserPromptOption,
+	type AskUserPromptQuestion,
+} from "./events.js";
+
+export default function (pi: ExtensionAPI) {
+	registerAskUserQuestionTool(pi);
+}

--- a/packages/ask-user-question/locales/de.json
+++ b/packages/ask-user-question/locales/de.json
@@ -1,0 +1,27 @@
+{
+  "_meta.notes": "Auto-translated draft. Native-speaker review welcome via PR. TUI symbols (↑/↓, ⚠) and key names (Enter, Esc, Tab, Space, n) are universal CLI conventions and stay untranslated.",
+
+  "sentinel.other": "Schreibe etwas.",
+  "sentinel.chat": "Darüber chatten",
+  "sentinel.next": "Weiter",
+
+  "submit.label": "Antworten senden",
+  "submit.cancel": "Abbrechen",
+
+  "hint.enter": "Enter zum Auswählen",
+  "hint.navigate": "↑/↓ zur Navigation",
+  "hint.toggle": "Leertaste zum Umschalten",
+  "hint.notes": "n für Notizen",
+  "hint.tab": "Tab wechselt die Frage",
+  "hint.cancel": "Esc zum Abbrechen",
+
+  "review.heading": "Antworten überprüfen",
+  "review.ready": "Bereit, deine Antworten zu senden?",
+  "review.incomplete": "⚠ Beantworte die verbleibenden Fragen vor dem Senden:",
+
+  "preview.no_preview": "Keine Vorschau verfügbar",
+  "preview.notes_affordance": "Notizen: drücke n, um Notizen hinzuzufügen",
+
+  "chat.summary": "Benutzer möchte darüber chatten",
+  "notes.header": "Notizen:"
+}

--- a/packages/ask-user-question/locales/en.json
+++ b/packages/ask-user-question/locales/en.json
@@ -1,0 +1,27 @@
+{
+  "sentinel.other": "Type something.",
+  "sentinel.chat": "Chat about this",
+  "sentinel.next": "Next",
+
+  "submit.label": "Submit answers",
+  "submit.cancel": "Cancel",
+
+  "hint.enter": "Enter to select",
+  "hint.navigate": "↑/↓ to navigate",
+  "hint.toggle": "Space to toggle",
+  "hint.notes": "n to add notes",
+  "hint.tab": "Tab to switch questions",
+  "hint.collapse": "Ctrl+] to collapse",
+  "hint.expand_line": "Ctrl+] to expand · Esc to cancel",
+  "hint.cancel": "Esc to cancel",
+
+  "review.heading": "Review your answers",
+  "review.ready": "Ready to submit your answers?",
+  "review.incomplete": "⚠ Answer remaining questions before submitting:",
+
+  "preview.no_preview": "No preview available",
+  "preview.notes_affordance": "Notes: press n to add notes",
+
+  "chat.summary": "User wants to chat about this",
+  "notes.header": "Notes:"
+}

--- a/packages/ask-user-question/locales/es.json
+++ b/packages/ask-user-question/locales/es.json
@@ -1,0 +1,27 @@
+{
+  "_meta.notes": "Auto-translated draft. Native-speaker review welcome via PR. TUI symbols (↑/↓, ⚠) and key names (Enter, Esc, Tab, Space, n) are universal CLI conventions and stay untranslated.",
+
+  "sentinel.other": "Escribe algo.",
+  "sentinel.chat": "Conversar sobre esto",
+  "sentinel.next": "Siguiente",
+
+  "submit.label": "Enviar respuestas",
+  "submit.cancel": "Cancelar",
+
+  "hint.enter": "Enter para seleccionar",
+  "hint.navigate": "↑/↓ para navegar",
+  "hint.toggle": "Espacio para alternar",
+  "hint.notes": "n para añadir notas",
+  "hint.tab": "Tab para cambiar de pregunta",
+  "hint.cancel": "Esc para cancelar",
+
+  "review.heading": "Revisa tus respuestas",
+  "review.ready": "¿Listo para enviar tus respuestas?",
+  "review.incomplete": "⚠ Responde las preguntas restantes antes de enviar:",
+
+  "preview.no_preview": "Vista previa no disponible",
+  "preview.notes_affordance": "Notas: pulsa n para añadir notas",
+
+  "chat.summary": "El usuario quiere conversar sobre esto",
+  "notes.header": "Notas:"
+}

--- a/packages/ask-user-question/locales/fr.json
+++ b/packages/ask-user-question/locales/fr.json
@@ -1,0 +1,27 @@
+{
+  "_meta.notes": "Auto-translated draft. Native-speaker review welcome via PR. TUI symbols (↑/↓, ⚠) and key names (Enter, Esc, Tab, Space, n) are universal CLI conventions and stay untranslated.",
+
+  "sentinel.other": "Écrivez quelque chose.",
+  "sentinel.chat": "Discuter de ceci",
+  "sentinel.next": "Suivant",
+
+  "submit.label": "Envoyer les réponses",
+  "submit.cancel": "Annuler",
+
+  "hint.enter": "Entrée pour sélectionner",
+  "hint.navigate": "↑/↓ pour naviguer",
+  "hint.toggle": "Espace pour basculer",
+  "hint.notes": "n pour ajouter des notes",
+  "hint.tab": "Tab pour changer de question",
+  "hint.cancel": "Échap pour annuler",
+
+  "review.heading": "Vérifiez vos réponses",
+  "review.ready": "Prêt à envoyer vos réponses ?",
+  "review.incomplete": "⚠ Répondez aux questions restantes avant d'envoyer :",
+
+  "preview.no_preview": "Aucun aperçu disponible",
+  "preview.notes_affordance": "Notes : appuyez sur n pour ajouter des notes",
+
+  "chat.summary": "L'utilisateur souhaite discuter de ceci",
+  "notes.header": "Notes :"
+}

--- a/packages/ask-user-question/locales/pt-BR.json
+++ b/packages/ask-user-question/locales/pt-BR.json
@@ -1,0 +1,27 @@
+{
+  "_meta.notes": "Auto-translated draft. Native-speaker review welcome via PR. TUI symbols (↑/↓, ⚠) and key names (Enter, Esc, Tab, Space, n) are universal CLI conventions and stay untranslated.",
+
+  "sentinel.other": "Digite algo.",
+  "sentinel.chat": "Conversar sobre isso",
+  "sentinel.next": "Próximo",
+
+  "submit.label": "Enviar respostas",
+  "submit.cancel": "Cancelar",
+
+  "hint.enter": "Enter para selecionar",
+  "hint.navigate": "↑/↓ para navegar",
+  "hint.toggle": "Espaço para alternar",
+  "hint.notes": "n para adicionar notas",
+  "hint.tab": "Tab para trocar de pergunta",
+  "hint.cancel": "Esc para cancelar",
+
+  "review.heading": "Revise suas respostas",
+  "review.ready": "Pronto para enviar suas respostas?",
+  "review.incomplete": "⚠ Responda as perguntas restantes antes de enviar:",
+
+  "preview.no_preview": "Pré-visualização indisponível",
+  "preview.notes_affordance": "Notas: pressione n para adicionar notas",
+
+  "chat.summary": "O usuário quer conversar sobre isso",
+  "notes.header": "Notas:"
+}

--- a/packages/ask-user-question/locales/pt.json
+++ b/packages/ask-user-question/locales/pt.json
@@ -1,0 +1,27 @@
+{
+  "_meta.notes": "European Portuguese (Portugal). Auto-translated draft. Native-speaker review welcome via PR. Distinct from pt-BR (Brasil): differs in lexicon (utilizador / você), conjugation, and some terms. TUI symbols (↑/↓, ⚠) and key names (Enter, Esc, Tab, Space, n) are universal CLI conventions and stay untranslated.",
+
+  "sentinel.other": "Escreva algo.",
+  "sentinel.chat": "Conversar sobre isto",
+  "sentinel.next": "Seguinte",
+
+  "submit.label": "Enviar respostas",
+  "submit.cancel": "Cancelar",
+
+  "hint.enter": "Enter para selecionar",
+  "hint.navigate": "↑/↓ para navegar",
+  "hint.toggle": "Espaço para alternar",
+  "hint.notes": "n para adicionar notas",
+  "hint.tab": "Tab para mudar de pergunta",
+  "hint.cancel": "Esc para cancelar",
+
+  "review.heading": "Reveja as suas respostas",
+  "review.ready": "Pronto para enviar as suas respostas?",
+  "review.incomplete": "⚠ Responda às perguntas restantes antes de enviar:",
+
+  "preview.no_preview": "Pré-visualização indisponível",
+  "preview.notes_affordance": "Notas: prima n para adicionar notas",
+
+  "chat.summary": "O utilizador quer conversar sobre isto",
+  "notes.header": "Notas:"
+}

--- a/packages/ask-user-question/locales/ru.json
+++ b/packages/ask-user-question/locales/ru.json
@@ -1,0 +1,27 @@
+{
+  "_meta.notes": "Auto-translated draft. Native-speaker review welcome via PR. TUI symbols (↑/↓, ⚠) and key names (Enter, Esc, Tab, Space, n) are universal CLI conventions and stay untranslated.",
+
+  "sentinel.other": "Введите что-нибудь.",
+  "sentinel.chat": "Обсудить это",
+  "sentinel.next": "Далее",
+
+  "submit.label": "Отправить ответы",
+  "submit.cancel": "Отмена",
+
+  "hint.enter": "Enter — выбрать",
+  "hint.navigate": "↑/↓ — навигация",
+  "hint.toggle": "Space — переключить",
+  "hint.notes": "n — добавить заметки",
+  "hint.tab": "Tab — следующий вопрос",
+  "hint.cancel": "Esc — отменить",
+
+  "review.heading": "Проверьте свои ответы",
+  "review.ready": "Готовы отправить ответы?",
+  "review.incomplete": "⚠ Ответьте на оставшиеся вопросы перед отправкой:",
+
+  "preview.no_preview": "Предпросмотр недоступен",
+  "preview.notes_affordance": "Заметки: нажмите n, чтобы добавить заметки",
+
+  "chat.summary": "Пользователь хочет обсудить это",
+  "notes.header": "Заметки:"
+}

--- a/packages/ask-user-question/locales/uk.json
+++ b/packages/ask-user-question/locales/uk.json
@@ -1,0 +1,27 @@
+{
+  "_meta.notes": "Auto-translated draft. Native-speaker review welcome via PR. TUI symbols (↑/↓, ⚠) and key names (Enter, Esc, Tab, Space, n) are universal CLI conventions and stay untranslated.",
+
+  "sentinel.other": "Введіть щось.",
+  "sentinel.chat": "Обговорити це",
+  "sentinel.next": "Далі",
+
+  "submit.label": "Надіслати відповіді",
+  "submit.cancel": "Скасувати",
+
+  "hint.enter": "Enter — обрати",
+  "hint.navigate": "↑/↓ — навігація",
+  "hint.toggle": "Space — перемкнути",
+  "hint.notes": "n — додати нотатки",
+  "hint.tab": "Tab — наступне питання",
+  "hint.cancel": "Esc — скасувати",
+
+  "review.heading": "Перегляньте свої відповіді",
+  "review.ready": "Готові надіслати відповіді?",
+  "review.incomplete": "⚠ Дайте відповіді на решту питань перед надсиланням:",
+
+  "preview.no_preview": "Попередній перегляд недоступний",
+  "preview.notes_affordance": "Нотатки: натисніть n, щоб додати нотатки",
+
+  "chat.summary": "Користувач хоче обговорити це",
+  "notes.header": "Нотатки:"
+}

--- a/packages/ask-user-question/locales/zh.json
+++ b/packages/ask-user-question/locales/zh.json
@@ -1,0 +1,29 @@
+{
+  "_meta.notes": "中文翻译。欢迎中文母语者通过 PR 审校。TUI 符号（↑/↓、⚠）为通用 CLI 约定，保持原文不译。Enter、Space 采用中文惯用说法（回车、空格）；Esc、Tab、Ctrl、n 等保留原文。",
+
+  "sentinel.other": "输入内容",
+  "sentinel.chat": "聊聊这个",
+  "sentinel.next": "下一个",
+
+  "submit.label": "提交答案",
+  "submit.cancel": "取消",
+
+  "hint.enter": "回车选择",
+  "hint.navigate": "↑/↓ 导航",
+  "hint.toggle": "空格切换",
+  "hint.notes": "按 n 添加备注",
+  "hint.tab": "Tab 切换问题",
+  "hint.collapse": "Ctrl+] 折叠",
+  "hint.expand_line": "Ctrl+] 展开 · Esc 取消",
+  "hint.cancel": "Esc 取消",
+
+  "review.heading": "检查你的答案",
+  "review.ready": "准备提交答案了吗？",
+  "review.incomplete": "⚠ 提交前请先回答以下问题：",
+
+  "preview.no_preview": "暂无预览",
+  "preview.notes_affordance": "备注：按 n 添加",
+
+  "chat.summary": "用户想聊聊这个话题",
+  "notes.header": "备注："
+}

--- a/packages/ask-user-question/package.json
+++ b/packages/ask-user-question/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@arvoretech/pi-ask-user-question",
+  "version": "1.0.0",
+  "description": "PI extension. A structured questionnaire the model can put to the user, answerable from the terminal overlay OR externally (e.g. Slack buttons) via an event channel. Fork of @juicesharp/rpiv-ask-user-question (MIT) with an external-answer race.",
+  "type": "module",
+  "exports": {
+    ".": "./index.ts",
+    "./events": "./events.ts"
+  },
+  "license": "MIT",
+  "author": "Arvore",
+  "scripts": {
+    "lint": "tsc --noEmit"
+  },
+  "files": [
+    "ask-user-question.ts",
+    "config.ts",
+    "events.ts",
+    "index.ts",
+    "LICENSE",
+    "locales/",
+    "README.md",
+    "state/",
+    "tool/",
+    "view/"
+  ],
+  "pi": {
+    "extensions": [
+      "./index.ts"
+    ]
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-tui": "*",
+    "typebox": "^1.2.6"
+  },
+  "devDependencies": {
+    "@earendil-works/pi-coding-agent": "latest",
+    "@earendil-works/pi-tui": "latest",
+    "@types/node": "^20.10.0",
+    "typebox": "^1.2.6",
+    "typescript": "^5.3.0"
+  },
+  "keywords": [
+    "pi-package",
+    "pi",
+    "extension",
+    "ask-user-question",
+    "questionnaire"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/arvoreeducacao/arvore-pi-extensions.git",
+    "directory": "packages/ask-user-question"
+  }
+}

--- a/packages/ask-user-question/state/build-questionnaire.ts
+++ b/packages/ask-user-question/state/build-questionnaire.ts
@@ -1,0 +1,310 @@
+import { getMarkdownTheme, type Theme } from "@earendil-works/pi-coding-agent";
+import { Input } from "@earendil-works/pi-tui";
+import type { QuestionData } from "../tool/types.js";
+import {
+	type BoundGlobalBinding,
+	type BoundPerTabBinding,
+	globalBinding,
+	perTabBinding,
+} from "../view/component-binding.js";
+import { ChatRowView } from "../view/components/chat-row-view.js";
+import { MultiSelectView } from "../view/components/multi-select-view.js";
+import { OptionListView } from "../view/components/option-list-view.js";
+import { PreviewBlockRenderer } from "../view/components/preview/preview-block-renderer.js";
+import { crossTabLeftWidthWithDonation } from "../view/components/preview/preview-layout-decider.js";
+import type { PreviewPaneProps } from "../view/components/preview/preview-pane.js";
+import { PreviewPane } from "../view/components/preview/preview-pane.js";
+import { SubmitPicker } from "../view/components/submit-picker.js";
+import { TabBar } from "../view/components/tab-bar.js";
+import type { WrappingSelectItem, WrappingSelectTheme } from "../view/components/wrapping-select.js";
+import { DialogView } from "../view/dialog-builder.js";
+import { QuestionnairePropsAdapter } from "../view/props-adapter.js";
+import type { StatefulView } from "../view/stateful-view.js";
+import type { TabBodyHeights, TabComponents } from "../view/tab-components.js";
+import { displayLabel } from "./i18n-bridge.js";
+import type { PerTabSelector } from "./selectors/contract.js";
+import { selectActivePreviewPaneIndex } from "./selectors/derivations.js";
+import {
+	selectChatRowProps,
+	selectDialogProps,
+	selectMultiSelectProps,
+	selectOptionListProps,
+	selectPreviewPaneProps,
+	selectSubmitPickerProps,
+	selectTabBarProps,
+} from "./selectors/projections.js";
+import type { QuestionnaireState } from "./state.js";
+
+export interface QuestionnaireBuildConfig {
+	tui: { terminal: { columns: number; rows: number }; requestRender(): void };
+	theme: Theme;
+	questions: readonly QuestionData[];
+	itemsByTab: ReadonlyArray<readonly WrappingSelectItem[]>;
+	isMulti: boolean;
+	initialState: QuestionnaireState;
+	getCurrentTab: () => number;
+}
+
+export interface QuestionnaireBuilt {
+	adapter: QuestionnairePropsAdapter;
+	notesInput: Input;
+	inlineInput: Input;
+	render: (width: number) => string[];
+	invalidate: () => void;
+}
+
+interface HeightComputers {
+	global: (width: number) => number;
+	current: (width: number) => number;
+}
+
+function previewBodyHeights(pane: PreviewPane): (width: number) => TabBodyHeights {
+	return (width) => ({
+		current: pane.naturalHeight(width),
+		max: pane.maxNaturalHeight(width),
+	});
+}
+
+function multiSelectBodyHeights(view: MultiSelectView): (width: number) => TabBodyHeights {
+	return (width) => {
+		const h = view.naturalHeight(width);
+		return { current: h, max: h };
+	};
+}
+
+const isActiveTab: PerTabSelector<boolean> = (s, ctx) =>
+	ctx.i === selectActivePreviewPaneIndex(s.currentTab, ctx.totalQuestions);
+
+/**
+ * Pure factory: assembles every TUI component, the props adapter, and a
+ * lifecycle handle. Session-state dependencies arrive via `getCurrentTab` and
+ * the `inputBuffer` cell. Initial paint is delegated to
+ * `adapter.apply(initialState)` (called by the session at construction-end);
+ * no selector is invoked here.
+ */
+export function buildQuestionnaire(config: QuestionnaireBuildConfig): QuestionnaireBuilt {
+	return new QuestionnaireBuilder(config).build();
+}
+
+/**
+ * Programming-by-intention assembly: each private method names one
+ * construction step from `build()`. Read top-down; the class is build-only and
+ * discarded once the handle is returned.
+ */
+class QuestionnaireBuilder {
+	private readonly tui: QuestionnaireBuildConfig["tui"];
+	private readonly theme: Theme;
+	private readonly questions: readonly QuestionData[];
+	private readonly itemsByTab: ReadonlyArray<readonly WrappingSelectItem[]>;
+	private readonly isMulti: boolean;
+	private readonly initialState: QuestionnaireState;
+	private readonly getCurrentTab: () => number;
+
+	private readonly selectTheme: WrappingSelectTheme;
+	private readonly markdownTheme = getMarkdownTheme();
+	private readonly chatRow: ChatRowView;
+	private readonly notesInput = new Input();
+	private readonly inlineInput = new Input();
+	private readonly getTerminalWidth = () => this.tui.terminal.columns;
+	private readonly getTerminalRows = () => this.tui.terminal.rows;
+
+	constructor(config: QuestionnaireBuildConfig) {
+		this.tui = config.tui;
+		this.theme = config.theme;
+		this.questions = config.questions;
+		this.itemsByTab = config.itemsByTab;
+		this.isMulti = config.isMulti;
+		this.initialState = config.initialState;
+		this.getCurrentTab = config.getCurrentTab;
+
+		this.selectTheme = this.makeSelectTheme();
+		this.chatRow = new ChatRowView({
+			item: { kind: "chat", label: displayLabel("chat") },
+			theme: this.selectTheme,
+		});
+	}
+
+	build(): QuestionnaireBuilt {
+		const tabs = this.buildTabComponents();
+		this.injectGlobalLeftWidth(tabs);
+		const submitPicker = this.buildSubmitPicker();
+		const tabBar = this.buildTabBar();
+		const heights = this.buildHeightComputers(tabs);
+		const dialog = this.buildDialog(tabs, submitPicker, tabBar, heights);
+		const globalBindings = this.buildGlobalBindings(dialog, submitPicker, tabBar);
+		const perTabBindings = this.buildPerTabBindings();
+		const adapter = this.buildAdapter(tabs, globalBindings, perTabBindings);
+		return this.handle(adapter, dialog);
+	}
+
+	private makeSelectTheme(): WrappingSelectTheme {
+		const t = this.theme;
+		return {
+			selectedText: (s) => t.fg("accent", t.bold(s)),
+			description: (s) => t.fg("muted", s),
+			scrollInfo: (s) => t.fg("dim", s),
+		};
+	}
+
+	private buildTabComponents(): ReadonlyArray<TabComponents> {
+		return this.questions.map((q, i) => this.buildTabFor(q, i));
+	}
+
+	private buildTabFor(question: QuestionData, index: number): TabComponents {
+		const optionList = new OptionListView({
+			items: this.itemsByTab[index] ?? [],
+			theme: this.selectTheme,
+		});
+		const previewBlock = new PreviewBlockRenderer({
+			question,
+			theme: this.theme,
+			markdownTheme: this.markdownTheme,
+		});
+		const preview = new PreviewPane({
+			question,
+			getTerminalWidth: this.getTerminalWidth,
+			optionListView: optionList,
+			previewBlock,
+		});
+		const multiSelect = question.multiSelect ? new MultiSelectView(this.theme, question) : undefined;
+		const bodyHeights = this.buildBodyHeights(question, preview, multiSelect);
+		return { optionList, preview, multiSelect, bodyHeights };
+	}
+
+	private buildBodyHeights(
+		question: QuestionData,
+		preview: PreviewPane,
+		multiSelect: MultiSelectView | undefined,
+	): (width: number) => TabBodyHeights {
+		return question.multiSelect ? multiSelectBodyHeights(multiSelect!) : previewBodyHeights(preview);
+	}
+
+	/**
+	 * Compute cross-tab max adaptive left width and inject into each PreviewPane.
+	 * Mirrors buildHeightComputers pattern — iterates all tabs, takes max.
+	 * Called after buildTabComponents, before buildDialog (so setGlobalLeftWidth
+	 * is set before any rendering occurs).
+	 */
+	private injectGlobalLeftWidth(tabs: ReadonlyArray<TabComponents>): void {
+		const questions = this.questions;
+		const itemsByTab = this.itemsByTab;
+		const tabsDescriptor = questions.map((q) => ({ multiSelect: q.multiSelect }));
+		const globalLeftWidth = (paneWidth: number): number =>
+			crossTabLeftWidthWithDonation(tabsDescriptor, itemsByTab, questions, paneWidth);
+		for (const tab of tabs) {
+			tab.preview.setGlobalLeftWidth(globalLeftWidth);
+		}
+	}
+
+	private buildSubmitPicker(): SubmitPicker | undefined {
+		return this.isMulti ? new SubmitPicker(this.theme) : undefined;
+	}
+
+	private buildTabBar(): TabBar | undefined {
+		return this.isMulti ? new TabBar(this.theme) : undefined;
+	}
+
+	private buildHeightComputers(tabs: ReadonlyArray<TabComponents>): HeightComputers {
+		const global = (width: number): number => {
+			let max = 0;
+			for (const tab of tabs) {
+				const h = tab.bodyHeights(width).max;
+				if (h > max) max = h;
+			}
+			return Math.max(1, max);
+		};
+		const current = (width: number): number => {
+			const idx = Math.min(this.getCurrentTab(), tabs.length - 1);
+			return Math.max(0, tabs[idx]?.bodyHeights(width).current ?? 0);
+		};
+		return { global, current };
+	}
+
+	private pickInitialActivePreview(tabs: ReadonlyArray<TabComponents>): StatefulView<PreviewPaneProps> {
+		const idx = selectActivePreviewPaneIndex(this.initialState.currentTab, this.questions.length);
+		return tabs[idx]?.preview ?? tabs[0]!.preview;
+	}
+
+	private buildDialog(
+		tabs: ReadonlyArray<TabComponents>,
+		submitPicker: SubmitPicker | undefined,
+		tabBar: TabBar | undefined,
+		heights: HeightComputers,
+	): DialogView {
+		return new DialogView(
+			{
+				theme: this.theme,
+				questions: this.questions,
+				tabBar,
+				notesInput: this.notesInput,
+				chatRow: this.chatRow,
+				isMulti: this.isMulti,
+				tabsByIndex: tabs,
+				submitPicker,
+				getBodyHeight: heights.global,
+				getCurrentBodyHeight: heights.current,
+				getTerminalRows: this.getTerminalRows,
+			},
+			{ state: this.initialState, activePreviewPane: this.pickInitialActivePreview(tabs) },
+		);
+	}
+
+	private buildGlobalBindings(
+		dialog: DialogView,
+		submitPicker: SubmitPicker | undefined,
+		tabBar: TabBar | undefined,
+	): ReadonlyArray<BoundGlobalBinding> {
+		return [
+			globalBinding({ component: dialog, select: selectDialogProps }),
+			globalBinding({ component: this.chatRow, select: selectChatRowProps }),
+			...(submitPicker ? [globalBinding({ component: submitPicker, select: selectSubmitPickerProps })] : []),
+			...(tabBar ? [globalBinding({ component: tabBar, select: selectTabBarProps })] : []),
+		];
+	}
+
+	private buildPerTabBindings(): ReadonlyArray<BoundPerTabBinding> {
+		return [
+			perTabBinding({
+				resolve: (tab) => tab.optionList,
+				predicate: isActiveTab,
+				select: selectOptionListProps,
+			}),
+			perTabBinding({
+				resolve: (tab) => tab.preview,
+				predicate: isActiveTab,
+				select: selectPreviewPaneProps,
+			}),
+			perTabBinding({
+				resolve: (tab) => tab.multiSelect,
+				select: selectMultiSelectProps,
+			}),
+		];
+	}
+
+	private buildAdapter(
+		tabs: ReadonlyArray<TabComponents>,
+		globalBindings: ReadonlyArray<BoundGlobalBinding>,
+		perTabBindings: ReadonlyArray<BoundPerTabBinding>,
+	): QuestionnairePropsAdapter {
+		return new QuestionnairePropsAdapter({
+			tui: this.tui,
+			questions: this.questions,
+			itemsByTab: this.itemsByTab,
+			tabsByIndex: tabs,
+			inlineInput: this.inlineInput,
+			globalBindings,
+			perTabBindings,
+			extraInvalidatables: [this.notesInput],
+		});
+	}
+
+	private handle(adapter: QuestionnairePropsAdapter, dialog: DialogView): QuestionnaireBuilt {
+		return {
+			adapter,
+			notesInput: this.notesInput,
+			inlineInput: this.inlineInput,
+			render: (w) => dialog.render(w),
+			invalidate: () => adapter.invalidate(),
+		};
+	}
+}

--- a/packages/ask-user-question/state/i18n-bridge.ts
+++ b/packages/ask-user-question/state/i18n-bridge.ts
@@ -1,0 +1,52 @@
+/**
+ * i18n bridge for rpiv-ask-user-question — single thin import surface so every
+ * call site routes through one place. Backed by `@juicesharp/rpiv-i18n`'s SDK
+ * when available; degrades to canonical-English fallbacks when not.
+ *
+ * - `t(key, fallback)` is `scope("@juicesharp/rpiv-ask-user-question")` if the
+ *   SDK is installed (live `/languages` updates propagate). If the SDK is
+ *   missing (standalone install without rpiv-i18n), `t` is an identity
+ *   passthrough that returns the inline English fallback at every call site,
+ *   so the extension stays online with English UI.
+ * - `displayLabel(kind)` resolves a sentinel kind to its locale-aware label,
+ *   with the canonical English `ROW_INTENT_META[kind].label` as fallback so
+ *   nothing renders blank if the namespace isn't registered.
+ *
+ * Strings are registered ONCE at extension load (see ../index.ts). Call sites
+ * MUST use this module at render time — never bake the result into a top-level
+ * `const X = displayLabel(...)`.
+ *
+ * Reserved-label validation stays English-locked: `RESERVED_LABEL_SET` checks
+ * the canonical `ROW_INTENT_META[kind].label`, never `displayLabel(kind)`.
+ */
+
+import { ROW_INTENT_META, type SentinelKind } from "./row-intent.js";
+
+export const I18N_NAMESPACE = "@juicesharp/rpiv-ask-user-question";
+
+type ScopeFn = (key: string, fallback: string) => string;
+type I18nSDK = { scope: (namespace: string) => ScopeFn };
+
+// Prefer the live SDK if installed: closures it returns track the active
+// locale, so /languages picker propagates to our render call sites. If the
+// SDK isn't installed (standalone install of this extension without
+// rpiv-i18n), the dynamic import fails, every t(key, fallback) returns the
+// canonical English literal, and the extension stays online.
+//
+// Top-level await is required so a synchronous `t(...)` call from any
+// downstream module sees the resolved scope; ESM module loading awaits this
+// before evaluating any importer.
+let scopeImpl: ScopeFn;
+try {
+	const i18nModule = "@juicesharp/rpiv-i18n";
+	const sdk = (await import(i18nModule)) as I18nSDK;
+	scopeImpl = sdk.scope(I18N_NAMESPACE);
+} catch {
+	scopeImpl = (_key, fallback) => fallback;
+}
+
+export const t: ScopeFn = scopeImpl;
+
+export function displayLabel(kind: SentinelKind): string {
+	return t(`sentinel.${kind}`, ROW_INTENT_META[kind].label);
+}

--- a/packages/ask-user-question/state/key-router.ts
+++ b/packages/ask-user-question/state/key-router.ts
@@ -1,0 +1,292 @@
+import { Key, matchesKey } from "@earendil-works/pi-tui";
+import type { QuestionAnswer } from "../tool/types.js";
+import { ROW_INTENT_META } from "./row-intent.js";
+import type { QuestionnaireRuntime, QuestionnaireState } from "./state.js";
+
+const KEYBIND_UP = "tui.select.up";
+const KEYBIND_DOWN = "tui.select.down";
+const KEYBIND_CONFIRM = "tui.select.confirm";
+const KEYBIND_CANCEL = "tui.select.cancel";
+
+const NOTES_ACTIVATE_KEY = "n";
+const SPACE_KEY = " ";
+
+export type QuestionnaireAction =
+	| { kind: "nav"; nextIndex: number }
+	| { kind: "tab_switch"; nextTab: number }
+	| { kind: "confirm"; answer: QuestionAnswer; autoAdvanceTab?: number }
+	| { kind: "toggle"; index: number }
+	| { kind: "multi_confirm"; selected: string[]; autoAdvanceTab?: number }
+	| { kind: "cancel" }
+	| { kind: "notes_enter" }
+	| { kind: "notes_exit" }
+	| { kind: "submit" }
+	| { kind: "submit_nav"; nextIndex: 0 | 1 }
+	| { kind: "focus_chat" }
+	/**
+	 * Carries the target index so UP/DOWN form a continuous cycle through
+	 * `[chat, option0, …, optionLast]`.
+	 */
+	| { kind: "focus_options"; optionIndex: number }
+	| { kind: "notes_forward"; data: string }
+	/** Flip `state.collapsed`. Always available, regardless of inner mode (see top intercept in `routeKey`). */
+	| { kind: "toggle_collapsed" }
+	| { kind: "ignore" };
+
+export interface QuestionnaireKeybindings {
+	matches(data: string, name: string): boolean;
+}
+
+export function wrapTab(index: number, total: number): number {
+	if (total <= 0) return 0;
+	return ((index % total) + total) % total;
+}
+
+export function allAnswered(state: QuestionnaireState, runtime: QuestionnaireRuntime): boolean {
+	if (runtime.questions.length === 0) return false;
+	for (let i = 0; i < runtime.questions.length; i++) {
+		if (!state.answers.has(i)) return false;
+	}
+	return true;
+}
+
+function totalTabs(runtime: QuestionnaireRuntime): number {
+	return runtime.isMulti ? runtime.questions.length + 1 : 1;
+}
+
+function computeAutoAdvanceTab(state: QuestionnaireState, runtime: QuestionnaireRuntime): number | undefined {
+	if (!runtime.isMulti) return undefined;
+	if (state.currentTab < runtime.questions.length - 1) return state.currentTab + 1;
+	return runtime.questions.length;
+}
+
+function buildSingleSelectAnswer(state: QuestionnaireState, runtime: QuestionnaireRuntime): QuestionAnswer | null {
+	const q = runtime.questions[state.currentTab];
+	if (!q) return null;
+
+	// Chat sentinel takes priority over inputMode: when chatFocused=true, the host overrides
+	// currentItem() to return the chat sentinel even if inputMode is still true (e.g. user
+	// navigated from "Type something." and DOWN focused the chat row).
+	const item = runtime.currentItem;
+	if (item?.kind === "chat") {
+		return {
+			questionIndex: state.currentTab,
+			question: q.question,
+			kind: "chat",
+			answer: item.label,
+		};
+	}
+
+	if (state.inputMode) {
+		const label = runtime.inputBuffer;
+		return {
+			questionIndex: state.currentTab,
+			question: q.question,
+			kind: "custom",
+			answer: label.length > 0 ? label : null,
+		};
+	}
+	if (!item) return null;
+	if (item.kind === "other") {
+		return null;
+	}
+	if (item.kind === "next") {
+		return null;
+	}
+	return {
+		questionIndex: state.currentTab,
+		question: q.question,
+		kind: "option",
+		answer: item.label,
+	};
+}
+
+function buildMultiSelected(state: QuestionnaireState, runtime: QuestionnaireRuntime): string[] {
+	const q = runtime.questions[state.currentTab];
+	if (!q) return [];
+	const out: string[] = [];
+	for (let i = 0; i < q.options.length; i++) {
+		if (state.multiSelectChecked.has(i)) {
+			const label = q.options[i]?.label;
+			if (typeof label === "string") out.push(label);
+		}
+	}
+	return out;
+}
+
+function tabSwitchAction(
+	data: string,
+	state: QuestionnaireState,
+	runtime: QuestionnaireRuntime,
+): QuestionnaireAction | null {
+	if (!runtime.isMulti) return null;
+	const total = totalTabs(runtime);
+	if (matchesKey(data, Key.tab) || matchesKey(data, Key.right)) {
+		return { kind: "tab_switch", nextTab: wrapTab(state.currentTab + 1, total) };
+	}
+	if (matchesKey(data, Key.shift("tab")) || matchesKey(data, Key.left)) {
+		return { kind: "tab_switch", nextTab: wrapTab(state.currentTab - 1, total) };
+	}
+	return null;
+}
+
+// DOWN at the last item emits focus_chat so the cycle [chat, option0, …, optionLast] wraps.
+function nextNavOnDown(state: QuestionnaireState, runtime: QuestionnaireRuntime): QuestionnaireAction {
+	if (runtime.items.length > 0 && state.optionIndex === runtime.items.length - 1) {
+		return { kind: "focus_chat" };
+	}
+	return { kind: "nav", nextIndex: wrapTab(state.optionIndex + 1, Math.max(1, runtime.items.length)) };
+}
+
+// UP at the top item emits focus_chat (symmetric with nextNavOnDown).
+function prevNavOnUp(state: QuestionnaireState, runtime: QuestionnaireRuntime): QuestionnaireAction {
+	if (runtime.items.length > 0 && state.optionIndex === 0) {
+		return { kind: "focus_chat" };
+	}
+	return { kind: "nav", nextIndex: wrapTab(state.optionIndex - 1, Math.max(1, runtime.items.length)) };
+}
+
+export function routeKey(data: string, state: QuestionnaireState, runtime: QuestionnaireRuntime): QuestionnaireAction {
+	const kb = runtime.keybindings;
+
+	// Collapse/expand toggle is a UI-level affordance — intercepted at the top so it
+	// works from every inner state (notes, inputMode, chat, submit tab, multi-select)
+	// without reaching any branch that would otherwise consume the keystroke. The
+	// questionnaire stays in pi-tui's overlay stack with focus while collapsed, so the
+	// expand key never falls through to a lower overlay (e.g. `/btw`) — that's why we
+	// toggle state instead of calling `OverlayHandle.setHidden(true)`.
+	//
+	// Ctrl+] (GS, 0x1d): chosen after Alt+Tab (OS-reserved on macOS), Ctrl+P (collides
+	// with pi-coding-agent "cycle model" + the user's virtual terminal), and F2 (taken
+	// by macOS function-key behavior) were all eliminated. Ctrl+] is free in every
+	// mainstream macOS terminal (Terminal.app, iTerm2, Warp), every multiplexer (tmux,
+	// zellij, screen — none use it as a prefix), and the legacy telnet/ssh escape role
+	// doesn't apply because our overlay runs in-process.
+	if (matchesKey(data, Key.ctrl("]"))) return { kind: "toggle_collapsed" };
+
+	// Collapsed-mode lockout: while collapsed, swallow every keystroke except cancel so
+	// the user can read the now-uncovered transcript without accidentally mutating
+	// answers or notes. The collapse toggle itself is already handled above.
+	if (state.collapsed) {
+		if (kb.matches(data, KEYBIND_CANCEL)) return { kind: "cancel" };
+		return { kind: "ignore" };
+	}
+
+	if (state.notesVisible) {
+		if (kb.matches(data, KEYBIND_CANCEL)) return { kind: "notes_exit" };
+		if (kb.matches(data, KEYBIND_CONFIRM)) return { kind: "notes_exit" };
+		return { kind: "notes_forward", data };
+	}
+
+	if (state.chatFocused) {
+		if (kb.matches(data, KEYBIND_CANCEL)) return { kind: "cancel" };
+		if (kb.matches(data, KEYBIND_CONFIRM)) {
+			const answer = buildSingleSelectAnswer(state, runtime);
+			if (!answer) return { kind: "ignore" };
+			return { kind: "confirm", answer, autoAdvanceTab: computeAutoAdvanceTab(state, runtime) };
+		}
+		// Continuous cycle: UP from chat → bottom of options (last navigable row), DOWN from
+		// chat → top of options (option 0). Symmetric with UP-at-top → focus_chat and
+		// DOWN-at-bottom → focus_chat below; together they form one wrapping cycle through
+		// `[chat, option0, …, optionLast]`.
+		if (kb.matches(data, KEYBIND_UP)) {
+			const last = Math.max(0, runtime.items.length - 1);
+			return { kind: "focus_options", optionIndex: last };
+		}
+		if (kb.matches(data, KEYBIND_DOWN)) {
+			return { kind: "focus_options", optionIndex: 0 };
+		}
+		const tab = tabSwitchAction(data, state, runtime);
+		if (tab) return tab;
+		return { kind: "ignore" };
+	}
+
+	if (state.inputMode) {
+		if (kb.matches(data, KEYBIND_CONFIRM)) {
+			const answer = buildSingleSelectAnswer(state, runtime);
+			if (!answer) return { kind: "ignore" };
+			return { kind: "confirm", answer, autoAdvanceTab: computeAutoAdvanceTab(state, runtime) };
+		}
+		if (kb.matches(data, KEYBIND_CANCEL)) return { kind: "cancel" };
+		if (kb.matches(data, KEYBIND_UP)) {
+			return prevNavOnUp(state, runtime);
+		}
+		if (kb.matches(data, KEYBIND_DOWN)) {
+			return nextNavOnDown(state, runtime);
+		}
+		return { kind: "ignore" };
+	}
+
+	if (runtime.isMulti && state.currentTab === runtime.questions.length) {
+		if (kb.matches(data, KEYBIND_CANCEL)) return { kind: "cancel" };
+		const tab = tabSwitchAction(data, state, runtime);
+		if (tab) return tab;
+		if (kb.matches(data, KEYBIND_UP) || kb.matches(data, KEYBIND_DOWN)) {
+			const delta = kb.matches(data, KEYBIND_DOWN) ? 1 : -1;
+			const next = wrapTab(state.submitChoiceIndex + delta, 2);
+			return { kind: "submit_nav", nextIndex: (next === 1 ? 1 : 0) as 0 | 1 };
+		}
+		if (kb.matches(data, KEYBIND_CONFIRM)) {
+			// D1 (revised): Submit always submits; Cancel always cancels. The warning header
+			// is informational only — `allAnswered(state)` no longer gates submission. Partial
+			// answers flow through `orderedAnswers()` in the host.
+			return state.submitChoiceIndex === 1 ? { kind: "cancel" } : { kind: "submit" };
+		}
+		return { kind: "ignore" };
+	}
+
+	const tab = tabSwitchAction(data, state, runtime);
+	if (tab) return tab;
+
+	const q = runtime.questions[state.currentTab];
+	if (!q) return { kind: "ignore" };
+
+	if (data === NOTES_ACTIVATE_KEY && !q.multiSelect && state.focusedOptionHasPreview) {
+		return { kind: "notes_enter" };
+	}
+
+	if (kb.matches(data, KEYBIND_UP)) {
+		return prevNavOnUp(state, runtime);
+	}
+	if (kb.matches(data, KEYBIND_DOWN)) {
+		return nextNavOnDown(state, runtime);
+	}
+
+	if (q.multiSelect) {
+		const focusedKind = runtime.currentItem?.kind;
+		const focusedMeta = focusedKind ? ROW_INTENT_META[focusedKind] : undefined;
+		// Space toggles the focused row's checkbox. Suppressed on rows whose META declares
+		// `blocksMultiToggle` (the Next sentinel) — Next is not a real option and has no
+		// checked/unchecked state.
+		if (data === SPACE_KEY) {
+			if (focusedMeta?.blocksMultiToggle) return { kind: "ignore" };
+			return { kind: "toggle", index: state.optionIndex };
+		}
+		if (kb.matches(data, KEYBIND_CONFIRM)) {
+			// Enter on a regular row toggles (matching Space) — committing the question is now
+			// gated behind explicit focus on a row whose META declares `autoSubmitsInMulti`
+			// (the Next sentinel), so Enter on options is a no-cost way to flip checkboxes
+			// without leaving the keyboard home row.
+			if (!focusedMeta?.autoSubmitsInMulti) return { kind: "toggle", index: state.optionIndex };
+			// Enter on Next: carry autoAdvanceTab so the host can advance to the next tab in
+			// multi-question mode, OR submit the dialog in single-question mode
+			// (autoAdvanceTab === undefined when !isMulti). Without this, a single multi-select
+			// question would have no way to commit at all.
+			return {
+				kind: "multi_confirm",
+				selected: buildMultiSelected(state, runtime),
+				autoAdvanceTab: computeAutoAdvanceTab(state, runtime),
+			};
+		}
+		if (kb.matches(data, KEYBIND_CANCEL)) return { kind: "cancel" };
+		return { kind: "ignore" };
+	}
+
+	if (kb.matches(data, KEYBIND_CONFIRM)) {
+		const answer = buildSingleSelectAnswer(state, runtime);
+		if (!answer) return { kind: "ignore" };
+		return { kind: "confirm", answer, autoAdvanceTab: computeAutoAdvanceTab(state, runtime) };
+	}
+	if (kb.matches(data, KEYBIND_CANCEL)) return { kind: "cancel" };
+	return { kind: "ignore" };
+}

--- a/packages/ask-user-question/state/questionnaire-session.ts
+++ b/packages/ask-user-question/state/questionnaire-session.ts
@@ -1,0 +1,202 @@
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { getKeybindings, type Input } from "@earendil-works/pi-tui";
+import type { QuestionData, QuestionnaireResult, QuestionParams } from "../tool/types.js";
+import type { WrappingSelectItem } from "../view/components/wrapping-select.js";
+import { COLLAPSED_HINT } from "../view/dialog-builder.js";
+import type { QuestionnairePropsAdapter } from "../view/props-adapter.js";
+import { buildQuestionnaire } from "./build-questionnaire.js";
+import { displayLabel, t } from "./i18n-bridge.js";
+import { type QuestionnaireAction, routeKey } from "./key-router.js";
+import { computeFocusedOptionHasPreview } from "./selectors/derivations.js";
+import type { QuestionnaireRuntime, QuestionnaireState } from "./state.js";
+import { type ApplyContext, type Effect, reduce } from "./state-reducer.js";
+
+// Module-level constant; reused for cursor-end mutations after setValue rehydration.
+// Ctrl-E → tui.editor.cursorLineEnd (public path; pi-tui keybindings.js:25-28).
+const CURSOR_END = "\x05";
+
+export interface QuestionnaireSessionConfig {
+	tui: { terminal: { columns: number; rows: number }; requestRender(): void };
+	theme: Theme;
+	params: QuestionParams;
+	itemsByTab: WrappingSelectItem[][];
+	done: (result: QuestionnaireResult) => void;
+}
+
+export interface QuestionnaireSessionComponent {
+	render(width: number): string[];
+	invalidate(): void;
+	handleInput(data: string): void;
+}
+
+function initialState(): QuestionnaireState {
+	return {
+		currentTab: 0,
+		optionIndex: 0,
+		inputMode: false,
+		notesVisible: false,
+		chatFocused: false,
+		answers: new Map(),
+		multiSelectChecked: new Set(),
+		notesByTab: new Map(),
+		focusedOptionHasPreview: false,
+		submitChoiceIndex: 0,
+		notesDraft: "",
+		collapsed: false,
+	};
+}
+
+/**
+ * Slim runtime: owns the canonical state cell, the input-buffer cell, the
+ * two-pass `notesVisible` dispatch loop, and the effect runner. State
+ * transitions go through the pure `reduce` reducer; UI fan-out goes through
+ * the `QuestionnairePropsAdapter` produced by `buildQuestionnaire`.
+ */
+export class QuestionnaireSession {
+	private state: QuestionnaireState = initialState();
+
+	private readonly questions: readonly QuestionData[];
+	private readonly isMulti: boolean;
+	private readonly itemsByTab: WrappingSelectItem[][];
+
+	private readonly notesInput: Input;
+	private readonly inlineInput: Input;
+	private readonly viewAdapter: QuestionnairePropsAdapter;
+
+	private readonly tui: QuestionnaireSessionConfig["tui"];
+	private readonly done: QuestionnaireSessionConfig["done"];
+
+	readonly component: QuestionnaireSessionComponent;
+
+	constructor(config: QuestionnaireSessionConfig) {
+		this.tui = config.tui;
+		this.done = config.done;
+		this.questions = config.params.questions;
+		this.isMulti = this.questions.length > 1;
+		this.itemsByTab = config.itemsByTab;
+		// Seed from the focused option at start; the reducer keeps it in sync via withFocusedOptionHasPreview.
+		this.state = { ...this.state, focusedOptionHasPreview: computeFocusedOptionHasPreview(this.questions, 0, 0) };
+
+		const built = buildQuestionnaire({
+			tui: this.tui,
+			theme: config.theme,
+			questions: this.questions,
+			itemsByTab: this.itemsByTab,
+			isMulti: this.isMulti,
+			initialState: this.state,
+			getCurrentTab: () => this.state.currentTab,
+		});
+
+		this.notesInput = built.notesInput;
+		this.inlineInput = built.inlineInput;
+		this.viewAdapter = built.adapter;
+
+		const theme = config.theme;
+		// Collapsed render: a single dim row at the bottom of the overlay. pi-tui sizes
+		// the overlay to `min(lines.length, maxHeight)`, so returning one line shrinks
+		// the bottom-anchored overlay from full-height to one row and the transcript
+		// behind it becomes readable (#47). The overlay stays focused and in the
+		// stack, so Ctrl+] still routes here to expand.
+		const collapsedRender = (_width: number): string[] => [
+			theme.fg("dim", ` ${t("hint.expand_line", COLLAPSED_HINT)} `),
+		];
+
+		this.component = {
+			render: (width) => (this.state.collapsed ? collapsedRender(width) : built.render(width)),
+			invalidate: built.invalidate,
+			handleInput: (data) => this.dispatch(data),
+		};
+
+		this.viewAdapter.apply(this.state);
+	}
+
+	dispatch(data: string): void {
+		const action = routeKey(data, this.state, this.runtime());
+		if (action.kind === "ignore") {
+			this.handleIgnoreInline(data);
+			return;
+		}
+		this.commit(action);
+	}
+
+	private commit(action: QuestionnaireAction): void {
+		const result = reduce(this.state, action, this.applyContext());
+		this.state = result.state;
+		for (const effect of result.effects) this.runEffect(effect);
+		this.state = this.mirrorNotesDraft(this.state);
+		this.viewAdapter.apply(this.state);
+	}
+
+	private mirrorNotesDraft(s: QuestionnaireState): QuestionnaireState {
+		const draft = this.notesInput.getValue();
+		return s.notesDraft === draft ? s : { ...s, notesDraft: draft };
+	}
+
+	private runEffect(effect: Effect): void {
+		switch (effect.kind) {
+			case "set_input_buffer":
+				this.inlineInput.setValue(effect.value);
+				this.inlineInput.handleInput(CURSOR_END);
+				return;
+			case "clear_input_buffer":
+				this.inlineInput.setValue("");
+				return;
+			case "set_notes_value":
+				this.notesInput.setValue(effect.value);
+				return;
+			case "set_notes_focused":
+				this.notesInput.focused = effect.focused;
+				return;
+			case "forward_notes_keystroke":
+				this.notesInput.handleInput(effect.data);
+				return;
+			case "done":
+				this.done(effect.result);
+				return;
+		}
+	}
+
+	/**
+	 * Per-keystroke `ignore` fast path: delegates to the headless `inlineInput`
+	 * Input so bracketed-paste accumulator (`input.js:33-63`) and Kitty CSI-u
+	 * decode (`input.js:155-163`) take effect. Cursor is NOT force-reset here —
+	 * doing so would corrupt split-chunk pastes (a `\x05` byte mid-paste lands
+	 * verbatim in `pasteBuffer` and survives `handlePaste`'s narrow strip).
+	 * Cursor advances naturally via `insertCharacter` on typing/paste; cursor-
+	 * movement keys (Left/Right/Home/End/word-jumps) are now functional, with
+	 * the always-end visual cursor marker drawn independently by
+	 * `WrappingSelect.renderInlineInputRow`. `viewAdapter.apply` is called
+	 * directly without a reducer round-trip — preserves the D3 fast-path
+	 * latency profile from Phase 11.
+	 */
+	private handleIgnoreInline(data: string): void {
+		if (!this.state.inputMode) return;
+		this.inlineInput.handleInput(data);
+		this.viewAdapter.apply(this.state);
+	}
+
+	private runtime(): QuestionnaireRuntime {
+		return {
+			keybindings: getKeybindings(),
+			inputBuffer: this.inlineInput.getValue(),
+			questions: this.questions,
+			isMulti: this.isMulti,
+			currentItem: this.currentItem(),
+			items: this.itemsByTab[this.state.currentTab] ?? [],
+		};
+	}
+
+	private applyContext(): ApplyContext {
+		return {
+			questions: this.questions,
+			itemsByTab: this.itemsByTab,
+		};
+	}
+
+	private currentItem(): WrappingSelectItem | undefined {
+		if (this.state.chatFocused) return { kind: "chat", label: displayLabel("chat") };
+		const arr = this.itemsByTab[this.state.currentTab] ?? [];
+		if (this.state.optionIndex < arr.length) return arr[this.state.optionIndex];
+		return { kind: "chat", label: displayLabel("chat") };
+	}
+}

--- a/packages/ask-user-question/state/row-intent.ts
+++ b/packages/ask-user-question/state/row-intent.ts
@@ -1,0 +1,159 @@
+import type { QuestionData } from "../tool/types.js";
+import type { WrappingSelectItem } from "../view/components/wrapping-select.js";
+
+/**
+ * Row kind discriminator. Single source of truth — derived from the runtime
+ * `WrappingSelectItem` union (`wrapping-select.ts:18-22`) so adding a new
+ * variant there forces a `ROW_INTENT_META` entry here (compile-time
+ * exhaustiveness via `Record<RowKind, …>`).
+ */
+export type RowKind = WrappingSelectItem["kind"];
+
+/**
+ * Sentinel kinds — the subset of `RowKind` representing protocol-driven rows
+ * (vs author-defined `option` rows). The auto-append walker, the reserved-label
+ * derivation, and `LABELS_BY_KIND` consumers iterate this list.
+ */
+export type SentinelKind = Exclude<RowKind, "option">;
+export const SENTINEL_KINDS: readonly SentinelKind[] = ["other", "chat", "next"];
+
+/**
+ * Per-kind static metadata. Pure data — no closures, no per-kind handler
+ * functions. Behavior-bearing branches (answer construction in
+ * `key-router.ts:69-99`, the Next-row render block in `multi-select-view.ts`,
+ * and the inline-Input render branch in `wrapping-select.ts`) keep their
+ * exhaustive switches and READ flags from this table.
+ *
+ * Adding a new sentinel:
+ *   1. Add the variant to `WrappingSelectItem` (`wrapping-select.ts:18-22`).
+ *   2. Add an entry here. Compile fails until both edits are present.
+ *   3. (If user-facing) author wherever the row is synthesized — typically
+ *      `buildItemsForQuestion` for main-list residents, or the `chatList`
+ *      construction site for non-main-list rows.
+ *
+ * Field semantics:
+ * - `label` — user-facing string. For `option` it's an empty placeholder
+ *   (per-instance labels come from `QuestionData.options[i].label`); every
+ *   sentinel uses its META entry as the single source of truth.
+ * - `reserved` — author-facing labels matching this string trigger
+ *   `reserved_label` at validation time. `RESERVED_LABEL_SET` is derived.
+ * - `livesInMainList` — true iff the row appears in `itemsByTab[i]`. Chat
+ *   lives in its own `chatList` (`questionnaire-session.ts:95`) so its row
+ *   never enters the main list.
+ * - `numbered` — true iff the row contributes to the main-list numbering
+ *   offset that `chatNumberingFor` reads. Multi-select Next is the only
+ *   numberable=false row that lives in the list; chat is numbered=true but
+ *   `livesInMainList=false` so the flag is moot for chat.
+ * - `activatesInputMode` — true iff focusing the row should toggle
+ *   `state.inputMode = true`. Read by `state-reducer.ts` `nav` /
+ *   `focus_options` cases.
+ * - `blocksMultiToggle` — in multiSelect mode, Space (and Enter-as-toggle)
+ *   on this row is suppressed. The Next sentinel is the only true.
+ * - `autoSubmitsInMulti` — in multiSelect mode, Enter on this row commits
+ *   the question (emits `multi_confirm`). The Next sentinel is the only true.
+ * - `autoAppendOnSingleSelectNoPreview` — `buildItemsForQuestion` appends
+ *   this row when the question is single-select AND no option carries a
+ *   `preview`. The "other" sentinel is the only true.
+ * - `autoAppendOnMultiSelect` — `buildItemsForQuestion` appends this row
+ *   when the question is multi-select. The Next sentinel is the only true.
+ */
+export interface RowIntentMeta {
+	label: string;
+	reserved: boolean;
+	livesInMainList: boolean;
+	numbered: boolean;
+	activatesInputMode: boolean;
+	blocksMultiToggle: boolean;
+	autoSubmitsInMulti: boolean;
+	autoAppendOnSingleSelectNoPreview: boolean;
+	autoAppendOnMultiSelect: boolean;
+}
+
+export const ROW_INTENT_META: Record<RowKind, RowIntentMeta> = {
+	option: {
+		label: "",
+		reserved: false,
+		livesInMainList: true,
+		numbered: true,
+		activatesInputMode: false,
+		blocksMultiToggle: false,
+		autoSubmitsInMulti: false,
+		autoAppendOnSingleSelectNoPreview: false,
+		autoAppendOnMultiSelect: false,
+	},
+	other: {
+		label: "Type something.",
+		reserved: true,
+		livesInMainList: true,
+		numbered: true,
+		activatesInputMode: true,
+		blocksMultiToggle: false,
+		autoSubmitsInMulti: false,
+		autoAppendOnSingleSelectNoPreview: true,
+		autoAppendOnMultiSelect: false,
+	},
+	chat: {
+		label: "Chat about this",
+		reserved: true,
+		livesInMainList: false,
+		numbered: true,
+		activatesInputMode: false,
+		blocksMultiToggle: false,
+		autoSubmitsInMulti: false,
+		autoAppendOnSingleSelectNoPreview: false,
+		autoAppendOnMultiSelect: false,
+	},
+	next: {
+		label: "Next",
+		reserved: true,
+		livesInMainList: true,
+		numbered: false,
+		activatesInputMode: false,
+		blocksMultiToggle: true,
+		autoSubmitsInMulti: true,
+		autoAppendOnSingleSelectNoPreview: false,
+		autoAppendOnMultiSelect: true,
+	},
+};
+
+/**
+ * Kind-keyed label view. `option` is excluded — its label is per-instance,
+ * not per-kind. `types.ts#SENTINEL_LABELS` re-sources from here.
+ */
+export const LABELS_BY_KIND: { readonly [K in SentinelKind]: string } = {
+	other: ROW_INTENT_META.other.label,
+	chat: ROW_INTENT_META.chat.label,
+	next: ROW_INTENT_META.next.label,
+};
+
+/**
+ * Reserved-label set for runtime validation. Includes "Other" (a model-conditioned
+ * label that has no runtime kind) plus every sentinel with `reserved: true`.
+ */
+export const RESERVED_LABEL_SET: ReadonlySet<string> = new Set<string>([
+	"Other",
+	...SENTINEL_KINDS.filter((k) => ROW_INTENT_META[k].reserved).map((k) => ROW_INTENT_META[k].label),
+]);
+
+/**
+ * Walk the META table to synthesize sentinel rows for one question. The two
+ * append predicates are mutually exclusive in practice (`multiSelect` vs
+ * `!multiSelect && !hasAnyPreview`) but the walker doesn't enforce that —
+ * adding a third bucket only requires a new META flag.
+ *
+ * Returns sentinel descriptors in declaration order of `SENTINEL_KINDS`. The
+ * caller wraps each with the `WrappingSelectItem` shape (kind + label).
+ */
+export function sentinelsToAppend(question: QuestionData, hasAnyPreview: boolean): SentinelKind[] {
+	const out: SentinelKind[] = [];
+	for (const k of SENTINEL_KINDS) {
+		const meta = ROW_INTENT_META[k];
+		if (!meta.livesInMainList) continue;
+		if (question.multiSelect === true) {
+			if (meta.autoAppendOnMultiSelect) out.push(k);
+		} else {
+			if (meta.autoAppendOnSingleSelectNoPreview && !hasAnyPreview) out.push(k);
+		}
+	}
+	return out;
+}

--- a/packages/ask-user-question/state/selectors/contract.ts
+++ b/packages/ask-user-question/state/selectors/contract.ts
@@ -1,0 +1,24 @@
+import type { QuestionData } from "../../tool/types.js";
+import type { PreviewPaneProps } from "../../view/components/preview/preview-pane.js";
+import type { WrappingSelectItem } from "../../view/components/wrapping-select.js";
+import type { ActiveView, StatefulView } from "../../view/stateful-view.js";
+import type { TabComponents } from "../../view/tab-components.js";
+import type { QuestionnaireState } from "../state.js";
+
+export interface BindingContext {
+	readonly questions: readonly QuestionData[];
+	readonly itemsByTab: ReadonlyArray<readonly WrappingSelectItem[]>;
+	readonly totalQuestions: number;
+	readonly activeView: ActiveView;
+	readonly inputBuffer: string;
+	readonly inputCursorOffset: number | undefined;
+	readonly activePreviewPane: StatefulView<PreviewPaneProps>;
+}
+
+export interface PerTabBindingContext extends BindingContext {
+	readonly tab: TabComponents;
+	readonly i: number;
+}
+
+export type GlobalSelector<P> = (state: QuestionnaireState, ctx: BindingContext) => P;
+export type PerTabSelector<P> = (state: QuestionnaireState, ctx: PerTabBindingContext) => P;

--- a/packages/ask-user-question/state/selectors/derivations.ts
+++ b/packages/ask-user-question/state/selectors/derivations.ts
@@ -1,0 +1,91 @@
+import type { QuestionAnswer, QuestionData } from "../../tool/types.js";
+import type { WrappingSelectItem } from "../../view/components/wrapping-select.js";
+import { ROW_INTENT_META } from "../row-intent.js";
+
+/**
+ * Pure derivation: does the option focused by `(currentTab, optionIndex)` carry a
+ * non-empty `preview` string? Mode gates (chat focus, notes mode, multiSelect) layer
+ * on top via dispatch branches; this predicate is intentionally mode-agnostic.
+ */
+export function computeFocusedOptionHasPreview(
+	questions: readonly QuestionData[],
+	currentTab: number,
+	optionIndex: number,
+): boolean {
+	const q = questions[currentTab];
+	if (!q) return false;
+	const opt = q.options[optionIndex];
+	return !!opt && typeof opt.preview === "string" && opt.preview.length > 0;
+}
+
+/**
+ * Numbering for the chat row's WrappingSelect, computed from the active tab's items.
+ *
+ * The chat row lives in its own one-item WrappingSelect; the host calls this on every tab
+ * switch / selection update to keep the chat row's `N. ` label continuous with the visible
+ * numbered rows of the active tab. The shape `{ offset, total }` mirrors
+ * `WrappingSelect.setNumbering(numberStartOffset, totalItemsForNumbering)` directly.
+ */
+export function chatNumberingFor(items: readonly WrappingSelectItem[]): {
+	offset: number;
+	total: number;
+} {
+	// Count only the visible-numbered rows. The Next sentinel renders without a number
+	// (see MultiSelectView), so it must NOT advance the chat row's number — otherwise
+	// chat reads as "6." next to options labeled 1-4. Sourced from `ROW_INTENT_META[kind].numbered`
+	// so adding a new non-numbered kind is a single META edit.
+	const count = items.filter((i) => ROW_INTENT_META[i.kind].numbered).length;
+	return { offset: count, total: count + 1 };
+}
+
+/**
+ * Which row in the active tab should be marked as "previously confirmed"? Drives the
+ * `WrappingSelect` confirmed-row indicator (label + ` ✔`) when the user navigates back
+ * to a question they already answered. Returns `undefined` when no marker should be drawn —
+ * multi-select handles its own `[✔]` boxes via `multiSelectChecked`, `kind: "chat"` ends the
+ * dialog so the row can never be re-entered, and a missing/non-matching answer (defensive)
+ * silently skips the marker.
+ */
+export function selectConfirmedIndicator(
+	questions: readonly QuestionData[],
+	currentTab: number,
+	answers: ReadonlyMap<number, QuestionAnswer>,
+	items: readonly WrappingSelectItem[],
+): { index: number; labelOverride?: string } | undefined {
+	const q = questions[currentTab];
+	if (!q || q.multiSelect === true) return undefined;
+	const prior = answers.get(currentTab);
+	if (!prior || prior.kind === "chat") return undefined;
+	if (prior.kind === "custom") {
+		const otherIndex = items.findIndex((it) => it.kind === "other");
+		if (otherIndex < 0) return undefined;
+		return { index: otherIndex, labelOverride: prior.answer ?? "" };
+	}
+	if (prior.kind !== "option" || typeof prior.answer !== "string") return undefined;
+	const index = items.findIndex((it) => it.kind === "option" && it.label === prior.answer);
+	if (index < 0) return undefined;
+	return { index };
+}
+
+/**
+ * Index of the preview pane to display for the current tab. The Submit tab (currentTab ===
+ * questions.length) reuses the last question's pane purely for layout — the strategy
+ * machinery picks the right body component independently. Defensive against `totalQuestions === 0`.
+ */
+export function selectActivePreviewPaneIndex(currentTab: number, totalQuestions: number): number {
+	if (totalQuestions <= 0) return 0;
+	return Math.min(currentTab, totalQuestions - 1);
+}
+
+/**
+ * Items array for the active tab, with the same Submit-tab clamp as `selectActivePreviewPaneIndex`.
+ * Falls back to an empty array if the index lands outside the items array (defensive).
+ */
+export function selectActiveTabItems(
+	itemsByTab: ReadonlyArray<readonly WrappingSelectItem[]>,
+	currentTab: number,
+	totalQuestions: number,
+): readonly WrappingSelectItem[] {
+	const idx = selectActivePreviewPaneIndex(currentTab, totalQuestions);
+	return itemsByTab[idx] ?? [];
+}

--- a/packages/ask-user-question/state/selectors/focus.ts
+++ b/packages/ask-user-question/state/selectors/focus.ts
@@ -1,0 +1,19 @@
+import type { ActiveView } from "../../view/stateful-view.js";
+
+/**
+ * Discriminated focus selector — single source of truth for "which view owns
+ * focus this tick?" Priority order matches the dispatcher cascade
+ * (`key-router.ts:151-178`) and the reducer's defensive clears
+ * (`state-reducer.ts:104-126`).
+ *
+ * Priority: notes > submit > chat > options.
+ */
+export function selectActiveView(
+	state: { notesVisible: boolean; chatFocused: boolean; currentTab: number },
+	totalQuestions: number,
+): ActiveView {
+	if (state.notesVisible) return "notes";
+	if (state.currentTab === totalQuestions) return "submit";
+	if (state.chatFocused) return "chat";
+	return "options";
+}

--- a/packages/ask-user-question/state/selectors/projections.ts
+++ b/packages/ask-user-question/state/selectors/projections.ts
@@ -1,0 +1,84 @@
+import type { ChatRowViewProps } from "../../view/components/chat-row-view.js";
+import { MULTI_SUBMIT_LABEL, type MultiSelectViewProps } from "../../view/components/multi-select-view.js";
+import type { OptionListViewProps } from "../../view/components/option-list-view.js";
+import type { PreviewPaneProps } from "../../view/components/preview/preview-pane.js";
+import type { SubmitPickerProps } from "../../view/components/submit-picker.js";
+import type { TabBarProps } from "../../view/components/tab-bar.js";
+import type { DialogProps } from "../../view/dialog-builder.js";
+import { displayLabel } from "../i18n-bridge.js";
+import type { GlobalSelector, PerTabSelector } from "./contract.js";
+import { chatNumberingFor, selectActiveTabItems, selectConfirmedIndicator } from "./derivations.js";
+
+export const selectMultiSelectProps: PerTabSelector<MultiSelectViewProps> = (state, ctx) => {
+	const question = ctx.questions[ctx.i];
+	if (!question) return { rows: [], nextActive: false, nextLabel: displayLabel("next") };
+	const focused = ctx.activeView === "options";
+	const rows: { checked: boolean; active: boolean }[] = [];
+	for (let i = 0; i < question.options.length; i++) {
+		rows.push({
+			checked: state.multiSelectChecked.has(i),
+			active: focused && i === state.optionIndex,
+		});
+	}
+	const nextActive = focused && state.optionIndex === question.options.length;
+	const isLastQuestion = ctx.i === ctx.questions.length - 1;
+	const nextLabel = isLastQuestion ? MULTI_SUBMIT_LABEL : displayLabel("next");
+	return { rows, nextActive, nextLabel };
+};
+
+export const selectOptionListProps: PerTabSelector<OptionListViewProps> = (state, ctx) => {
+	const items = ctx.itemsByTab[ctx.i] ?? [];
+	const focused = ctx.activeView === "options";
+	const confirmed = selectConfirmedIndicator(ctx.questions, state.currentTab, state.answers, items);
+	return {
+		selectedIndex: state.optionIndex,
+		focused,
+		inputBuffer: ctx.inputBuffer,
+		inputCursorOffset: ctx.inputCursorOffset,
+		...(confirmed ? { confirmed } : {}),
+	};
+};
+
+export const selectSubmitPickerProps: GlobalSelector<SubmitPickerProps> = (state, ctx) => {
+	const focused = ctx.activeView === "submit";
+	return {
+		rows: [
+			{ active: focused && state.submitChoiceIndex === 0 },
+			{ active: focused && state.submitChoiceIndex === 1 },
+		],
+	};
+};
+
+export const selectPreviewPaneProps: PerTabSelector<PreviewPaneProps> = (state, ctx) => ({
+	notesVisible: state.notesVisible,
+	selectedIndex: state.optionIndex,
+	focused: ctx.activeView === "options",
+});
+
+export const selectTabBarProps: GlobalSelector<TabBarProps> = (state, ctx) => {
+	const tabs = ctx.questions.map((q, i) => ({
+		label: q.header && q.header.length > 0 ? q.header : `Q${i + 1}`,
+		answered: state.answers.has(i),
+		active: i === state.currentTab,
+	}));
+	return {
+		tabs,
+		submit: {
+			active: state.currentTab === ctx.questions.length,
+			allAnswered: state.answers.size === ctx.questions.length && ctx.questions.length > 0,
+		},
+	};
+};
+
+export const selectChatRowProps: GlobalSelector<ChatRowViewProps> = (state, ctx) => {
+	const activeItems = selectActiveTabItems(ctx.itemsByTab, state.currentTab, ctx.totalQuestions);
+	return {
+		focused: ctx.activeView === "chat",
+		numbering: chatNumberingFor(activeItems),
+	};
+};
+
+export const selectDialogProps: GlobalSelector<DialogProps> = (state, ctx) => ({
+	state,
+	activePreviewPane: ctx.activePreviewPane,
+});

--- a/packages/ask-user-question/state/state-reducer.ts
+++ b/packages/ask-user-question/state/state-reducer.ts
@@ -1,0 +1,295 @@
+import type { QuestionAnswer, QuestionData, QuestionnaireResult } from "../tool/types.js";
+import type { WrappingSelectItem } from "../view/components/wrapping-select.js";
+import type { QuestionnaireAction } from "./key-router.js";
+import { ROW_INTENT_META } from "./row-intent.js";
+import { computeFocusedOptionHasPreview } from "./selectors/derivations.js";
+import type { QuestionnaireState } from "./state.js";
+
+/** Session-lifetime constants. No live-component reads — peripheral values live on canonical state. */
+export interface ApplyContext {
+	questions: readonly QuestionData[];
+	itemsByTab: ReadonlyArray<readonly WrappingSelectItem[]>;
+}
+
+/**
+ * Declarative side-effects emitted by `reduce`. The runtime executes them after
+ * committing the new state, then asks the props-adapter to re-project. Closed set —
+ * adding an effect requires updating both the union AND the runtime's `runEffect` switch
+ * (compiler-enforced exhaustive). No string-keyed escape hatch.
+ */
+export type Effect =
+	| { kind: "set_input_buffer"; value: string }
+	| { kind: "clear_input_buffer" }
+	| { kind: "set_notes_value"; value: string }
+	| { kind: "set_notes_focused"; focused: boolean }
+	| { kind: "forward_notes_keystroke"; data: string }
+	| { kind: "done"; result: QuestionnaireResult };
+
+export interface ApplyResult {
+	state: QuestionnaireState;
+	effects: readonly Effect[];
+}
+
+function orderedAnswers(state: QuestionnaireState, questions: readonly QuestionData[]): QuestionAnswer[] {
+	const out: QuestionAnswer[] = [];
+	for (let i = 0; i < questions.length; i++) {
+		const a = state.answers.get(i);
+		if (a) out.push(a);
+	}
+	return out;
+}
+
+function withFocusedOptionHasPreview(
+	state: QuestionnaireState,
+	questions: readonly QuestionData[],
+): QuestionnaireState {
+	const focusedOptionHasPreview = computeFocusedOptionHasPreview(questions, state.currentTab, state.optionIndex);
+	if (state.focusedOptionHasPreview === focusedOptionHasPreview) return state;
+	return { ...state, focusedOptionHasPreview };
+}
+
+function syncMultiSelectFromAnswers(
+	answers: ReadonlyMap<number, QuestionAnswer>,
+	questions: readonly QuestionData[],
+	tab: number,
+): ReadonlySet<number> {
+	const q = questions[tab];
+	if (!q?.multiSelect) return new Set();
+	const saved = answers.get(tab);
+	const labels = saved?.selected ?? [];
+	const indices = new Set<number>();
+	for (let i = 0; i < q.options.length; i++) {
+		if (labels.includes(q.options[i]!.label)) indices.add(i);
+	}
+	return indices;
+}
+
+function persistMultiSelectAnswer(state: QuestionnaireState, ctx: ApplyContext): ReadonlyMap<number, QuestionAnswer> {
+	const q = ctx.questions[state.currentTab];
+	if (!q?.multiSelect) return state.answers;
+	const selected: string[] = [];
+	for (let i = 0; i < q.options.length; i++) {
+		if (state.multiSelectChecked.has(i)) selected.push(q.options[i]!.label);
+	}
+	const out = new Map(state.answers);
+	if (selected.length === 0) {
+		out.delete(state.currentTab);
+		return out;
+	}
+	const pendingNotes = state.notesByTab.get(state.currentTab);
+	out.set(state.currentTab, {
+		questionIndex: state.currentTab,
+		question: q.question,
+		kind: "multi",
+		answer: null,
+		selected,
+		...(pendingNotes && pendingNotes.length > 0 ? { notes: pendingNotes } : {}),
+	});
+	return out;
+}
+
+function switchTabResult(state: QuestionnaireState, nextTab: number, ctx: ApplyContext): ApplyResult {
+	const notesValue = state.notesByTab.get(nextTab) ?? state.answers.get(nextTab)?.notes ?? "";
+	const transitioned: QuestionnaireState = {
+		...state,
+		currentTab: nextTab,
+		optionIndex: 0,
+		inputMode: false,
+		notesVisible: false,
+		chatFocused: false,
+		submitChoiceIndex: 0,
+		multiSelectChecked: syncMultiSelectFromAnswers(state.answers, ctx.questions, nextTab),
+		notesDraft: notesValue,
+	};
+	const finalState = withFocusedOptionHasPreview(transitioned, ctx.questions);
+	return {
+		state: finalState,
+		effects: [
+			{ kind: "set_notes_focused", focused: false },
+			{ kind: "set_notes_value", value: notesValue },
+		],
+	};
+}
+
+function doneFor(state: QuestionnaireState, ctx: ApplyContext, cancelled: boolean): ApplyResult {
+	const result: QuestionnaireResult = { answers: orderedAnswers(state, ctx.questions), cancelled };
+	return { state, effects: [{ kind: "done", result }] };
+}
+
+/**
+ * Per-kind handler signature: action payload narrows to the matching union member
+ * via `Extract`, so handlers consume fully-typed actions without `as` casts.
+ */
+type Handler<K extends QuestionnaireAction["kind"]> = (
+	state: QuestionnaireState,
+	action: Extract<QuestionnaireAction, { kind: K }>,
+	ctx: ApplyContext,
+) => ApplyResult;
+
+const navHandler: Handler<"nav"> = (state, action, ctx) => {
+	const items = ctx.itemsByTab[state.currentTab] ?? [];
+	const item = items[action.nextIndex];
+	const inputMode = item ? ROW_INTENT_META[item.kind].activatesInputMode : false;
+	const next = withFocusedOptionHasPreview({ ...state, optionIndex: action.nextIndex, inputMode }, ctx.questions);
+	if (!inputMode) {
+		return { state: next, effects: [{ kind: "clear_input_buffer" }] };
+	}
+	const prior = state.answers.get(state.currentTab);
+	if (prior?.kind === "custom" && typeof prior.answer === "string") {
+		return { state: next, effects: [{ kind: "set_input_buffer", value: prior.answer }] };
+	}
+	return { state: next, effects: [] };
+};
+
+const tabSwitchHandler: Handler<"tab_switch"> = (state, action, ctx) => switchTabResult(state, action.nextTab, ctx);
+
+const confirmHandler: Handler<"confirm"> = (state, action, ctx) => {
+	let answer = action.answer;
+	if (answer.kind === "option" && answer.answer) {
+		const q = ctx.questions[answer.questionIndex];
+		const matched = q?.options.find((o) => o.label === answer.answer);
+		if (matched?.preview && matched.preview.length > 0) {
+			answer = { ...answer, preview: matched.preview };
+		}
+	}
+	const pendingNotes = state.notesByTab.get(answer.questionIndex);
+	if (pendingNotes && pendingNotes.length > 0) {
+		answer = { ...answer, notes: pendingNotes };
+	}
+	const answers = new Map(state.answers);
+	answers.set(answer.questionIndex, answer);
+	const next: QuestionnaireState = { ...state, answers };
+	if (answer.kind === "chat") return doneFor(next, ctx, false);
+	if (action.autoAdvanceTab !== undefined) return switchTabResult(next, action.autoAdvanceTab, ctx);
+	return doneFor(next, ctx, false);
+};
+
+const toggleHandler: Handler<"toggle"> = (state, action, ctx) => {
+	const checked = new Set(state.multiSelectChecked);
+	if (checked.has(action.index)) checked.delete(action.index);
+	else checked.add(action.index);
+	const intermediate: QuestionnaireState = { ...state, multiSelectChecked: checked };
+	const answers = persistMultiSelectAnswer(intermediate, ctx);
+	return { state: { ...intermediate, answers }, effects: [] };
+};
+
+const multiConfirmHandler: Handler<"multi_confirm"> = (state, action, ctx) => {
+	const q = ctx.questions[state.currentTab];
+	if (!q) return { state, effects: [] };
+	const pendingNotes = state.notesByTab.get(state.currentTab);
+	const answers = new Map(state.answers);
+	answers.set(state.currentTab, {
+		questionIndex: state.currentTab,
+		question: q.question,
+		kind: "multi",
+		answer: null,
+		selected: action.selected,
+		...(pendingNotes && pendingNotes.length > 0 ? { notes: pendingNotes } : {}),
+	});
+	const synced: QuestionnaireState = {
+		...state,
+		answers,
+		multiSelectChecked: syncMultiSelectFromAnswers(answers, ctx.questions, state.currentTab),
+	};
+	if (action.autoAdvanceTab !== undefined) return switchTabResult(synced, action.autoAdvanceTab, ctx);
+	return doneFor(synced, ctx, false);
+};
+
+const notesEnterHandler: Handler<"notes_enter"> = (state, _action, _ctx) => {
+	const value = state.answers.get(state.currentTab)?.notes ?? "";
+	return {
+		state: { ...state, notesVisible: true, notesDraft: value },
+		effects: [
+			{ kind: "set_notes_value", value },
+			{ kind: "set_notes_focused", focused: true },
+		],
+	};
+};
+
+const notesExitHandler: Handler<"notes_exit"> = (state, _action, _ctx) => {
+	const trimmed = state.notesDraft.trim();
+	const notes = new Map(state.notesByTab);
+	const answers = new Map(state.answers);
+	if (trimmed.length === 0) {
+		notes.delete(state.currentTab);
+		const prev = answers.get(state.currentTab);
+		if (prev?.notes) {
+			const stripped = { ...prev };
+			delete (stripped as { notes?: string }).notes;
+			answers.set(state.currentTab, stripped);
+		}
+	} else {
+		notes.set(state.currentTab, trimmed);
+		const prev = answers.get(state.currentTab);
+		if (prev) answers.set(state.currentTab, { ...prev, notes: trimmed });
+	}
+	return {
+		state: { ...state, notesByTab: notes, answers, notesVisible: false },
+		effects: [{ kind: "set_notes_focused", focused: false }],
+	};
+};
+
+const focusOptionsHandler: Handler<"focus_options"> = (state, action, ctx) => {
+	const items = ctx.itemsByTab[state.currentTab] ?? [];
+	const focused = items[action.optionIndex];
+	const inputMode = focused ? ROW_INTENT_META[focused.kind].activatesInputMode : false;
+	const next = withFocusedOptionHasPreview(
+		{ ...state, chatFocused: false, optionIndex: action.optionIndex, inputMode },
+		ctx.questions,
+	);
+	return { state: next, effects: inputMode ? [] : [{ kind: "clear_input_buffer" }] };
+};
+
+const cancelHandler: Handler<"cancel"> = (s, _a, c) => doneFor(s, c, true);
+const submitHandler: Handler<"submit"> = (s, _a, c) => doneFor(s, c, false);
+const submitNavHandler: Handler<"submit_nav"> = (s, a, _c) => ({
+	state: { ...s, submitChoiceIndex: a.nextIndex },
+	effects: [],
+});
+const focusChatHandler: Handler<"focus_chat"> = (s, _a, _c) => ({
+	state: { ...s, chatFocused: true },
+	effects: [],
+});
+const notesForwardHandler: Handler<"notes_forward"> = (s, a, _c) => ({
+	state: s,
+	effects: [{ kind: "forward_notes_keystroke", data: a.data }],
+});
+const toggleCollapsedHandler: Handler<"toggle_collapsed"> = (s, _a, _c) => ({
+	state: { ...s, collapsed: !s.collapsed },
+	effects: [],
+});
+const ignoreHandler: Handler<"ignore"> = (s, _a, _c) => ({ state: s, effects: [] });
+
+/**
+ * Compile-time-exhaustive dispatch table. `{ [K in Kind]: Handler<K> }` requires
+ * an entry per union member — adding a new `QuestionnaireAction` variant fails to
+ * compile here until a handler is registered, mirroring the `Record<RowKind, …>`
+ * pattern used by `ROW_INTENT_META`.
+ */
+const HANDLERS: { [K in QuestionnaireAction["kind"]]: Handler<K> } = {
+	nav: navHandler,
+	tab_switch: tabSwitchHandler,
+	confirm: confirmHandler,
+	toggle: toggleHandler,
+	multi_confirm: multiConfirmHandler,
+	cancel: cancelHandler,
+	notes_enter: notesEnterHandler,
+	notes_exit: notesExitHandler,
+	notes_forward: notesForwardHandler,
+	submit: submitHandler,
+	submit_nav: submitNavHandler,
+	focus_chat: focusChatHandler,
+	focus_options: focusOptionsHandler,
+	toggle_collapsed: toggleCollapsedHandler,
+	ignore: ignoreHandler,
+};
+
+/**
+ * Pure reducer: (state, action, ctx) → (state, Effect[]). Mirrors `rpiv-todo`'s `applyTaskMutation`.
+ * Delegates to `HANDLERS` — per-kind handlers above are pure, named, and individually testable.
+ * `ignore` is also handled outside the reducer by `handleIgnoreInline` in the runtime fast path.
+ */
+export function reduce(state: QuestionnaireState, action: QuestionnaireAction, ctx: ApplyContext): ApplyResult {
+	const handler = HANDLERS[action.kind] as Handler<typeof action.kind>;
+	return handler(state, action as never, ctx);
+}

--- a/packages/ask-user-question/state/state.ts
+++ b/packages/ask-user-question/state/state.ts
@@ -1,0 +1,50 @@
+import type { QuestionAnswer, QuestionData } from "../tool/types.js";
+import type { WrappingSelectItem } from "../view/components/wrapping-select.js";
+
+/**
+ * Canonical state for the questionnaire dialog. Single source of truth — both the
+ * dispatcher (`routeKey`) and the view layer read this same shape.
+ */
+export interface QuestionnaireState {
+	currentTab: number;
+	optionIndex: number;
+	inputMode: boolean;
+	notesVisible: boolean;
+	chatFocused: boolean;
+	answers: ReadonlyMap<number, QuestionAnswer>;
+	multiSelectChecked: ReadonlySet<number>;
+	/**
+	 * Pre-answer notes side-band, keyed by tab index. Decoupled from `answers` so adding
+	 * notes does NOT mark a question answered (the Submit-tab missing-check would falsely
+	 * pass otherwise). Merged into the answer at confirm time.
+	 */
+	notesByTab: ReadonlyMap<number, string>;
+	/** True iff the focused option carries a non-empty `preview` string. Gates `notes_enter` and the "n to add notes" hint chip. */
+	focusedOptionHasPreview: boolean;
+	/** Focused row in the Submit-tab picker (0 = Submit, 1 = Cancel). Reset on tab switch. */
+	submitChoiceIndex: number;
+	/** Canonical mirror of the in-flight notes editor; runtime mirrors after `forward_notes_keystroke`. */
+	notesDraft: string;
+	/**
+	 * Collapsed mode: the questionnaire shrinks to a single hint row so the agent transcript
+	 * behind the bottom-anchored overlay becomes readable. Toggled by `Ctrl+]` from any state;
+	 * while true, every keystroke except cancel is swallowed (see `routeKey`). The overlay
+	 * stays focused so the expand key never falls through to an underlying overlay (e.g.
+	 * `/btw`) — that focus-restore property is the entire reason we render a collapsed row
+	 * instead of calling `OverlayHandle.setHidden(true)`.
+	 */
+	collapsed: boolean;
+}
+
+/**
+ * Per-tick context the dispatcher needs alongside canonical state. Held separately
+ * because `keybindings` / `inputBuffer` must never reach view setProps consumers.
+ */
+export interface QuestionnaireRuntime {
+	keybindings: { matches(data: string, name: string): boolean };
+	inputBuffer: string;
+	questions: readonly QuestionData[];
+	isMulti: boolean;
+	currentItem: WrappingSelectItem | undefined;
+	items: readonly WrappingSelectItem[];
+}

--- a/packages/ask-user-question/tool/external-answer.ts
+++ b/packages/ask-user-question/tool/external-answer.ts
@@ -1,0 +1,53 @@
+import type { AskUserAnswerEventPayload } from "../events.js";
+import type { QuestionAnswer, QuestionnaireResult, QuestionParams } from "./types.js";
+
+/**
+ * Map an external answer payload (e.g. from a Slack button click) onto a
+ * `QuestionnaireResult`, the same shape the terminal overlay produces. Labels
+ * are validated against the authored options; unknown labels fall back to a
+ * free-text (`custom`) answer so a listener can also send arbitrary text.
+ * Questions with no matching entry are left unanswered (the envelope builder
+ * treats a partial/empty set as a decline).
+ */
+export function externalAnswerToResult(
+	payload: AskUserAnswerEventPayload,
+	params: QuestionParams,
+): QuestionnaireResult {
+	if (payload.cancelled) {
+		return { answers: [], cancelled: true };
+	}
+
+	const answers: QuestionAnswer[] = [];
+	for (const entry of payload.answers ?? []) {
+		const i = entry.questionIndex;
+		const question = params.questions[i];
+		if (!question) continue;
+
+		if (Array.isArray(entry.labels) && entry.labels.length > 0) {
+			const valid = entry.labels.filter((l) => question.options.some((o) => o.label === l));
+			if (valid.length === 0) continue;
+			answers.push({ questionIndex: i, question: question.question, kind: "multi", answer: null, selected: valid });
+			continue;
+		}
+
+		if (typeof entry.label === "string" && entry.label.length > 0) {
+			const match = question.options.find((o) => o.label === entry.label);
+			if (match) {
+				answers.push({
+					questionIndex: i,
+					question: question.question,
+					kind: "option",
+					answer: match.label,
+					preview: typeof match.preview === "string" && match.preview.length > 0 ? match.preview : undefined,
+				});
+				continue;
+			}
+		}
+
+		if (typeof entry.text === "string" && entry.text.length > 0) {
+			answers.push({ questionIndex: i, question: question.question, kind: "custom", answer: entry.text });
+		}
+	}
+
+	return { answers, cancelled: false };
+}

--- a/packages/ask-user-question/tool/format-answer.ts
+++ b/packages/ask-user-question/tool/format-answer.ts
@@ -1,0 +1,47 @@
+import { t } from "../state/i18n-bridge.js";
+import type { QuestionAnswer } from "./types.js";
+
+/**
+ * Continuation message used in the LLM-facing envelope. Two-sentence imperative form
+ * — the model needs the "Continue the conversation…" directive to know what to do next
+ * after the user picks chat instead of answering.
+ */
+export const CHAT_CONTINUATION_MESSAGE =
+	"User wants to chat about this. Continue the conversation to help them decide.";
+
+/**
+ * One-sentence summary form shown in the on-screen Submit-tab review pane. The dialog
+ * already shows the question; the imperative continuation directive belongs in the
+ * envelope, not in the user-facing summary box.
+ */
+export const CHAT_SUMMARY_MESSAGE = "User wants to chat about this";
+
+/**
+ * Placeholder for empty / null answer text. Used uniformly across both variants — the
+ * earlier `(no answer)` fallback in the dialog summary was accidental drift; tests pin
+ * `(no input)` only.
+ */
+export const NO_INPUT_PLACEHOLDER = "(no input)";
+
+export type FormatAnswerVariant = "summary" | "envelope";
+
+/**
+ * Format a `QuestionAnswer` to its scalar string form. Variant controls only the
+ * `kind: "chat"` branch — the envelope's two-sentence imperative is needed by the LLM,
+ * the dialog summary's one-sentence reminder is not. All other branches return identical
+ * strings; the `kind: "custom"` empty-string handling and the option fallback both unify
+ * on `NO_INPUT_PLACEHOLDER`. Switch is exhaustive — non-`void` return enforces every
+ * variant is handled.
+ */
+export function formatAnswerScalar(a: QuestionAnswer, variant: FormatAnswerVariant): string {
+	switch (a.kind) {
+		case "chat":
+			return variant === "envelope" ? CHAT_CONTINUATION_MESSAGE : t("chat.summary", CHAT_SUMMARY_MESSAGE);
+		case "multi":
+			return a.selected && a.selected.length > 0 ? a.selected.join(", ") : NO_INPUT_PLACEHOLDER;
+		case "custom":
+			return a.answer && a.answer.length > 0 ? a.answer : NO_INPUT_PLACEHOLDER;
+		case "option":
+			return a.answer ?? NO_INPUT_PLACEHOLDER;
+	}
+}

--- a/packages/ask-user-question/tool/response-envelope.ts
+++ b/packages/ask-user-question/tool/response-envelope.ts
@@ -1,0 +1,47 @@
+import { formatAnswerScalar } from "./format-answer.js";
+import type { QuestionAnswer, QuestionnaireResult, QuestionParams } from "./types.js";
+
+export const DECLINE_MESSAGE = "User declined to answer questions";
+export const ENVELOPE_PREFIX = "User has answered your questions:";
+export const ENVELOPE_SUFFIX = "You can now continue with the user's answers in mind.";
+
+/**
+ * Map a `QuestionnaireResult` (or null/cancelled) to the LLM-facing tool envelope.
+ * Pure of `(result, params)`; cancelled and "no segments" both fall to `DECLINE_MESSAGE`
+ * so the model sees a single canonical "didn't answer" signal regardless of why.
+ */
+export function buildQuestionnaireResponse(result: QuestionnaireResult | null | undefined, params: QuestionParams) {
+	if (!result || result.cancelled) {
+		return buildToolResult(DECLINE_MESSAGE, {
+			answers: result?.answers ?? [],
+			cancelled: true,
+		});
+	}
+	const segments: string[] = [];
+	for (let i = 0; i < params.questions.length; i++) {
+		const a = result.answers.find((x) => x.questionIndex === i);
+		if (a) segments.push(buildAnswerSegment(a));
+	}
+	if (segments.length === 0) {
+		return buildToolResult(DECLINE_MESSAGE, { answers: result.answers, cancelled: true });
+	}
+	return buildToolResult(`${ENVELOPE_PREFIX} ${segments.join(" ")} ${ENVELOPE_SUFFIX}`, result);
+}
+
+/**
+ * Format a single answer segment for the envelope. Pure of `a`. The `"Q"="A"` shape and
+ * the optional `selected preview:` / `user notes:` suffixes are pinned by envelope tests.
+ */
+export function buildAnswerSegment(a: QuestionAnswer): string {
+	const parts: string[] = [`"${a.question}"="${formatAnswerScalar(a, "envelope")}"`];
+	if (a.preview && a.preview.length > 0) parts.push(`selected preview: ${a.preview}`);
+	if (a.notes && a.notes.length > 0) parts.push(`user notes: ${a.notes}`);
+	return `${parts.join(". ")}.`;
+}
+
+export function buildToolResult(text: string, details: QuestionnaireResult) {
+	return {
+		content: [{ type: "text" as const, text }],
+		details,
+	};
+}

--- a/packages/ask-user-question/tool/types.ts
+++ b/packages/ask-user-question/tool/types.ts
@@ -1,0 +1,148 @@
+import { type Static, Type } from "typebox";
+import { LABELS_BY_KIND, ROW_INTENT_META } from "../state/row-intent.js";
+
+export const MAX_QUESTIONS = 4;
+export const MIN_OPTIONS = 2;
+export const MAX_OPTIONS = 4;
+export const MAX_HEADER_LENGTH = 16;
+export const MAX_LABEL_LENGTH = 60;
+
+/**
+ * User-facing labels for the three runtime sentinel rows, keyed by their
+ * `WrappingSelectItem.kind` discriminator. Sourced from
+ * `ROW_INTENT_META` via `LABELS_BY_KIND` (`row-intent.ts`) — single source of
+ * truth. Adding a new sentinel requires extending the `WrappingSelectItem`
+ * union AND adding an entry to `ROW_INTENT_META`; this map then auto-extends.
+ */
+export const SENTINEL_LABELS = LABELS_BY_KIND;
+
+export type SentinelKind = keyof typeof SENTINEL_LABELS;
+export type SentinelLabel = (typeof SENTINEL_LABELS)[SentinelKind];
+
+/**
+ * Labels reserved for Pi-internal sentinels — authoring an option with any
+ * of these labels triggers the `reserved_label` runtime guard. Three of the
+ * four come from `ROW_INTENT_META` (the runtime kinds); `"Other"` is
+ * reserved for CC parity only (the model is conditioned to reach for
+ * "Other" in CC; we reject it so the runtime sentinel is the single source
+ * of truth) and has no runtime kind.
+ *
+ * Reserved unconditionally — multiSelect questions also reject these labels
+ * even though the runtime sentinel is suppressed there.
+ *
+ * Order is pinned by `types.test.ts:292` — keep the explicit
+ * `["Other", other, chat, next]` literal so consumers using
+ * `RESERVED_LABELS[i]` indexing or `Set` membership see no behavior change.
+ */
+export const RESERVED_LABELS = [
+	"Other",
+	ROW_INTENT_META.other.label,
+	ROW_INTENT_META.chat.label,
+	ROW_INTENT_META.next.label,
+] as const;
+export type ReservedLabel = (typeof RESERVED_LABELS)[number];
+
+export const OptionSchema = Type.Object({
+	label: Type.String({
+		maxLength: MAX_LABEL_LENGTH,
+		description: `MAX ${MAX_LABEL_LENGTH} CHARACTERS — hard limit, requests over the limit are rejected. The display text for this option that the user will see and select. Should be concise (1-5 words) and clearly describe the choice.`,
+	}),
+	description: Type.String({
+		description:
+			"Explanation of what this option means or what will happen if chosen. Useful for providing context about trade-offs or implications.",
+	}),
+	preview: Type.Optional(
+		Type.String({
+			description:
+				"Optional preview content rendered when this option is focused. Use for mockups, code snippets, or visual comparisons that help users compare options. See the tool description for the expected content format.",
+		}),
+	),
+});
+
+export const QuestionSchema = Type.Object({
+	question: Type.String({
+		description:
+			'The complete question to ask the user. Should be clear, specific, and end with a question mark. Example: "Which library should we use for date formatting?" If multiSelect is true, phrase it accordingly, e.g. "Which features do you want to enable?"',
+	}),
+	header: Type.String({
+		maxLength: MAX_HEADER_LENGTH,
+		description: `MAX ${MAX_HEADER_LENGTH} CHARACTERS — hard limit, requests over the limit are rejected. Very short chip/tag shown next to the question. Examples: "Auth method", "Library", "Approach".`,
+	}),
+	options: Type.Array(OptionSchema, {
+		minItems: MIN_OPTIONS,
+		maxItems: MAX_OPTIONS,
+		description:
+			"The available choices for this question. Must have 2-4 options. Each option should be a distinct, mutually exclusive choice (unless multiSelect is enabled). The 'Type something.' row is appended automatically — do NOT author it.",
+	}),
+	multiSelect: Type.Optional(
+		Type.Boolean({
+			default: false,
+			description:
+				"Set to true to allow the user to select multiple options instead of just one. Use when choices are not mutually exclusive.",
+		}),
+	),
+});
+
+export const QuestionsSchema = Type.Array(QuestionSchema, {
+	minItems: 1,
+	maxItems: MAX_QUESTIONS,
+	description: "Questions to ask the user (1-4 questions)",
+});
+
+export const QuestionParamsSchema = Type.Object({
+	questions: QuestionsSchema,
+});
+
+export type OptionData = Static<typeof OptionSchema>;
+export type QuestionData = Static<typeof QuestionSchema>;
+export type QuestionParams = Static<typeof QuestionParamsSchema>;
+
+/**
+ * Answer-intent discriminated union. `kind` is the single discriminator —
+ * pre-1.0.3 boolean flags have been removed (see `banned-flags.test.ts`).
+ * Mirrors the row-side `WrappingSelectItem.kind` vocabulary where possible;
+ * `multi` is the multi-select variant (no row-side analog).
+ *
+ * Variant semantics:
+ * - `option`: user picked one of the author-defined options. `answer` is the option's label.
+ * - `custom`: user typed free-text via the "Type something." row. `answer` is the typed text or null.
+ * - `chat`: user picked the chat sentinel. `answer` is the literal "Chat about this".
+ * - `multi`: user committed multi-select choices. `selected` carries chosen labels; `answer` is null.
+ */
+export interface QuestionAnswer {
+	questionIndex: number;
+	question: string;
+	kind: "option" | "custom" | "chat" | "multi";
+	answer: string | null;
+	selected?: string[];
+	notes?: string;
+	/**
+	 * Markdown text from the matched option's `preview` field, populated only
+	 * when the user lands on a single-select option carrying a `preview`.
+	 * Used by `buildQuestionnaireResponse` to echo `selected preview: <preview>`
+	 * into the LLM-facing envelope. Undefined for multi-select, custom-text
+	 * (`kind: "custom"`), and chat (`kind: "chat"`) answers.
+	 */
+	preview?: string;
+}
+
+export type QuestionnaireError =
+	| "no_ui"
+	| "no_questions"
+	| "empty_options"
+	| "too_many_questions"
+	| "duplicate_question"
+	| "duplicate_option_label"
+	| "reserved_label";
+
+export interface QuestionnaireResult {
+	answers: QuestionAnswer[];
+	cancelled: boolean;
+	error?: QuestionnaireError;
+}
+
+export function isQuestionnaireResult(value: unknown): value is QuestionnaireResult {
+	if (!value || typeof value !== "object") return false;
+	const v = value as Record<string, unknown>;
+	return Array.isArray(v.answers) && typeof v.cancelled === "boolean";
+}

--- a/packages/ask-user-question/tool/validate-questionnaire.ts
+++ b/packages/ask-user-question/tool/validate-questionnaire.ts
@@ -1,0 +1,56 @@
+import { MAX_QUESTIONS, MIN_OPTIONS, type QuestionnaireError, type QuestionParams, RESERVED_LABELS } from "./types.js";
+
+export const ERROR_NO_QUESTIONS = "Error: At least one question is required";
+export const ERROR_TOO_MANY_QUESTIONS = `Error: At most ${MAX_QUESTIONS} questions are allowed per invocation`;
+export const ERROR_DUPLICATE_QUESTION = "Error: Question text must be unique within an invocation";
+export const ERROR_TOO_FEW_OPTIONS = `Error: Each question requires at least ${MIN_OPTIONS} options`;
+export const ERROR_RESERVED_LABEL = `Error: Option label is reserved (${RESERVED_LABELS.join(", ")})`;
+export const ERROR_DUPLICATE_OPTION_LABEL = "Error: Option labels must be unique within a question";
+
+const RESERVED_LABEL_SET: ReadonlySet<string> = new Set(RESERVED_LABELS);
+
+export type ValidationResult = { ok: true } | { ok: false; error: QuestionnaireError; message: string };
+
+/**
+ * Pure runtime validator for `QuestionParams`. Covers every guard except
+ * `no_ui` (which depends on `ctx.hasUI` and stays inline at the call site).
+ * `reserved_label` MUST short-circuit before `duplicate_option_label`.
+ */
+export function validateQuestionnaire(typed: QuestionParams): ValidationResult {
+	if (typed.questions.length === 0) {
+		return { ok: false, error: "no_questions", message: ERROR_NO_QUESTIONS };
+	}
+	if (typed.questions.length > MAX_QUESTIONS) {
+		return { ok: false, error: "too_many_questions", message: ERROR_TOO_MANY_QUESTIONS };
+	}
+
+	const seenQuestions = new Set<string>();
+	for (const q of typed.questions) {
+		if (seenQuestions.has(q.question)) {
+			return { ok: false, error: "duplicate_question", message: ERROR_DUPLICATE_QUESTION };
+		}
+		seenQuestions.add(q.question);
+	}
+
+	for (const q of typed.questions) {
+		if (q.options.length < MIN_OPTIONS) {
+			return { ok: false, error: "empty_options", message: ERROR_TOO_FEW_OPTIONS };
+		}
+		const seenLabels = new Set<string>();
+		for (const o of q.options) {
+			if (RESERVED_LABEL_SET.has(o.label)) {
+				return { ok: false, error: "reserved_label", message: ERROR_RESERVED_LABEL };
+			}
+			if (seenLabels.has(o.label)) {
+				return {
+					ok: false,
+					error: "duplicate_option_label",
+					message: ERROR_DUPLICATE_OPTION_LABEL,
+				};
+			}
+			seenLabels.add(o.label);
+		}
+	}
+
+	return { ok: true };
+}

--- a/packages/ask-user-question/tsconfig.json
+++ b/packages/ask-user-question/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "types": ["node"]
+  },
+  "include": ["*.ts", "state/**/*.ts", "tool/**/*.ts", "view/**/*.ts"]
+}

--- a/packages/ask-user-question/view/component-binding.ts
+++ b/packages/ask-user-question/view/component-binding.ts
@@ -1,0 +1,45 @@
+import type {
+	BindingContext,
+	GlobalSelector,
+	PerTabBindingContext,
+	PerTabSelector,
+} from "../state/selectors/contract.js";
+import type { QuestionnaireState } from "../state/state.js";
+import type { StatefulView } from "./stateful-view.js";
+import type { TabComponents } from "./tab-components.js";
+
+export interface ComponentBinding<P> {
+	readonly component: StatefulView<P>;
+	readonly select: GlobalSelector<P>;
+}
+
+export interface PerTabBinding<P> {
+	readonly resolve: (tab: TabComponents) => StatefulView<P> | undefined;
+	readonly select: PerTabSelector<P>;
+	readonly predicate?: PerTabSelector<boolean>;
+}
+
+export interface BoundGlobalBinding {
+	apply(state: QuestionnaireState, ctx: BindingContext): void;
+	invalidate(): void;
+}
+
+export interface BoundPerTabBinding {
+	apply(state: QuestionnaireState, ctx: PerTabBindingContext): void;
+}
+
+export function globalBinding<P>(spec: ComponentBinding<P>): BoundGlobalBinding {
+	return {
+		apply: (state, ctx) => spec.component.setProps(spec.select(state, ctx)),
+		invalidate: () => spec.component.invalidate(),
+	};
+}
+
+export function perTabBinding<P>(spec: PerTabBinding<P>): BoundPerTabBinding {
+	return {
+		apply: (state, ctx) => {
+			if (spec.predicate && !spec.predicate(state, ctx)) return;
+			spec.resolve(ctx.tab)?.setProps(spec.select(state, ctx));
+		},
+	};
+}

--- a/packages/ask-user-question/view/components/chat-row-view.ts
+++ b/packages/ask-user-question/view/components/chat-row-view.ts
@@ -1,0 +1,56 @@
+import type { Component } from "@earendil-works/pi-tui";
+import type { StatefulView } from "../stateful-view.js";
+import { WrappingSelect, type WrappingSelectItem, type WrappingSelectTheme } from "./wrapping-select.js";
+
+/**
+ * Per-tick projection of chat-row state. The chat row is a single-item
+ * `WrappingSelect` rendered in the question-tab footer; it owns no per-tab
+ * state — only `focused` (whether the chat row is the active focus target)
+ * and `numbering` (display number aligned with the active tab's items).
+ */
+export interface ChatRowViewProps {
+	focused: boolean;
+	numbering: { offset: number; total: number };
+}
+
+export interface ChatRowViewConfig {
+	/** The single chat sentinel row — `{kind: "chat", label: SENTINEL_LABELS.chat}`. */
+	item: WrappingSelectItem;
+	theme: WrappingSelectTheme;
+}
+
+/**
+ * Typed wrapper around the chat-row `WrappingSelect`. Replaces the prior
+ * raw-primitive consumption at `props-adapter.ts:106, :120` and removes the
+ * accidental surface area (8 unused `WrappingSelect` setters) noted in
+ * research Q4.
+ *
+ * Pattern modeled after `OptionListView` (`option-list-view.ts:27-93`):
+ * mirror-then-delegate `setProps`; render is pure delegation; `Component`
+ * triplet forwards.
+ */
+export class ChatRowView implements StatefulView<ChatRowViewProps>, Component {
+	private readonly select: WrappingSelect;
+
+	constructor(config: ChatRowViewConfig) {
+		this.select = new WrappingSelect([config.item], 1, config.theme, {
+			numberStartOffset: 0,
+			totalItemsForNumbering: 1,
+		});
+	}
+
+	setProps(props: ChatRowViewProps): void {
+		this.select.setFocused(props.focused);
+		this.select.setNumbering(props.numbering.offset, props.numbering.total);
+	}
+
+	handleInput(_data: string): void {}
+
+	invalidate(): void {
+		this.select.invalidate();
+	}
+
+	render(width: number): string[] {
+		return this.select.render(width);
+	}
+}

--- a/packages/ask-user-question/view/components/multi-select-view.ts
+++ b/packages/ask-user-question/view/components/multi-select-view.ts
@@ -1,0 +1,135 @@
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
+import { displayLabel } from "../../state/i18n-bridge.js";
+import type { QuestionData } from "../../tool/types.js";
+import type { StatefulView } from "../stateful-view.js";
+
+const ACTIVE_POINTER = "❯ ";
+const INACTIVE_POINTER = "  ";
+const CHECKED = "[✔]";
+const UNCHECKED = "[ ]";
+const NUMBER_SEPARATOR = ". ";
+const BOX_LABEL_GAP = " ";
+// CC parity: description continuation indents to col 2 (past the pointer slot), NOT to the
+// full prefix column. Wrap width still uses prefixVisibleWidth so naturalHeight matches render.
+const CONTINUATION_INDENT = "  ";
+
+export const MULTI_SUBMIT_LABEL = "Submit";
+
+export interface MultiSelectViewProps {
+	rows: ReadonlyArray<{ checked: boolean; active: boolean }>;
+	nextActive: boolean;
+	nextLabel: string;
+}
+
+/**
+ * Renders the multi-select option list (one row per option — pointer + checkbox + label —
+ * plus zero or more wrapped continuation lines per description).
+ *
+ * `naturalHeight(width)` is state-INDEPENDENT (depends only on theme glyph widths,
+ * question.options, and width) so the host can compute a stable globalContentHeight
+ * without rendering. `naturalHeight(w) === render(w).length` for every props.
+ *
+ * `setProps(props)` is a pure field reassignment — no render, no invalidate side effects.
+ */
+export class MultiSelectView implements StatefulView<MultiSelectViewProps> {
+	private props: MultiSelectViewProps;
+
+	constructor(
+		private readonly theme: Theme,
+		private readonly question: QuestionData,
+	) {
+		this.props = { rows: [], nextActive: false, nextLabel: displayLabel("next") };
+	}
+
+	setProps(props: MultiSelectViewProps): void {
+		this.props = props;
+	}
+
+	handleInput(_data: string): void {}
+
+	invalidate(): void {}
+
+	render(width: number): string[] {
+		const lines: string[] = [];
+		const prefixWidth = this.prefixVisibleWidth();
+		const contentWidth = Math.max(1, width - prefixWidth);
+		const numberWidth = String(Math.max(1, this.question.options.length)).length;
+		for (let i = 0; i < this.question.options.length; i++) {
+			const opt = this.question.options[i];
+			const row = this.props.rows[i];
+			if (!opt || !row) continue;
+			const pointer = row.active ? this.theme.fg("accent", ACTIVE_POINTER) : INACTIVE_POINTER;
+			// Checked uses the same `accent` hue as the active-row label so checked rows read
+			// as "selected" rather than "success" — matches the visual rhythm of the rest of
+			// the dialog (active pointer, label, picker rows are all accent).
+			const box = row.checked ? this.theme.fg("accent", CHECKED) : this.theme.fg("muted", UNCHECKED);
+			const label = truncateToWidth(opt.label, contentWidth, "…");
+			const styledLabel = row.active ? this.theme.fg("accent", this.theme.bold(label)) : label;
+			const num = String(i + 1).padStart(numberWidth, " ");
+			const line = `${pointer}${num}${NUMBER_SEPARATOR}${box}${BOX_LABEL_GAP}${styledLabel}`;
+			lines.push(truncateToWidth(line, width, ""));
+			if (opt.description) {
+				const wrapped = wrapTextWithAnsi(opt.description, contentWidth);
+				for (const segment of wrapped) {
+					lines.push(CONTINUATION_INDENT + this.theme.fg("muted", segment));
+				}
+			}
+		}
+		const nextPointer = this.props.nextActive ? this.theme.fg("accent", ACTIVE_POINTER) : INACTIVE_POINTER;
+		const nextLabel = this.props.nextActive
+			? this.theme.fg("accent", this.theme.bold(this.props.nextLabel))
+			: this.props.nextLabel;
+		lines.push(truncateToWidth(`${nextPointer}${nextLabel}`, width, ""));
+		return lines;
+	}
+
+	/**
+	 * Returns the [startRow, endRow) range of the active (focused) row within
+	 * `render(width)`. Labels are always 1 row (truncated); descriptions wrap.
+	 */
+	focusedItemRowRange(width: number): [number, number] {
+		const prefixWidth = this.prefixVisibleWidth();
+		const contentWidth = Math.max(1, width - prefixWidth);
+		let row = 0;
+		for (let i = 0; i < this.question.options.length; i++) {
+			const opt = this.question.options[i];
+			const r = this.props.rows[i];
+			if (!opt || !r) continue;
+			const itemHeight = 1 + (opt.description ? wrapTextWithAnsi(opt.description, contentWidth).length : 0);
+			if (r.active) {
+				return [row, row + itemHeight];
+			}
+			row += itemHeight;
+		}
+		if (this.props.nextActive) {
+			return [row, row + 1];
+		}
+		return [0, 0];
+	}
+
+	naturalHeight(width: number): number {
+		const contentWidth = Math.max(1, width - this.prefixVisibleWidth());
+		let total = 0;
+		for (const opt of this.question.options) {
+			if (!opt) continue;
+			total += 1; // row line
+			if (opt.description) {
+				total += wrapTextWithAnsi(opt.description, contentWidth).length;
+			}
+		}
+		return total + 1; // Next sentinel row (no description; never wraps).
+	}
+
+	private prefixVisibleWidth(): number {
+		// Canonical prefix for OPTION rows: INACTIVE_POINTER + numberWidth digits + NUMBER_SEPARATOR
+		// + UNCHECKED + BOX_LABEL_GAP. State-independent because ACTIVE/INACTIVE pointer share
+		// visibleWidth, CHECKED/UNCHECKED share visibleWidth, and numberWidth is constant per question.
+		// The Next sentinel uses a bare `pointer + "Next"` shape — its width never exceeds this prefix
+		// at any reasonable terminal width, so it's safe to leave it out of the canonical computation.
+		const numberWidth = String(Math.max(1, this.question.options.length)).length;
+		return (
+			visibleWidth(INACTIVE_POINTER) + numberWidth + visibleWidth(`${NUMBER_SEPARATOR}${UNCHECKED}${BOX_LABEL_GAP}`)
+		);
+	}
+}

--- a/packages/ask-user-question/view/components/option-list-view.ts
+++ b/packages/ask-user-question/view/components/option-list-view.ts
@@ -1,0 +1,71 @@
+import type { StatefulView } from "../stateful-view.js";
+import { WrappingSelect, type WrappingSelectItem, type WrappingSelectTheme } from "./wrapping-select.js";
+
+/**
+ * Maximum number of option rows visible in the WrappingSelect window. Lifted here from
+ * `preview-pane.ts` so the cap travels with the option-list owner.
+ */
+export const MAX_VISIBLE_OPTIONS = 10;
+
+export interface OptionListViewConfig {
+	items: readonly WrappingSelectItem[];
+	theme: WrappingSelectTheme;
+}
+
+/**
+ * Per-tick projection of OptionListView state. After Phase 11b, `inputBuffer`
+ * is part of the props bag — the session-owned `inlineInput` (a headless
+ * `pi-tui` Input instance) supplies its current `getValue()` here per tick.
+ * `OptionListView` is purely props-driven; the imperative buffer surface and
+ * read-back getters are gone.
+ */
+export interface OptionListViewProps {
+	selectedIndex: number;
+	focused: boolean;
+	inputBuffer: string;
+	inputCursorOffset?: number;
+	/** Optional previously-confirmed indicator. Omit when no marker should be drawn. */
+	confirmed?: { index: number; labelOverride?: string };
+}
+
+/**
+ * Sole owner of the option list's interactive state. Wraps a single
+ * `WrappingSelect`. Implements `StatefulView<OptionListViewProps>`:
+ * `setProps` is the only mutator; render output reflects the last props
+ * received.
+ */
+export class OptionListView implements StatefulView<OptionListViewProps> {
+	private readonly select: WrappingSelect;
+
+	constructor(config: OptionListViewConfig) {
+		// Reserve a slot for the chat row in the WrappingSelect's number-padding so
+		// the column width is identical whether or not the user navigates into chat
+		// (chat row uses items.length + 1).
+		this.select = new WrappingSelect(config.items, Math.min(config.items.length, MAX_VISIBLE_OPTIONS), config.theme, {
+			numberStartOffset: 0,
+			totalItemsForNumbering: config.items.length + 1,
+		});
+	}
+
+	setProps(props: OptionListViewProps): void {
+		this.select.setSelectedIndex(props.selectedIndex);
+		this.select.setFocused(props.focused);
+		this.select.setConfirmedIndex(props.confirmed?.index, props.confirmed?.labelOverride);
+		this.select.setInputBuffer(props.inputBuffer);
+		this.select.setInputCursorOffset(props.inputCursorOffset);
+	}
+
+	handleInput(_data: string): void {}
+
+	invalidate(): void {
+		this.select.invalidate();
+	}
+
+	render(width: number): string[] {
+		return this.select.render(width);
+	}
+
+	focusedItemRowRange(width: number): [number, number] {
+		return this.select.focusedItemRowRange(width);
+	}
+}

--- a/packages/ask-user-question/view/components/preview/markdown-content-cache.ts
+++ b/packages/ask-user-question/view/components/preview/markdown-content-cache.ts
@@ -1,0 +1,77 @@
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { Markdown, type MarkdownTheme, visibleWidth } from "@earendil-works/pi-tui";
+import { t } from "../../../state/i18n-bridge.js";
+import type { QuestionData } from "../../../tool/types.js";
+import { stripFenceMarkers } from "./preview-box-renderer.js";
+
+/** CC parity in side-by-side layout. */
+export const MAX_PREVIEW_HEIGHT_SIDE_BY_SIDE = 20;
+/** Preserves narrow-terminal protection in stacked layout. */
+export const MAX_PREVIEW_HEIGHT_STACKED = 15;
+export const NO_PREVIEW_TEXT = "No preview available";
+/** 1 blank separator + 1 affordance text row reserved when `hasAnyPreview` (height stability of the affordance row's offset relative to the box). */
+export const NOTES_AFFORDANCE_OVERHEAD = 2;
+
+/**
+ * Per-question cache for rendered markdown previews. Width-keyed: switching the
+ * inner width invalidates every cached `Markdown`'s render output (pi-tui's
+ * `Markdown.render(width)` re-wraps when width changes).
+ *
+ * Replaces the inline `previewTexts`, `markdownCache`, `cachedWidth` triple from
+ * the previous monolithic `preview-pane.ts`. One Markdown per option, lazy on
+ * first request, never re-constructed — count semantics frozen by tests.
+ */
+export class MarkdownContentCache {
+	private readonly previewTexts: Map<number, string>;
+	private readonly markdownCache: Map<number, Markdown>;
+	private cachedWidth: number | undefined;
+	private readonly theme: Theme;
+	private readonly markdownTheme: MarkdownTheme;
+
+	constructor(question: QuestionData, theme: Theme, markdownTheme: MarkdownTheme) {
+		this.theme = theme;
+		this.markdownTheme = markdownTheme;
+		this.previewTexts = new Map();
+		for (let i = 0; i < question.options.length; i++) {
+			const raw = question.options[i]?.preview;
+			if (raw && raw.length > 0) this.previewTexts.set(i, raw);
+		}
+		this.markdownCache = new Map();
+	}
+
+	hasAnyPreview(): boolean {
+		return this.previewTexts.size > 0;
+	}
+
+	has(optionIndex: number): boolean {
+		return this.previewTexts.has(optionIndex);
+	}
+
+	/**
+	 * Compute the body lines for a given option at a given inner width. Width changes
+	 * invalidate the per-Markdown render cache.
+	 */
+	bodyFor(optionIndex: number, innerWidth: number): string[] {
+		if (this.cachedWidth !== innerWidth) {
+			for (const md of this.markdownCache.values()) md.invalidate();
+			this.cachedWidth = innerWidth;
+		}
+		const text = this.previewTexts.get(optionIndex);
+		if (!text) {
+			const placeholder = this.theme.fg("dim", t("preview.no_preview", NO_PREVIEW_TEXT));
+			const pad = Math.max(0, innerWidth - visibleWidth(placeholder));
+			return [placeholder + " ".repeat(pad)];
+		}
+		let md = this.markdownCache.get(optionIndex);
+		if (!md) {
+			md = new Markdown(text, 0, 0, this.markdownTheme);
+			this.markdownCache.set(optionIndex, md);
+		}
+		return stripFenceMarkers(md.render(innerWidth));
+	}
+
+	invalidate(): void {
+		for (const md of this.markdownCache.values()) md.invalidate();
+		this.cachedWidth = undefined;
+	}
+}

--- a/packages/ask-user-question/view/components/preview/preview-block-renderer.ts
+++ b/packages/ask-user-question/view/components/preview/preview-block-renderer.ts
@@ -1,0 +1,109 @@
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import type { MarkdownTheme } from "@earendil-works/pi-tui";
+import { t } from "../../../state/i18n-bridge.js";
+import type { QuestionData } from "../../../tool/types.js";
+import {
+	MAX_PREVIEW_HEIGHT_SIDE_BY_SIDE,
+	MAX_PREVIEW_HEIGHT_STACKED,
+	MarkdownContentCache,
+	NOTES_AFFORDANCE_OVERHEAD,
+} from "./markdown-content-cache.js";
+import {
+	BORDER_HORIZONTAL_OVERHEAD,
+	BORDER_INNER_PADDING_HORIZONTAL,
+	BORDER_VERTICAL_OVERHEAD,
+	computeBoxDimensions,
+	renderBorderedBox,
+} from "./preview-box-renderer.js";
+import type { PreviewLayoutMode } from "./preview-layout-decider.js";
+
+/**
+ * Affordance text shown below the bordered preview when focused on a preview-bearing option.
+ * Re-exported by `preview-pane.ts` for the existing test surface.
+ */
+export const NOTES_AFFORDANCE_TEXT = "Notes: press n to add notes";
+
+export interface PreviewBlockRendererConfig {
+	question: QuestionData;
+	theme: Theme;
+	markdownTheme: MarkdownTheme;
+}
+
+/**
+ * Renders the bordered markdown preview block for a single question (one block per render call,
+ * for the option at `optionIndex`). Owns a per-question `MarkdownContentCache`.
+ *
+ * NOT a `Component` — pure render-and-measure helper consumed by `PreviewPane`. The layout mode
+ * is threaded as an explicit param (never re-derived from column width post-split).
+ *
+ * The affordance row is always emitted (visually empty when gated) so the preview block's row
+ * count is height-stable across affordance-state transitions.
+ */
+export class PreviewBlockRenderer {
+	private readonly theme: Theme;
+	private readonly cache: MarkdownContentCache;
+
+	constructor(config: PreviewBlockRendererConfig) {
+		this.theme = config.theme;
+		this.cache = new MarkdownContentCache(config.question, config.theme, config.markdownTheme);
+	}
+
+	hasAnyPreview(): boolean {
+		return this.cache.hasAnyPreview();
+	}
+
+	has(optionIndex: number): boolean {
+		return this.cache.has(optionIndex);
+	}
+
+	invalidate(): void {
+		this.cache.invalidate();
+	}
+
+	/**
+	 * Height contribution of the preview block: `BORDER_VERTICAL_OVERHEAD + contentRows +
+	 * NOTES_AFFORDANCE_OVERHEAD`. Always returns the same value as `renderBlock(...).length`
+	 * — the affordance overhead is constant, not gated by `focused`/`notesVisible`.
+	 */
+	blockHeight(width: number, optionIndex: number, mode: PreviewLayoutMode): number {
+		const cap = mode === "side-by-side" ? MAX_PREVIEW_HEIGHT_SIDE_BY_SIDE : MAX_PREVIEW_HEIGHT_STACKED;
+		const contentBudget = Math.max(1, cap - BORDER_VERTICAL_OVERHEAD - NOTES_AFFORDANCE_OVERHEAD);
+		const innerWidth = Math.max(1, width - BORDER_HORIZONTAL_OVERHEAD - 2 * BORDER_INNER_PADDING_HORIZONTAL);
+		const rawRows = this.cache.bodyFor(optionIndex, innerWidth).length;
+		const contentRows = Math.min(rawRows, contentBudget);
+		return BORDER_VERTICAL_OVERHEAD + contentRows + NOTES_AFFORDANCE_OVERHEAD;
+	}
+
+	/**
+	 * Render the full preview block at `width`: bordered box + blank separator + affordance row.
+	 * `focused` and `notesVisible` together gate the affordance text (visible only when the
+	 * focused option carries a preview AND notes mode is inactive). The affordance row is ALWAYS
+	 * emitted (as an empty string when gated) so the row count is invariant.
+	 */
+	renderBlock(
+		width: number,
+		optionIndex: number,
+		mode: PreviewLayoutMode,
+		focused: boolean,
+		notesVisible: boolean,
+	): string[] {
+		const cap = mode === "side-by-side" ? MAX_PREVIEW_HEIGHT_SIDE_BY_SIDE : MAX_PREVIEW_HEIGHT_STACKED;
+		const contentBudget = Math.max(1, cap - BORDER_VERTICAL_OVERHEAD - NOTES_AFFORDANCE_OVERHEAD);
+		const maxInnerWidth = Math.max(1, width - BORDER_HORIZONTAL_OVERHEAD - 2 * BORDER_INNER_PADDING_HORIZONTAL);
+
+		const raw = this.cache.bodyFor(optionIndex, maxInnerWidth);
+		const truncated = raw.length > contentBudget;
+		const hidden = truncated ? raw.length - contentBudget : 0;
+		const contentLines = truncated ? raw.slice(0, contentBudget) : raw;
+
+		const { boxWidth } = computeBoxDimensions(contentLines, maxInnerWidth);
+		const colorFn = (s: string) => this.theme.fg("accent", s);
+		const boxedLines = renderBorderedBox(contentLines, boxWidth, colorFn, hidden);
+
+		const showAffordance = focused && !notesVisible && this.cache.has(optionIndex);
+		const affordance = showAffordance
+			? this.theme.fg("muted", t("preview.notes_affordance", NOTES_AFFORDANCE_TEXT))
+			: "";
+		return [...boxedLines, "", affordance];
+	}
+}

--- a/packages/ask-user-question/view/components/preview/preview-box-renderer.ts
+++ b/packages/ask-user-question/view/components/preview/preview-box-renderer.ts
@@ -1,0 +1,86 @@
+import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+
+const ANSI_SGR_RE = /\x1b\[[0-9;]*m/g;
+const ANSI_OSC8_RE = /\x1b\]8;[^\x07\x1b]*(?:\x07|\x1b\\)/g;
+const FENCE_MARKER_RE = /^`{3}/;
+
+/** Top + bottom border rows consumed by `renderBorderedBox`. */
+export const BORDER_VERTICAL_OVERHEAD = 2;
+/** Left + right vertical bar columns (`│ ... │`) consumed by `renderBorderedBox`. */
+export const BORDER_HORIZONTAL_OVERHEAD = 2;
+/** Inner horizontal padding (1 col) between each border bar and content area. */
+export const BORDER_INNER_PADDING_HORIZONTAL = 1;
+/** Floor for the preview box's inner content width — CC parity (`PreviewBox.minWidth`). */
+export const BOX_MIN_CONTENT_WIDTH = 40;
+
+/**
+ * Drops fenced-code-block marker lines (` ``` ` opener/closer) from rendered markdown.
+ * pi-tui's Markdown emits literal opening ` ```lang ` and closing ` ``` ` lines around
+ * code blocks; this strip leaves only the highlighted code body. Inline code
+ * (`codespan`) is unaffected — pi-tui already renders it without backticks.
+ */
+export function stripFenceMarkers(lines: readonly string[]): string[] {
+	return lines.filter((line) => {
+		const clean = line.replace(ANSI_SGR_RE, "").replace(ANSI_OSC8_RE, "");
+		return !FENCE_MARKER_RE.test(clean);
+	});
+}
+
+/**
+ * Wraps `lines` in a 4-sided ASCII border with 1 col of inner horizontal padding.
+ * Layout per content row: `│` + ` ` + content padded to `contentInner` + ` ` + `│`,
+ * where `contentInner = width - BORDER_HORIZONTAL_OVERHEAD - 2 * BORDER_INNER_PADDING_HORIZONTAL`.
+ * Top/bottom dash runs span corner-to-corner (`width - BORDER_HORIZONTAL_OVERHEAD`). When
+ * `hidden > 0`, the bottom-row dash run is replaced with ` ✂ ── N lines hidden ── ` (corners stay).
+ */
+export function renderBorderedBox(
+	lines: readonly string[],
+	width: number,
+	colorFn: (s: string) => string,
+	hidden = 0,
+): string[] {
+	const dashSpan = Math.max(1, width - BORDER_HORIZONTAL_OVERHEAD);
+	const contentInner = Math.max(1, dashSpan - 2 * BORDER_INNER_PADDING_HORIZONTAL);
+	const pad = " ".repeat(BORDER_INNER_PADDING_HORIZONTAL);
+	const top = colorFn(`┌${"─".repeat(dashSpan)}┐`);
+	const out: string[] = [top];
+	for (const line of lines) {
+		const padded = truncateToWidth(line, contentInner, "", true);
+		out.push(`${colorFn("│")}${pad}${padded}${pad}${colorFn("│")}`);
+	}
+	if (hidden > 0) {
+		const indicator = ` ✂ ── ${hidden} lines hidden ── `;
+		const space = dashSpan - indicator.length;
+		const leftFill = "─".repeat(Math.max(0, Math.floor(space / 2)));
+		const rightFill = "─".repeat(Math.max(0, dashSpan - leftFill.length - indicator.length));
+		out.push(colorFn(`└${leftFill}${indicator}${rightFill}┘`));
+	} else {
+		out.push(colorFn(`└${"─".repeat(dashSpan)}┘`));
+	}
+	return out;
+}
+
+/**
+ * Compute box dimensions from content lines. Pure of args.
+ *
+ * CC parity:
+ *   contentWidth = max(minWidth, widestRenderedLine)
+ *   boxWidth     = min(contentWidth + 4, effectiveMaxWidth)
+ *
+ * Trailing whitespace is stripped before measuring because pi-tui's
+ * `Markdown.render(width)` pads every line to `width`, which would otherwise force
+ * the box to fill the whole column allocation.
+ */
+export function computeBoxDimensions(
+	contentLines: readonly string[],
+	maxInnerWidth: number,
+): { innerWidth: number; boxWidth: number } {
+	let widest = Math.min(BOX_MIN_CONTENT_WIDTH, maxInnerWidth);
+	for (const line of contentLines) {
+		const w = visibleWidth(line.replace(/\s+$/, ""));
+		if (w > widest) widest = w;
+	}
+	const innerWidth = Math.min(widest, maxInnerWidth);
+	const boxWidth = innerWidth + BORDER_HORIZONTAL_OVERHEAD + 2 * BORDER_INNER_PADDING_HORIZONTAL;
+	return { innerWidth, boxWidth };
+}

--- a/packages/ask-user-question/view/components/preview/preview-layout-decider.ts
+++ b/packages/ask-user-question/view/components/preview/preview-layout-decider.ts
@@ -1,0 +1,199 @@
+import { visibleWidth } from "@earendil-works/pi-tui";
+import type { QuestionData } from "../../../tool/types.js";
+import type { WrappingSelectItem } from "../wrapping-select.js";
+import { BORDER_HORIZONTAL_OVERHEAD, BORDER_INNER_PADDING_HORIZONTAL } from "./preview-box-renderer.js";
+
+/** Min terminal/pane width for the side-by-side layout to engage. */
+export const PREVIEW_MIN_WIDTH = 100;
+/** Visual gap between options column and preview column in side-by-side. */
+export const PREVIEW_COLUMN_GAP = 2;
+/** 1 col padding inside the preview column (between gap and `│`). */
+export const PREVIEW_PADDING_LEFT = 1;
+/** Empty rows between options and preview blocks in stacked (narrow) layout. */
+export const STACKED_GAP_ROWS = 1;
+
+/** Floor for the adaptive left column width — prevents collapse on short labels. */
+export const MIN_LEFT = 30;
+/** Ceiling ratio: left column never exceeds this fraction of pane width. */
+export const MAX_LEFT_RATIO = 0.5;
+/** Floor for the preview column width — prevents right-side collapse on narrow terminals. */
+export const MIN_PREVIEW_WIDTH = 45;
+/** visibleWidth(" ✔") = 2 (space + ✔ codepoint). Reserved on the longest-label measurement
+ *  so a confirmed row never gets truncated when MIN_LEFT clamps the column. */
+export const CONFIRMED_OVERHEAD = 2;
+
+export type PreviewLayoutMode = "side-by-side" | "stacked";
+
+/**
+ * Decide layout mode from terminal + pane widths. Pure of inputs.
+ *
+ * The terminal-width gate is the AND check from the previous `preview-pane.ts` —
+ * lifted here so the decision is computed ONCE per render and threaded explicitly
+ * through `previewBlockHeight`. Removes the bug class where `previewBlockHeight`
+ * re-derived `sideBySide` from a column width (already < pane width post-split),
+ * capping height too short.
+ */
+export function decideLayout(terminalWidth: number, paneWidth: number): PreviewLayoutMode {
+	return terminalWidth >= PREVIEW_MIN_WIDTH && paneWidth >= PREVIEW_MIN_WIDTH ? "side-by-side" : "stacked";
+}
+
+/**
+ * Compute the adaptive left column width from option labels.
+ * Pure function — deterministic for a given (items, totalForNumbering, paneWidth).
+ *
+ * Pipeline:
+ *   1. Measure: longest visible label width + prefix overhead + confirmed-mark overhead
+ *   2. Clamp: floor MIN_LEFT, ceiling paneWidth * MAX_LEFT_RATIO
+ *   3. Safety net: never exceed available = paneWidth - GAP - MIN_PREVIEW_WIDTH
+ */
+export function adaptiveLeftWidth(
+	items: readonly WrappingSelectItem[],
+	totalForNumbering: number,
+	paneWidth: number,
+): number {
+	const prefixW = String(Math.max(1, totalForNumbering)).length + 4; // digits + "❯ " + ". "
+	const confirmedOverhead = CONFIRMED_OVERHEAD; // visibleWidth(" ✔") = 2 (space + ✔ codepoint)
+	let maxLabel = 0;
+	for (const item of items) {
+		const w = visibleWidth(item.label);
+		if (w > maxLabel) maxLabel = w;
+	}
+	const desired = maxLabel + prefixW + confirmedOverhead;
+	const ratioCapped = Math.min(desired, Math.floor(paneWidth * MAX_LEFT_RATIO));
+	const available = paneWidth - PREVIEW_COLUMN_GAP - MIN_PREVIEW_WIDTH;
+	return Math.max(MIN_LEFT, Math.min(ratioCapped, Math.max(1, available)));
+}
+
+/**
+ * Cross-tab maximum left-column width. Aggregates `adaptiveLeftWidth` over every tab
+ * and returns the widest result, so the options column stays stable on tab switch.
+ *
+ * Pure function — `tabs.length` MUST equal `itemsByTab.length`. Multi-select tabs
+ * use `items.length` for numbering; single-select tabs add 1 for the chat row slot.
+ * Floor is `MIN_LEFT` so an all-empty input still produces a usable column.
+ */
+export function crossTabMaxLeftWidth(
+	tabs: ReadonlyArray<{ multiSelect?: boolean }>,
+	itemsByTab: ReadonlyArray<readonly WrappingSelectItem[]>,
+	paneWidth: number,
+): number {
+	let max = MIN_LEFT;
+	for (let i = 0; i < tabs.length; i++) {
+		const items = itemsByTab[i] ?? [];
+		const totalForNumbering = tabs[i]?.multiSelect ? items.length : items.length + 1;
+		const tabWidth = adaptiveLeftWidth(items, totalForNumbering, paneWidth);
+		if (tabWidth > max) max = tabWidth;
+	}
+	return max;
+}
+
+/**
+ * Source-line probe: measures the widest source line across all options' previews.
+ * Returns 0 when no option carries a preview.
+ *
+ * V1 heuristic — works well for tree/table/heading/list content where source-line
+ * width ≈ rendered width. Paragraphs overstate (source width "wants" the full pane);
+ * the worst case is "donation does nothing useful" — fallback to the label-driven path.
+ * Upgrade path: replace with a render-width probe that invokes Markdown at a probe width.
+ *
+ * Pure function — O(total chars) per question; no Markdown invocation, no cache interaction.
+ */
+export function previewSourceWidth(question: QuestionData): number {
+	let max = 0;
+	for (const option of question.options) {
+		const text = option.preview;
+		if (!text) continue;
+		for (const line of text.split("\n")) {
+			const w = visibleWidth(line);
+			if (w > max) max = w;
+		}
+	}
+	return max;
+}
+
+/**
+ * Cross-tab/cross-option preview budget. Iterates all questions, computes each question's
+ * preview appetite via `previewSourceWidth`, adds box + padding overhead (5 cols), and
+ * returns the widest result. Floor is `MIN_PREVIEW_WIDTH` so a previewless question still
+ * reserves a usable column. Ceiling ensures the left column retains its `MIN_LEFT` floor.
+ *
+ * Pure function — same cross-tab max pattern as `crossTabMaxLeftWidth`.
+ */
+export function crossTabPreviewBudget(questions: readonly QuestionData[], paneWidth: number): number {
+	let max = MIN_PREVIEW_WIDTH;
+	for (const question of questions) {
+		const rawWidth = previewSourceWidth(question);
+		const capped = Math.min(rawWidth, paneWidth - PREVIEW_COLUMN_GAP - MIN_LEFT);
+		const budget = capped + BORDER_HORIZONTAL_OVERHEAD + 2 * BORDER_INNER_PADDING_HORIZONTAL + PREVIEW_PADDING_LEFT;
+		if (budget > max) max = budget;
+	}
+	return max;
+}
+
+/**
+ * Cross-tab left-column width with slack donation. Combines the label-driven width
+ * (from `crossTabMaxLeftWidth`) with the slack donated by narrow previews.
+ *
+ * Pipeline:
+ *   1. `labelDriven` = `crossTabMaxLeftWidth(tabs, itemsByTab, paneWidth)`
+ *   2. `previewBudget` = `crossTabPreviewBudget(questions, paneWidth)`
+ *   3. `slackDonation` = `paneWidth − GAP − previewBudget`
+ *   4. Return `min(max(labelDriven, slackDonation), ceiling)` where `ceiling = paneWidth − GAP − MIN_PREVIEW_WIDTH`
+ *
+ * Invariants:
+ *   - Floor: result ≥ MIN_LEFT (labelDriven ≥ MIN_LEFT)
+ *   - Preview floor: right column ≥ MIN_PREVIEW_WIDTH (ceiling enforces this)
+ *   - Cross-tab stability: both reductions are tab-independent
+ *   - Determinism: pure of (questions, itemsByTab, paneWidth)
+ *
+ * `crossTabMaxLeftWidth` is NOT replaced — it continues to exist as the primitive.
+ * `MAX_LEFT_RATIO` caps the label-driven path inside `adaptiveLeftWidth`; donation
+ * operates above the cap when preview slack is available.
+ */
+export function crossTabLeftWidthWithDonation(
+	tabs: ReadonlyArray<{ multiSelect?: boolean }>,
+	itemsByTab: ReadonlyArray<readonly WrappingSelectItem[]>,
+	questions: readonly QuestionData[],
+	paneWidth: number,
+): number {
+	const labelDriven = crossTabMaxLeftWidth(tabs, itemsByTab, paneWidth);
+	// Compact-content guard: labels at MIN_LEFT fit below the floor, so widening
+	// the column would only inject dead space between the option list and the
+	// preview box. Skip donation and preserve the compact intent.
+	if (labelDriven <= MIN_LEFT) return labelDriven;
+	const previewBudget = crossTabPreviewBudget(questions, paneWidth);
+	const slackDonation = paneWidth - PREVIEW_COLUMN_GAP - previewBudget;
+	const ceiling = paneWidth - PREVIEW_COLUMN_GAP - MIN_PREVIEW_WIDTH;
+	return Math.min(Math.max(labelDriven, slackDonation), Math.max(1, ceiling));
+}
+
+/**
+ * Width allocation for side-by-side mode.
+ * `adaptiveLeft` is the pre-computed left column width (from `adaptiveLeftWidth`,
+ * cross-tab aggregated). The Math.max(1, ...) calls keep both columns >= 1 col on
+ * extreme inputs.
+ */
+export function columnWidths(
+	paneWidth: number,
+	adaptiveLeft: number,
+): { leftWidth: number; rightWidth: number; gap: number } {
+	const gap = PREVIEW_COLUMN_GAP;
+	const leftWidth = Math.min(adaptiveLeft, Math.max(1, paneWidth - gap - 1));
+	const rightWidth = Math.max(1, paneWidth - leftWidth - gap);
+	return { leftWidth, rightWidth, gap };
+}
+
+/**
+ * Returns the widths actually passed to `options.render` and `previewLines` inside
+ * `render()`. Stacked uses the full pane width for both; side-by-side splits via
+ * `columnWidths`, with the preview column offset by `PREVIEW_PADDING_LEFT`.
+ */
+export function bodyWidths(
+	paneWidth: number,
+	mode: PreviewLayoutMode,
+	adaptiveLeft: number,
+): { optionsWidth: number; previewWidth: number } {
+	if (mode === "stacked") return { optionsWidth: paneWidth, previewWidth: paneWidth };
+	const { leftWidth, rightWidth } = columnWidths(paneWidth, adaptiveLeft);
+	return { optionsWidth: leftWidth, previewWidth: Math.max(1, rightWidth - PREVIEW_PADDING_LEFT) };
+}

--- a/packages/ask-user-question/view/components/preview/preview-pane.ts
+++ b/packages/ask-user-question/view/components/preview/preview-pane.ts
@@ -1,0 +1,205 @@
+import { type Component, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import type { QuestionData } from "../../../tool/types.js";
+import type { StatefulView } from "../../stateful-view.js";
+import type { OptionListView } from "../option-list-view.js";
+import type { PreviewBlockRenderer } from "./preview-block-renderer.js";
+import {
+	bodyWidths,
+	columnWidths,
+	decideLayout,
+	PREVIEW_PADDING_LEFT,
+	type PreviewLayoutMode,
+	STACKED_GAP_ROWS,
+} from "./preview-layout-decider.js";
+
+// ----- Re-exports for test imports — keep `./preview-pane.js` as the public surface -----
+export {
+	MAX_PREVIEW_HEIGHT_SIDE_BY_SIDE,
+	MAX_PREVIEW_HEIGHT_STACKED,
+	NO_PREVIEW_TEXT,
+	NOTES_AFFORDANCE_OVERHEAD,
+} from "./markdown-content-cache.js";
+export { NOTES_AFFORDANCE_TEXT, PreviewBlockRenderer } from "./preview-block-renderer.js";
+export {
+	BORDER_HORIZONTAL_OVERHEAD,
+	BORDER_INNER_PADDING_HORIZONTAL,
+	BORDER_VERTICAL_OVERHEAD,
+	BOX_MIN_CONTENT_WIDTH,
+	renderBorderedBox,
+	stripFenceMarkers,
+} from "./preview-box-renderer.js";
+export {
+	PREVIEW_COLUMN_GAP,
+	PREVIEW_MIN_WIDTH,
+	PREVIEW_PADDING_LEFT,
+	STACKED_GAP_ROWS,
+} from "./preview-layout-decider.js";
+
+/**
+ * Per-tick projection of PreviewPane state. Replaces the prior
+ * `setNotesVisible(boolean)` sliver-setter and the sibling reads of
+ * `optionListView.getSelectedIndex()` / `isFocused()`. The pane now reads
+ * `selectedIndex` and `focused` from its own props — both derived from
+ * canonical state via `selectPreviewPaneProps`. `OptionListView` and
+ * `PreviewPane` see the same source of truth without the cross-component
+ * live read.
+ */
+export interface PreviewPaneProps {
+	notesVisible: boolean;
+	selectedIndex: number;
+	focused: boolean;
+}
+
+export interface PreviewPaneConfig {
+	question: QuestionData;
+	getTerminalWidth: () => number;
+	optionListView: OptionListView;
+	previewBlock: PreviewBlockRenderer;
+}
+
+/**
+ * Thin layout composer. Receives `selectedIndex` / `focused` / `notesVisible`
+ * via `setProps` per tick (computed by `selectPreviewPaneProps` from canonical
+ * state). Delegates option-side rendering to `OptionListView` (which still
+ * owns its render-time state — input buffer, confirmedIndex) and preview-side
+ * rendering to `PreviewBlockRenderer` (which owns the markdown cache and
+ * bordered-box composition).
+ *
+ * `naturalHeight` and `maxNaturalHeight` query both children's heights; `render`
+ * combines them via `decideLayout` (mode threaded into both calls — never
+ * re-derived).
+ */
+export class PreviewPane implements StatefulView<PreviewPaneProps>, Component {
+	private readonly question: QuestionData;
+	private readonly getTerminalWidth: () => number;
+	private readonly optionListView: OptionListView;
+	private readonly previewBlock: PreviewBlockRenderer;
+	private props: PreviewPaneProps;
+	/**
+	 * Cross-tab max left-width getter. Set exactly once by `buildQuestionnaire.injectGlobalLeftWidth`
+	 * before any render. Initialized to a throwing sentinel so missing injection is a hard fail
+	 * rather than a silent fallback to a magic constant — render is illegal until injected.
+	 */
+	private globalLeftWidth: (paneWidth: number) => number = () => {
+		throw new Error("PreviewPane.setGlobalLeftWidth must be called before render()");
+	};
+
+	constructor(config: PreviewPaneConfig) {
+		this.question = config.question;
+		this.getTerminalWidth = config.getTerminalWidth;
+		this.optionListView = config.optionListView;
+		this.previewBlock = config.previewBlock;
+		this.props = { notesVisible: false, selectedIndex: 0, focused: false };
+	}
+
+	setGlobalLeftWidth(getter: (paneWidth: number) => number): void {
+		this.globalLeftWidth = getter;
+	}
+
+	private getAdaptiveLeft(paneWidth: number): number {
+		return this.globalLeftWidth(paneWidth);
+	}
+
+	setProps(props: PreviewPaneProps): void {
+		this.props = props;
+	}
+
+	handleInput(_data: string): void {}
+
+	invalidate(): void {
+		this.previewBlock.invalidate();
+		this.optionListView.invalidate();
+	}
+
+	render(width: number): string[] {
+		if (this.question.multiSelect === true) return this.optionListView.render(width);
+		// Spec: hide the preview pane entirely when no option carries a `preview`.
+		if (!this.previewBlock.hasAnyPreview()) return this.optionListView.render(width);
+
+		const mode = decideLayout(this.getTerminalWidth(), width);
+		if (mode === "side-by-side") return this.renderSideBySide(width, mode);
+
+		// Stacked: options + blank gap + preview block.
+		return [
+			...this.optionListView.render(width),
+			...Array(STACKED_GAP_ROWS).fill(""),
+			...this.previewBlock.renderBlock(
+				width,
+				this.props.selectedIndex,
+				mode,
+				this.props.focused,
+				this.props.notesVisible,
+			),
+		];
+	}
+
+	focusedItemRowRange(width: number): [number, number] {
+		if (this.question.multiSelect === true) return this.optionListView.focusedItemRowRange(width);
+		if (!this.previewBlock.hasAnyPreview()) return this.optionListView.focusedItemRowRange(width);
+		const mode = decideLayout(this.getTerminalWidth(), width);
+		if (mode === "stacked") return this.optionListView.focusedItemRowRange(width);
+		const adaptiveLeft = this.getAdaptiveLeft(width);
+		const { leftWidth } = columnWidths(width, adaptiveLeft);
+		return this.optionListView.focusedItemRowRange(leftWidth);
+	}
+
+	naturalHeight(width: number): number {
+		if (this.question.multiSelect === true) return this.optionListView.render(width).length;
+		if (!this.previewBlock.hasAnyPreview()) return this.optionListView.render(width).length;
+		const mode = decideLayout(this.getTerminalWidth(), width);
+		const adaptiveLeft = this.getAdaptiveLeft(width);
+		const { optionsWidth, previewWidth } = bodyWidths(width, mode, adaptiveLeft);
+		const optionsHeight = this.optionListView.render(optionsWidth).length;
+		const previewBlockHeight = this.previewBlock.blockHeight(previewWidth, this.props.selectedIndex, mode);
+		if (mode === "side-by-side") return Math.max(optionsHeight, previewBlockHeight);
+		return optionsHeight + STACKED_GAP_ROWS + previewBlockHeight;
+	}
+
+	maxNaturalHeight(width: number): number {
+		if (this.question.multiSelect === true) return this.optionListView.render(width).length;
+		if (!this.previewBlock.hasAnyPreview()) return this.optionListView.render(width).length;
+		const mode = decideLayout(this.getTerminalWidth(), width);
+		const adaptiveLeft = this.getAdaptiveLeft(width);
+		const { optionsWidth, previewWidth } = bodyWidths(width, mode, adaptiveLeft);
+		const optionsHeight = this.optionListView.render(optionsWidth).length;
+		let maxPreviewBlock = 0;
+		for (let i = 0; i < this.question.options.length; i++) {
+			const h = this.previewBlock.blockHeight(previewWidth, i, mode);
+			if (h > maxPreviewBlock) maxPreviewBlock = h;
+		}
+		if (mode === "side-by-side") return Math.max(optionsHeight, maxPreviewBlock);
+		return optionsHeight + STACKED_GAP_ROWS + maxPreviewBlock;
+	}
+
+	private renderSideBySide(width: number, mode: PreviewLayoutMode): string[] {
+		const adaptiveLeft = this.getAdaptiveLeft(width);
+		const { leftWidth, rightWidth, gap } = columnWidths(width, adaptiveLeft);
+		const leftLines = this.optionListView.render(leftWidth);
+		const rightLines = this.renderPaddedPreviewLines(rightWidth, mode);
+		const rows = Math.max(leftLines.length, rightLines.length);
+		const gapStr = " ".repeat(gap);
+		const out: string[] = [];
+		for (let i = 0; i < rows; i++) {
+			const leftRaw = leftLines[i] ?? "";
+			const rightRaw = rightLines[i] ?? "";
+			const leftClamped = truncateToWidth(leftRaw, leftWidth, "");
+			const leftPad = " ".repeat(Math.max(0, leftWidth - visibleWidth(leftClamped)));
+			const joined = `${leftClamped}${leftPad}${gapStr}${rightRaw}`;
+			out.push(truncateToWidth(joined, width, ""));
+		}
+		return out;
+	}
+
+	private renderPaddedPreviewLines(colWidth: number, mode: PreviewLayoutMode): string[] {
+		const inner = Math.max(1, colWidth - PREVIEW_PADDING_LEFT);
+		const contentLines = this.previewBlock.renderBlock(
+			inner,
+			this.props.selectedIndex,
+			mode,
+			this.props.focused,
+			this.props.notesVisible,
+		);
+		const pad = " ".repeat(PREVIEW_PADDING_LEFT);
+		return contentLines.map((l) => (l === "" ? "" : `${pad}${l}`));
+	}
+}

--- a/packages/ask-user-question/view/components/submit-picker.ts
+++ b/packages/ask-user-question/view/components/submit-picker.ts
@@ -1,0 +1,65 @@
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { truncateToWidth } from "@earendil-works/pi-tui";
+import { t } from "../../state/i18n-bridge.js";
+import type { StatefulView } from "../stateful-view.js";
+
+const ACTIVE_POINTER = "❯ ";
+const INACTIVE_POINTER = "  ";
+const NUMBER_SEPARATOR = ". ";
+
+export const SUBMIT_LABEL = "Submit answers";
+export const CANCEL_LABEL = "Cancel";
+
+/**
+ * Per-tick projection of SubmitPicker state. The picker is a fixed 2-row
+ * structure (Submit / Cancel) — labels are static, only the active marker
+ * varies per tick. `selectSubmitPickerProps` precomputes `active` per row.
+ */
+export interface SubmitPickerProps {
+	/** Per-row active flag. Length always 2: row 0 = Submit, row 1 = Cancel. */
+	rows: ReadonlyArray<{ active: boolean }>;
+}
+
+/**
+ * Static 2-row picker rendered on the Submit Tab. Row 0 = "Submit answers", Row 1 = "Cancel".
+ *
+ * - Active pointer (❯) follows `props.rows[i].active` per tick.
+ * - Both rows render in normal style at all times — D1 (revised) allows partial submission,
+ *   so Submit is never dimmed or visually marked as unselectable. The warning header in
+ *   `buildSubmitContainer` is the sole signal of incompleteness.
+ * - `naturalHeight(width)` is state-INDEPENDENT and returns a constant 2, so the
+ *   chrome-mirror layout in `buildSubmitContainer` can subtract a fixed 2 lines without
+ *   re-rendering.
+ */
+export class SubmitPicker implements StatefulView<SubmitPickerProps> {
+	private props: SubmitPickerProps;
+
+	constructor(private readonly theme: Theme) {
+		this.props = { rows: [{ active: false }, { active: false }] };
+	}
+
+	setProps(props: SubmitPickerProps): void {
+		this.props = props;
+	}
+
+	handleInput(_data: string): void {}
+
+	invalidate(): void {}
+
+	naturalHeight(_width: number): number {
+		return 2;
+	}
+
+	render(width: number): string[] {
+		const lines: string[] = [];
+		for (let i = 0; i < 2; i++) {
+			const text = i === 0 ? t("submit.label", SUBMIT_LABEL) : t("submit.cancel", CANCEL_LABEL);
+			const active = this.props.rows[i]?.active ?? false;
+			const pointer = active ? ACTIVE_POINTER : INACTIVE_POINTER;
+			const number = `${i + 1}${NUMBER_SEPARATOR}`;
+			const label = active ? this.theme.fg("accent", this.theme.bold(text)) : this.theme.fg("text", text);
+			lines.push(truncateToWidth(`${pointer}${number}${label}`, width, ""));
+		}
+		return lines;
+	}
+}

--- a/packages/ask-user-question/view/components/tab-bar.ts
+++ b/packages/ask-user-question/view/components/tab-bar.ts
@@ -1,0 +1,57 @@
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { truncateToWidth } from "@earendil-works/pi-tui";
+import type { StatefulView } from "../stateful-view.js";
+
+/**
+ * Per-tick projection of TabBar state. The selector
+ * (`selectTabBarProps`) hoists every render-time derivation
+ * (`allAnswered`, `answered`, `isActive`, `submitActive`) into props so
+ * `render()` is pure styling. Replaces the prior `setConfig(TabBarConfig)`
+ * snowflake and the inline `+ 1` magic at `props-adapter.ts:127`.
+ */
+export interface TabBarProps {
+	/** One per author-defined question, in order. */
+	tabs: ReadonlyArray<{ label: string; answered: boolean; active: boolean }>;
+	/** Submit-tab state. `allAnswered` drives the success/dim color picker. */
+	submit: { active: boolean; allAnswered: boolean };
+}
+
+export class TabBar implements StatefulView<TabBarProps> {
+	private props: TabBarProps;
+
+	constructor(private readonly theme: Theme) {
+		this.props = { tabs: [], submit: { active: false, allAnswered: false } };
+	}
+
+	setProps(props: TabBarProps): void {
+		this.props = props;
+	}
+
+	handleInput(_data: string): void {}
+
+	invalidate(): void {}
+
+	render(width: number): string[] {
+		const pieces: string[] = [" ← "];
+
+		for (const tab of this.props.tabs) {
+			const box = tab.answered ? "■" : "□";
+			const rawSeg = ` ${box} ${tab.label} `;
+			const styled = tab.active
+				? this.theme.bg("selectedBg", this.theme.fg("text", rawSeg))
+				: this.theme.fg(tab.answered ? "success" : "muted", rawSeg);
+			pieces.push(styled);
+			pieces.push(" ");
+		}
+
+		const submitText = " ✓ Submit ";
+		const submitStyled = this.props.submit.active
+			? this.theme.bg("selectedBg", this.theme.fg("text", submitText))
+			: this.theme.fg(this.props.submit.allAnswered ? "success" : "dim", submitText);
+		pieces.push(submitStyled);
+		pieces.push(" →");
+
+		const tabLine = truncateToWidth(pieces.join(""), width, "");
+		return [tabLine, ""];
+	}
+}

--- a/packages/ask-user-question/view/components/wrapping-select.ts
+++ b/packages/ask-user-question/view/components/wrapping-select.ts
@@ -1,0 +1,330 @@
+import type { Component } from "@earendil-works/pi-tui";
+import { CURSOR_MARKER, visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
+
+// Grapheme-aware extraction at the cursor: pi-tui's Input advances `cursor` by
+// grapheme-cluster code-unit length, so the cursor can land between code units of
+// one cluster (emoji, ZWJ, combining marks). Single-code-unit slicing would split
+// the cluster across the SGR 7/27 boundary.
+const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+
+/**
+ * Row-intent discriminated union. `kind` is the single discriminator —
+ * pre-1.0.3 boolean flags have been removed (see `banned-flags.test.ts`).
+ * Modeled after `QuestionnaireAction` (`key-router.ts:13-32`) and `Effect`
+ * (`state-reducer.ts:26-32`) — pure literal-tagged variants, no shared base,
+ * exhaustive-`switch` enforcement via non-`void` returns.
+ *
+ * Variant semantics:
+ * - `option`: a regular author-defined option row.
+ * - `other`: the inline free-text input row appended to single-select questions
+ *   (label is "Type something."). Renders as inline `Input` when active.
+ * - `chat`: the abandon-questionnaire escape-hatch row (label is "Chat about this").
+ * - `next`: the explicit commit-and-advance row appended to multi-select questions
+ *   (label is "Next"). Renders without a number / checkbox.
+ */
+export type WrappingSelectItem =
+	| { kind: "option"; label: string; description?: string }
+	| { kind: "other"; label: string; description?: string }
+	| { kind: "chat"; label: string; description?: string }
+	| { kind: "next"; label: string; description?: string };
+
+export interface WrappingSelectTheme {
+	selectedText: (text: string) => string;
+	description: (text: string) => string;
+	scrollInfo: (text: string) => string;
+}
+
+/**
+ * Numbering controls.
+ *
+ * Use `numberStartOffset` + `totalItemsForNumbering` when a list is logically a slice of a
+ * larger numbered sequence — e.g. the chat row lives in its own WrappingSelect but should
+ * render as `(N+1).` where N is the previous list's item count, with the column padded as
+ * if both lists were one continuous numbered sequence.
+ */
+export interface WrappingSelectOptions {
+	/** Start numbering at this offset + 1 (default 0 → rows labeled 1, 2, 3 …). */
+	numberStartOffset?: number;
+	/** Override the total used to pad the number column (useful when items span multiple lists). */
+	totalItemsForNumbering?: number;
+}
+
+export class WrappingSelect implements Component {
+	private static readonly ACTIVE_POINTER = "❯ ";
+	private static readonly INACTIVE_POINTER = "  ";
+	private static readonly NUMBER_SEPARATOR = ". ";
+	private static readonly CONFIRMED_MARK = " ✔";
+	private static readonly MIN_CONTENT_WIDTH = 1;
+
+	private readonly items: readonly WrappingSelectItem[];
+	private readonly maxVisible: number;
+	private readonly theme: WrappingSelectTheme;
+	private numberStartOffset: number;
+	private totalItemsForNumbering: number;
+
+	private selectedIndex = 0;
+	private focused = true;
+	private inputBuffer = "";
+	private inputCursorOffset: number | undefined = undefined;
+	/**
+	 * Index of the row that was previously confirmed for this list (e.g. the user's prior
+	 * answer when re-entering a multi-question tab). Renders `<label> ✔` in the active-row
+	 * styling but WITHOUT the `❯` pointer — pointer is reserved for the live cursor. When
+	 * `selectedIndex === confirmedIndex && focused`, the active rendering wins (no double-mark).
+	 */
+	private confirmedIndex: number | undefined = undefined;
+	/**
+	 * When set together with `confirmedIndex`, replaces the row's static label at render time.
+	 * Used for the `kind: "other"` sentinel — its label is "Type something." but if the user's
+	 * prior answer was custom text, we render that text instead (e.g. `4. Hello ✔`).
+	 */
+	private confirmedLabelOverride: string | undefined = undefined;
+
+	constructor(
+		items: readonly WrappingSelectItem[],
+		maxVisible: number,
+		theme: WrappingSelectTheme,
+		options: WrappingSelectOptions = {},
+	) {
+		this.items = items;
+		this.maxVisible = Math.max(1, maxVisible);
+		this.theme = theme;
+		this.numberStartOffset = options.numberStartOffset ?? 0;
+		this.totalItemsForNumbering = options.totalItemsForNumbering ?? items.length;
+	}
+
+	/**
+	 * Update the numbering offset + total padding width without rebuilding the component.
+	 * Used by the host to keep the chat-row WrappingSelect's number aligned with the active tab's
+	 * options list when the user switches tabs (each tab can have a different items count).
+	 */
+	setNumbering(numberStartOffset: number, totalItemsForNumbering: number): void {
+		this.numberStartOffset = numberStartOffset;
+		this.totalItemsForNumbering = Math.max(1, totalItemsForNumbering);
+	}
+
+	setSelectedIndex(index: number): void {
+		this.selectedIndex = Math.max(0, Math.min(index, this.items.length - 1));
+	}
+
+	setFocused(focused: boolean): void {
+		this.focused = focused;
+	}
+
+	/**
+	 * Mark a previously-confirmed row. Pass `undefined` to clear. `labelOverride` replaces
+	 * the row's static `item.label` at render time — used for the `kind: "other"` sentinel so
+	 * the row reads `Hello ✔` instead of `Type something. ✔` when the prior answer was custom
+	 * text.
+	 */
+	setConfirmedIndex(index: number | undefined, labelOverride?: string): void {
+		if (index === undefined) {
+			this.confirmedIndex = undefined;
+			this.confirmedLabelOverride = undefined;
+			return;
+		}
+		this.confirmedIndex = Math.max(0, Math.min(index, this.items.length - 1));
+		this.confirmedLabelOverride = labelOverride;
+	}
+
+	setInputBuffer(text: string): void {
+		this.inputBuffer = text;
+	}
+
+	/** Set the cursor offset for the inline input row. `undefined` → end-of-buffer fallback. */
+	setInputCursorOffset(offset: number | undefined): void {
+		this.inputCursorOffset = offset;
+	}
+
+	/** Intentionally empty — input is routed at the container level. */
+	handleInput(_data: string): void {}
+
+	invalidate(): void {}
+
+	render(width: number): string[] {
+		if (this.items.length === 0) return [];
+
+		const { startIndex, endIndex } = this.computeVisibleWindow();
+		const numberWidth = String(Math.max(1, this.totalItemsForNumbering)).length;
+		const lines: string[] = [];
+
+		for (let i = startIndex; i < endIndex; i++) {
+			const item = this.items[i];
+			if (!item) continue;
+			const isActive = i === this.selectedIndex && this.focused;
+			lines.push(...this.renderItem(item, i, isActive, width, numberWidth));
+		}
+
+		if (this.hasItemsOutsideWindow(startIndex, endIndex)) {
+			lines.push(this.theme.scrollInfo(`  (${this.selectedIndex + 1}/${this.items.length})`));
+		}
+		return lines;
+	}
+
+	/**
+	 * Returns the [startRow, endRow) range of the focused (selected) item within
+	 * the output of `render(width)`. Computed by iterating the visible window and
+	 * summing per-item row counts — O(maxVisible) per call.
+	 */
+	focusedItemRowRange(width: number): [number, number] {
+		if (this.items.length === 0) return [0, 0];
+		const { startIndex, endIndex } = this.computeVisibleWindow();
+		const numberWidth = String(Math.max(1, this.totalItemsForNumbering)).length;
+		let row = 0;
+		for (let i = startIndex; i < endIndex; i++) {
+			const item = this.items[i];
+			if (!item) continue;
+			const isActive = i === this.selectedIndex && this.focused;
+			const itemRowCount = this.computeItemRowCount(item, i, isActive, width, numberWidth);
+			if (i === this.selectedIndex) {
+				return [row, row + itemRowCount];
+			}
+			row += itemRowCount;
+		}
+		return [0, 1];
+	}
+
+	/**
+	 * Per-item row count. Delegates to `renderItem().length` so `renderItem` remains
+	 * the single source of truth for per-item row math — eliminates the prior shadow-copy
+	 * that risked silent miscounts when new `kind` values branch in `renderItem` but not here.
+	 */
+	private computeItemRowCount(
+		item: WrappingSelectItem,
+		index: number,
+		isActive: boolean,
+		width: number,
+		numberWidth: number,
+	): number {
+		return this.renderItem(item, index, isActive, width, numberWidth).length;
+	}
+
+	private computeVisibleWindow(): { startIndex: number; endIndex: number } {
+		const half = Math.floor(this.maxVisible / 2);
+		const startIndex = Math.max(0, Math.min(this.selectedIndex - half, this.items.length - this.maxVisible));
+		const endIndex = Math.min(startIndex + this.maxVisible, this.items.length);
+		return { startIndex, endIndex };
+	}
+
+	private hasItemsOutsideWindow(startIndex: number, endIndex: number): boolean {
+		return startIndex > 0 || endIndex < this.items.length;
+	}
+
+	private renderItem(
+		item: WrappingSelectItem,
+		index: number,
+		isActive: boolean,
+		width: number,
+		numberWidth: number,
+	): string[] {
+		const rowPrefix = this.buildRowPrefix(index, isActive, numberWidth);
+		const continuationPrefix = " ".repeat(visibleWidth(rowPrefix));
+		const contentWidth = Math.max(WrappingSelect.MIN_CONTENT_WIDTH, width - visibleWidth(rowPrefix));
+
+		if (this.shouldRenderAsInlineInput(item, isActive)) {
+			return this.renderInlineInputRow(rowPrefix, continuationPrefix, contentWidth);
+		}
+
+		// Confirmed row gets a trailing ` ✔` and accent+bold styling; pointer is independent
+		// (still ❯ when active). When `index === confirmedIndex` AND `isActive`, both `❯` and
+		// `✔` appear on the same row — load-bearing for the case where the prior answer was
+		// row 0 (cursor resets to 0 on tab-back, so the confirmed row IS the active row).
+		// Optional `confirmedLabelOverride` replaces the static label (used for `kind: "other"`
+		// + `kind: "custom"` answer); the inline-input branch above still wins for `kind: "other" + isActive`.
+		const isConfirmed = index === this.confirmedIndex;
+		const label = isConfirmed
+			? `${this.confirmedLabelOverride ?? item.label}${WrappingSelect.CONFIRMED_MARK}`
+			: item.label;
+		const applySelectedStyle = isActive || isConfirmed;
+
+		return [
+			...this.renderLabelBlock(label, rowPrefix, continuationPrefix, contentWidth, applySelectedStyle),
+			...this.renderDescriptionBlock(item.description, continuationPrefix, contentWidth),
+		];
+	}
+
+	private buildRowPrefix(index: number, isActive: boolean, numberWidth: number): string {
+		const pointer = isActive ? WrappingSelect.ACTIVE_POINTER : WrappingSelect.INACTIVE_POINTER;
+		const displayNumber = this.numberStartOffset + index + 1;
+		const paddedNumber = String(displayNumber).padStart(numberWidth, " ");
+		return `${pointer}${paddedNumber}${WrappingSelect.NUMBER_SEPARATOR}`;
+	}
+
+	private shouldRenderAsInlineInput(item: WrappingSelectItem, isActive: boolean): boolean {
+		return item.kind === "other" && isActive;
+	}
+
+	/**
+	 * Render the inline input row across one or more lines, wrapping at `contentWidth`
+	 * so long input doesn't run off the right edge or trip the parent renderer's
+	 * width invariant. Mirrors `renderLabelBlock`'s contract: first line carries
+	 * `rowPrefix`, continuation lines carry `continuationPrefix` (spaces), and every
+	 * emitted line passes through `theme.selectedText`.
+	 *
+	 * Cursor visualization follows the standard TUI input-widget pattern (ECMA-48
+	 * SGR 7 reverse-video on the cell *at* the cursor, not an inserted glyph) —
+	 * same approach used by pi-tui Input.render (input.js:411-418), ink-text-input,
+	 * terkelg/prompts, ratatui's user-input example, etc. Split: `before | at | after`
+	 * where `at` is the single character under the cursor (or U+00A0 NBSP at end-of-
+	 * buffer) wrapped in `\x1b[7m…\x1b[27m`. No characters shift; the column under
+	 * the cursor inverts.
+	 *
+	 * pi-tui's zero-width `CURSOR_MARKER` (APC sentinel) is emitted immediately
+	 * before the `at` cell so the TUI framebuffer can position the hardware
+	 * terminal cursor at that column (visible iff pi's `showHardwareCursor`
+	 * setting is on — `pi-coding-agent/main.js:303`). `visibleWidth` strips the
+	 * marker as zero-width (utils.js:187-203), so wrap math is preserved.
+	 *
+	 * NBSP at end-of-buffer (rather than literal space): `wrapTextWithAnsi`
+	 * tokenizes on whitespace, so a literal space inside the reverse-video escape
+	 * pair would cause `wrapTextWithAnsi` to break the line at the cursor. NBSP
+	 * preserves the visible width-1 contribution without registering as a wrap
+	 * break — the conventional workaround documented across ANSI-aware string
+	 * wrappers.
+	 */
+	private renderInlineInputRow(rowPrefix: string, continuationPrefix: string, contentWidth: number): string[] {
+		const buffer = this.inputBuffer;
+		const requested = this.inputCursorOffset;
+		const offset =
+			requested !== undefined && requested >= 0 && requested <= buffer.length ? requested : buffer.length;
+		const before = buffer.slice(0, offset);
+		const [firstGrapheme] = graphemeSegmenter.segment(buffer.slice(offset));
+		const rawAt = firstGrapheme ? firstGrapheme.segment : "";
+		// Whitespace at cursor (including end-of-buffer fallback) tokenizes as a wrap
+		// break inside `wrapTextWithAnsi`, splitting the line at the cursor. Substitute
+		// U+00A0 (NBSP): visually identical to a space, wrap-safe.
+		const atCursor = rawAt === "" || rawAt === " " ? " " : rawAt;
+		const after = buffer.slice(offset + rawAt.length);
+		const raw = `${before}${CURSOR_MARKER}\x1b[7m${atCursor}\x1b[27m${after}`;
+		const wrapped = wrapTextWithAnsi(raw, contentWidth);
+		return wrapped.map((segment, index) => {
+			const prefix = index === 0 ? rowPrefix : continuationPrefix;
+			return this.theme.selectedText(`${prefix}${segment}`);
+		});
+	}
+
+	private renderLabelBlock(
+		label: string,
+		rowPrefix: string,
+		continuationPrefix: string,
+		contentWidth: number,
+		applySelectedStyle: boolean,
+	): string[] {
+		const wrapped = wrapTextWithAnsi(label, contentWidth);
+		return wrapped.map((segment, index) => {
+			const prefix = index === 0 ? rowPrefix : continuationPrefix;
+			const line = `${prefix}${segment}`;
+			return applySelectedStyle ? this.theme.selectedText(line) : line;
+		});
+	}
+
+	private renderDescriptionBlock(
+		description: string | undefined,
+		continuationPrefix: string,
+		contentWidth: number,
+	): string[] {
+		if (!description) return [];
+		const wrapped = wrapTextWithAnsi(description, contentWidth);
+		return wrapped.map((segment) => `${continuationPrefix}${this.theme.description(segment)}`);
+	}
+}

--- a/packages/ask-user-question/view/dialog-builder.ts
+++ b/packages/ask-user-question/view/dialog-builder.ts
@@ -1,0 +1,220 @@
+import { DynamicBorder, type Theme } from "@earendil-works/pi-coding-agent";
+import { type Component, Container, type Input, Spacer } from "@earendil-works/pi-tui";
+import type { QuestionnaireState } from "../state/state.js";
+import type { QuestionData } from "../tool/types.js";
+import type { ChatRowView } from "./components/chat-row-view.js";
+import type { PreviewPaneProps } from "./components/preview/preview-pane.js";
+import type { TabBar } from "./components/tab-bar.js";
+import type { StatefulView } from "./stateful-view.js";
+import type { TabComponents } from "./tab-components.js";
+import { QuestionTabStrategy, SubmitTabStrategy, type TabContentStrategy } from "./tab-content-strategy.js";
+
+export const HINT_PART_ENTER = "Enter to select";
+export const HINT_PART_NAV = "↑/↓ to navigate";
+export const HINT_PART_TOGGLE = "Space to toggle";
+export const HINT_PART_NOTES = "n to add notes";
+export const HINT_PART_TAB = "Tab to switch questions";
+export const HINT_PART_CANCEL = "Esc to cancel";
+export const HINT_PART_COLLAPSE = "Ctrl+] to collapse";
+export const HINT_PART_EXPAND = "Ctrl+] to expand";
+/**
+ * `HINT_SINGLE` / `HINT_MULTI` describe the CORE hint that must always be visible —
+ * the collapse affordance is appended AFTER cancel by `buildHintText` so the core
+ * stays a contiguous prefix substring of the rendered line. On narrow terminals the
+ * collapse tail clips with `…` (`OneLineClippedText`); the core is preserved.
+ */
+export const HINT_SINGLE = [HINT_PART_ENTER, HINT_PART_NAV, HINT_PART_CANCEL].join(" · ");
+export const HINT_MULTI = [HINT_PART_ENTER, HINT_PART_NAV, HINT_PART_TAB, HINT_PART_CANCEL].join(" · ");
+export const HINT_MULTISELECT_SUFFIX = ` · ${HINT_PART_TOGGLE}`;
+export const HINT_NOTES_SUFFIX = ` · ${HINT_PART_NOTES}`;
+/** Single-line footer shown by `QuestionnaireSession` when `state.collapsed === true`. Bypasses `buildHintText`. */
+export const COLLAPSED_HINT = [HINT_PART_EXPAND, HINT_PART_CANCEL].join(" · ");
+export const REVIEW_HEADING = "Review your answers";
+export const READY_PROMPT = "Ready to submit your answers?";
+export const INCOMPLETE_WARNING_PREFIX = "⚠ Answer remaining questions before submitting:";
+
+const OVERFLOW_UP = "↑";
+const OVERFLOW_DOWN = "↓";
+const OVERFLOW_BOTH = "↕";
+
+export type DialogState = QuestionnaireState;
+
+/** Per-tick projection of dialog state. Written by the adapter; read by the strategy thunk. */
+export interface DialogProps {
+	state: DialogState;
+	activePreviewPane: StatefulView<PreviewPaneProps>;
+}
+
+/** Construction-time config for `DialogView`. Frozen after construction. */
+export interface DialogConfig {
+	theme: Theme;
+	questions: readonly QuestionData[];
+	tabBar: TabBar | undefined;
+	notesInput: Input;
+	chatRow: ChatRowView;
+	isMulti: boolean;
+	tabsByIndex: ReadonlyArray<TabComponents>;
+	/** Optional so single-question mode and non-submit tests can omit it; SubmitTabStrategy falls back to Spacer rows. */
+	submitPicker?: Component;
+	/** Worst-case body height across all tabs/options. Determines the stable overall dialog footprint. */
+	getBodyHeight: (width: number) => number;
+	/** Body height of the CURRENTLY active tab/option. The chrome subtracts this from `getBodyHeight` to absorb the residual OUTSIDE the bordered region. */
+	getCurrentBodyHeight: (width: number) => number;
+	/** Terminal height getter. Mirrors `getTerminalWidth` — reads `tui.terminal.rows` at render time. */
+	getTerminalRows: () => number;
+}
+
+/**
+ * The 7th renderable, promoted from a structural literal to a named class so
+ * all view-layer components share one explicit `implements StatefulView<P>`
+ * contract. `setProps(DialogProps)` writes the live cell read by the
+ * strategy thunk during `render()`. `liveProps.activePreviewPane` is a
+ * resolved pane reference threaded by the adapter per tick — the dialog
+ * itself does not derive it.
+ */
+export class DialogView implements StatefulView<DialogProps> {
+	private liveProps: DialogProps;
+	private readonly config: DialogConfig;
+	private readonly questionStrategy: TabContentStrategy;
+	private readonly submitStrategy: TabContentStrategy | undefined;
+	private readonly maxFooterRowCount: number;
+
+	constructor(config: DialogConfig, initialProps: DialogProps) {
+		this.config = config;
+		this.liveProps = initialProps;
+		this.questionStrategy = new QuestionTabStrategy({
+			theme: config.theme,
+			questions: config.questions,
+			getPreviewPane: () => this.liveProps.activePreviewPane,
+			tabsByIndex: config.tabsByIndex,
+			notesInput: config.notesInput,
+			chatRow: config.chatRow,
+			isMulti: config.isMulti,
+			getCurrentBodyHeight: config.getCurrentBodyHeight,
+		});
+		this.submitStrategy = config.isMulti
+			? new SubmitTabStrategy({
+					theme: config.theme,
+					questions: config.questions,
+					submitPicker: config.submitPicker,
+				})
+			: undefined;
+		this.maxFooterRowCount = Math.max(this.questionStrategy.footerRowCount, this.submitStrategy?.footerRowCount ?? 0);
+	}
+
+	setProps(props: DialogProps): void {
+		this.liveProps = props;
+	}
+
+	handleInput(_data: string): void {}
+
+	// Invalidation is driven by `QuestionnairePropsAdapter.invalidate()`, which
+	// owns the full set of renderables (binding registries + extras like
+	// `notesInput`). DialogView has no cached layout of its own.
+	invalidate(): void {}
+
+	render(width: number): string[] {
+		const state = this.liveProps.state;
+		const onSubmit = this.config.isMulti && state.currentTab === this.config.questions.length;
+		const strategy = onSubmit && this.submitStrategy ? this.submitStrategy : this.questionStrategy;
+
+		// Cache heading rows (avoid double construction in render and container build).
+		const headingRowCache = strategy.headingRows(state);
+		const headingCount = headingRowCache.length;
+
+		// Build container WITHOUT residual spacer — spacer handled below based on overflow.
+		const natural = this.buildContainerFromStrategy(strategy, headingRowCache).render(width);
+
+		// Fixed region sizes (deterministic from structure).
+		// TabBar.render() returns [tabLine, ""] — always 2 rows.
+		const topFixed = 1 + (this.config.isMulti && this.config.tabBar ? 2 : 0) + 1;
+		const bottomFixed = 1 + strategy.footerRowCount;
+		const middleRows = natural.length - topFixed - bottomFixed;
+
+		// Residual spacer: equalizes total height across tabs (only needed when no overflow).
+		const spacerRows = Math.max(
+			0,
+			this.config.getBodyHeight(width) +
+				this.maxFooterRowCount -
+				strategy.bodyHeight(width, state) -
+				strategy.footerRowCount,
+		);
+
+		const termRows = this.config.getTerminalRows();
+
+		if (natural.length + spacerRows <= termRows) {
+			// No overflow — add residual spacer rows after footer.
+			return spacerRows > 0 ? [...natural, ...Array<string>(spacerRows).fill("")] : natural;
+		}
+
+		// OVERFLOW — apply 3-region partition with scroll-to-focus.
+		const availableMiddle = Math.max(0, termRows - topFixed - bottomFixed);
+		if (availableMiddle === 0) {
+			// Terminal too small for any middle content — show just chrome.
+			const chromeOnly = [...natural.slice(0, topFixed), ...natural.slice(natural.length - bottomFixed)];
+			return chromeOnly.length > termRows ? chromeOnly.slice(0, termRows) : chromeOnly;
+		}
+
+		const bodyRange = strategy.focusedItemRowRange(width, state);
+
+		// Compute scroll window centered on the focused option.
+		let scrollStart: number;
+		if (bodyRange) {
+			const focusedRowInMiddle = headingCount + bodyRange[0];
+			const focusedHeight = bodyRange[1] - bodyRange[0];
+			// Center the focused item vertically in the available middle space.
+			const idealStart = focusedRowInMiddle - Math.floor(Math.max(0, availableMiddle - focusedHeight) / 2);
+			scrollStart = Math.max(0, Math.min(idealStart, middleRows - availableMiddle));
+		} else {
+			// No interactive focus (submit tab) — top-anchor the middle.
+			scrollStart = 0;
+		}
+
+		const scrollableMiddle = natural.slice(topFixed + scrollStart, topFixed + scrollStart + availableMiddle);
+
+		const hasUp = scrollStart > 0;
+		const hasDown = scrollStart + availableMiddle < middleRows;
+		if (hasUp && hasDown && scrollableMiddle.length === 1) {
+			// Single-row middle: combined ↕ avoids the prior collision where ↓ overwrote ↑.
+			scrollableMiddle[0] = this.config.theme.fg("dim", OVERFLOW_BOTH);
+		} else {
+			if (hasUp && scrollableMiddle.length > 0) {
+				scrollableMiddle[0] = this.config.theme.fg("dim", OVERFLOW_UP);
+			}
+			if (hasDown && scrollableMiddle.length > 0) {
+				scrollableMiddle[scrollableMiddle.length - 1] = this.config.theme.fg("dim", OVERFLOW_DOWN);
+			}
+		}
+
+		const result = [
+			...natural.slice(0, topFixed),
+			...scrollableMiddle,
+			...natural.slice(natural.length - bottomFixed),
+		];
+		// Safety: never exceed terminal rows (covers the availableMiddle === 0 case
+		// where topFixed + bottomFixed > termRows).
+		return result.length > termRows ? result.slice(0, termRows) : result;
+	}
+
+	private buildContainerFromStrategy(strategy: TabContentStrategy, headingRowCache: Component[]): Container {
+		const { theme, isMulti, tabBar } = this.config;
+		const state = this.liveProps.state;
+		const container = new Container();
+		const border = () => new DynamicBorder((s) => theme.fg("accent", s));
+
+		container.addChild(border());
+		if (isMulti && tabBar) container.addChild(tabBar);
+		container.addChild(new Spacer(1));
+
+		for (const c of headingRowCache) container.addChild(c);
+		container.addChild(strategy.bodyComponent(state));
+		container.addChild(new Spacer(1));
+		for (const c of strategy.midRows(state)) container.addChild(c);
+
+		container.addChild(border());
+		for (const c of strategy.footerRows(state)) container.addChild(c);
+
+		// BodyResidualSpacer moved out of Container — handled in render().
+		return container;
+	}
+}

--- a/packages/ask-user-question/view/props-adapter.ts
+++ b/packages/ask-user-question/view/props-adapter.ts
@@ -1,0 +1,123 @@
+import type { Input } from "@earendil-works/pi-tui";
+import type { BindingContext, PerTabBindingContext } from "../state/selectors/contract.js";
+import { selectActivePreviewPaneIndex } from "../state/selectors/derivations.js";
+import { selectActiveView } from "../state/selectors/focus.js";
+import type { QuestionnaireState } from "../state/state.js";
+import type { QuestionData } from "../tool/types.js";
+import type { BoundGlobalBinding, BoundPerTabBinding } from "./component-binding.js";
+import type { WrappingSelectItem } from "./components/wrapping-select.js";
+import type { TabComponents } from "./tab-components.js";
+
+/** Cache-invalidation contract used by the adapter. `pi-tui` `Component` already satisfies it. */
+interface Invalidatable {
+	invalidate(): void;
+}
+
+/**
+ * Reads pi-tui Input's private `cursor` field via type escape with full runtime validation.
+ * Returns `undefined` on any failure → graceful degradation to end-of-buffer cursor.
+ * Follow-up: replace with Input.getCursorOffset() when pi-tui exposes a public API.
+ */
+function getInputCursorOffset(input: Input): number | undefined {
+	const raw = (input as unknown as { cursor?: unknown }).cursor;
+	if (typeof raw !== "number") return undefined;
+	if (!Number.isSafeInteger(raw)) return undefined;
+	const value = input.getValue();
+	if (raw < 0 || raw > value.length) return undefined;
+	return raw;
+}
+
+export interface QuestionnairePropsAdapterConfig {
+	tui: { requestRender(): void };
+	questions: readonly QuestionData[];
+	itemsByTab: ReadonlyArray<readonly WrappingSelectItem[]>;
+	tabsByIndex: ReadonlyArray<TabComponents>;
+	inlineInput: Input;
+	globalBindings: ReadonlyArray<BoundGlobalBinding>;
+	perTabBindings: ReadonlyArray<BoundPerTabBinding>;
+	/**
+	 * Renderables not reached by the binding registries (e.g. the notes
+	 * `Input`, which is typed into directly and has no props). Walked by
+	 * `invalidate()` after the binding-driven components.
+	 */
+	extraInvalidatables?: ReadonlyArray<Invalidatable>;
+}
+
+/**
+ * View fan-out: drives every component setter from the canonical state via
+ * two binding registries. `globalBindings` covers the cross-tab components
+ * (chatRow, dialog, submitPicker?, tabBar?); `perTabBindings` covers the
+ * per-tab kinds (optionList, preview, multiSelect?). The hand-coded fan-out
+ * collapses to one global loop + one nested per-tab loop. The inline-Other
+ * value is read from the headless `inlineInput` instance per tick into ctx so
+ * `selectOptionListProps` sees the live value.
+ */
+export class QuestionnairePropsAdapter {
+	private readonly tui: QuestionnairePropsAdapterConfig["tui"];
+	private readonly questions: readonly QuestionData[];
+	private readonly itemsByTab: ReadonlyArray<readonly WrappingSelectItem[]>;
+	private readonly tabsByIndex: ReadonlyArray<TabComponents>;
+	private readonly inlineInput: Input;
+	private readonly globalBindings: ReadonlyArray<BoundGlobalBinding>;
+	private readonly perTabBindings: ReadonlyArray<BoundPerTabBinding>;
+	private readonly extraInvalidatables: ReadonlyArray<Invalidatable>;
+
+	constructor(config: QuestionnairePropsAdapterConfig) {
+		this.tui = config.tui;
+		this.questions = config.questions;
+		this.itemsByTab = config.itemsByTab;
+		this.tabsByIndex = config.tabsByIndex;
+		this.inlineInput = config.inlineInput;
+		this.globalBindings = config.globalBindings;
+		this.perTabBindings = config.perTabBindings;
+		this.extraInvalidatables = config.extraInvalidatables ?? [];
+	}
+
+	apply(state: QuestionnaireState): void {
+		const totalQuestions = this.questions.length;
+		const activeView = selectActiveView(state, totalQuestions);
+		const paneIndex = selectActivePreviewPaneIndex(state.currentTab, totalQuestions);
+		const activePreviewPane = this.tabsByIndex[paneIndex]?.preview ?? this.tabsByIndex[0]!.preview;
+
+		const ctx: BindingContext = {
+			questions: this.questions,
+			itemsByTab: this.itemsByTab,
+			totalQuestions,
+			activeView,
+			inputBuffer: this.inlineInput.getValue(),
+			inputCursorOffset: getInputCursorOffset(this.inlineInput),
+			activePreviewPane,
+		};
+
+		for (const binding of this.globalBindings) {
+			binding.apply(state, ctx);
+		}
+
+		for (let i = 0; i < this.tabsByIndex.length; i++) {
+			const tab = this.tabsByIndex[i]!;
+			const tabCtx: PerTabBindingContext = { ...ctx, tab, i };
+			for (const binding of this.perTabBindings) {
+				binding.apply(state, tabCtx);
+			}
+		}
+
+		this.tui.requestRender();
+	}
+
+	/**
+	 * Invalidates every owned renderable. Called by the session in place of
+	 * the old `dialog.invalidate()` forwarding chain — DialogView no longer
+	 * reaches into siblings (chatRow, tabBar, notesInput, activePreviewPane).
+	 * Iterates the same registries used by `apply()` plus
+	 * `extraInvalidatables` for components outside the binding system.
+	 */
+	invalidate(): void {
+		for (const b of this.globalBindings) b.invalidate();
+		for (const tab of this.tabsByIndex) {
+			tab.optionList.invalidate();
+			tab.preview.invalidate();
+			tab.multiSelect?.invalidate();
+		}
+		for (const x of this.extraInvalidatables) x.invalidate();
+	}
+}

--- a/packages/ask-user-question/view/stateful-view.ts
+++ b/packages/ask-user-question/view/stateful-view.ts
@@ -1,0 +1,25 @@
+import type { Component } from "@earendil-works/pi-tui";
+
+/**
+ * Generic prop-driven component contract. Every renderable owns its own `P` shape;
+ * the adapter computes `P` from canonical state via per-component selectors and
+ * pushes it via `setProps`. `focused: boolean` is a field on `P` only where the
+ * component needs it.
+ */
+export interface StatefulView<P> extends Component {
+	setProps(props: P): void;
+}
+
+/**
+ * Discriminated focus union — encodes the four-cell focus invariant
+ * (`notesVisible`, submit-tab, `chatFocused`, options) that was previously
+ * structural-only. Dispatcher cascade (`key-router.ts:151-178`) and reducer's
+ * defensive clears (`state-reducer.ts:104-126`) enforce mutual exclusion;
+ * this type makes it explicit so per-component `focused: boolean` flags
+ * derive from one equality check against this discriminant rather than
+ * four parallel boolean reads.
+ *
+ * Priority order: notes > submit > chat > options. Matches the dispatcher
+ * cascade exactly so the union is observably equivalent to today's reads.
+ */
+export type ActiveView = "notes" | "chat" | "options" | "submit";

--- a/packages/ask-user-question/view/tab-components.ts
+++ b/packages/ask-user-question/view/tab-components.ts
@@ -1,0 +1,16 @@
+import type { MultiSelectView } from "./components/multi-select-view.js";
+import type { OptionListViewProps } from "./components/option-list-view.js";
+import type { PreviewPane } from "./components/preview/preview-pane.js";
+import type { StatefulView } from "./stateful-view.js";
+
+export interface TabBodyHeights {
+	current: number;
+	max: number;
+}
+
+export interface TabComponents {
+	optionList: StatefulView<OptionListViewProps>;
+	preview: PreviewPane;
+	multiSelect?: MultiSelectView;
+	bodyHeights: (width: number) => TabBodyHeights;
+}

--- a/packages/ask-user-question/view/tab-content-strategy.ts
+++ b/packages/ask-user-question/view/tab-content-strategy.ts
@@ -1,0 +1,252 @@
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { type Component, Container, type Input, Spacer, Text, truncateToWidth } from "@earendil-works/pi-tui";
+import { t } from "../state/i18n-bridge.js";
+import { formatAnswerScalar } from "../tool/format-answer.js";
+import type { QuestionData } from "../tool/types.js";
+import type { ChatRowView } from "./components/chat-row-view.js";
+import type { PreviewPane, PreviewPaneProps } from "./components/preview/preview-pane.js";
+import {
+	type DialogState,
+	HINT_PART_CANCEL,
+	HINT_PART_COLLAPSE,
+	HINT_PART_ENTER,
+	HINT_PART_NAV,
+	HINT_PART_NOTES,
+	HINT_PART_TAB,
+	HINT_PART_TOGGLE,
+	INCOMPLETE_WARNING_PREFIX,
+	READY_PROMPT,
+	REVIEW_HEADING,
+} from "./dialog-builder.js";
+import type { StatefulView } from "./stateful-view.js";
+import type { TabComponents } from "./tab-components.js";
+
+const NOTES_HEADER = "Notes:";
+
+/**
+ * Single-row, width-clipped chrome cell. The footer row count is invariant
+ * (`QuestionTabStrategy.footerRowCount = 4`) — pi-tui's `Text` word-wraps when
+ * the styled hint exceeds `width`, inflating that row count and desyncing the
+ * `bodyHeight + footerRowCount` math in `DialogView.render`. Clipping with
+ * `truncateToWidth` (ANSI-aware, matches `multi-select-view.ts` usage) keeps
+ * the hint on one line; the collapse affordance falls off the right edge with
+ * `…` on terminals too narrow to advertise it.
+ */
+class OneLineClippedText implements Component {
+	constructor(
+		private readonly text: string,
+		private readonly paddingLeft: number = 0,
+	) {}
+
+	render(width: number): string[] {
+		const pad = " ".repeat(this.paddingLeft);
+		const avail = Math.max(0, width - this.paddingLeft);
+		return [pad + truncateToWidth(this.text, avail, "…", false)];
+	}
+
+	invalidate(): void {}
+
+	handleInput(_data: string): void {}
+}
+
+/**
+ * Per-tab content provider. Pure functional — closes over construction-time
+ * config; per-tick state threads through method args. The chrome wrapper
+ * enforces height equality across tabs via `bodyHeight + footerRowCount`.
+ */
+export interface TabContentStrategy {
+	/** Total RENDERED footer rows — MUST equal what `footerRows()` actually emits. Drives residual math. */
+	readonly footerRowCount: number;
+
+	/** Variable rows above the body, after top chrome (border + tabBar + Spacer). */
+	headingRows(state: DialogState): Component[];
+
+	/** Body Component placed at the body slot. */
+	bodyComponent(state: DialogState): Component;
+
+	/** Natural rendered height of `bodyComponent(state)` at given width. */
+	bodyHeight(width: number, state: DialogState): number;
+
+	/** Optional rows between body's trailing Spacer and the bottom border. */
+	midRows(state: DialogState): Component[];
+
+	/** Footer rows below the bottom border. Rendered row count MUST equal `footerRowCount`. */
+	footerRows(state: DialogState): Component[];
+
+	/** Row range of the focused item within the body's rendered output, or undefined if no interactive focus. */
+	focusedItemRowRange(width: number, state: DialogState): [number, number] | undefined;
+}
+
+export interface QuestionTabStrategyConfig {
+	theme: Theme;
+	questions: readonly QuestionData[];
+	getPreviewPane: () => StatefulView<PreviewPaneProps>;
+	tabsByIndex: ReadonlyArray<TabComponents>;
+	notesInput: Input;
+	chatRow: ChatRowView;
+	isMulti: boolean;
+	getCurrentBodyHeight: (width: number) => number;
+}
+
+export class QuestionTabStrategy implements TabContentStrategy {
+	/** Spacer(1) + chatRow(1) + Spacer(1) + Text(hint, 1) = 4 rendered rows. */
+	readonly footerRowCount = 4;
+
+	constructor(private readonly config: QuestionTabStrategyConfig) {}
+
+	headingRows(state: DialogState): Component[] {
+		const out: Component[] = [];
+		const question = this.config.questions[state.currentTab];
+		// In multi-question mode the tab bar already shows the header; suppress the inline badge.
+		if (!this.config.isMulti && question?.header && question.header.length > 0) {
+			out.push(new Text(this.config.theme.bg("selectedBg", ` ${question.header} `), 1, 0));
+			out.push(new Spacer(1));
+		}
+		if (question) {
+			out.push(new Text(this.config.theme.bold(question.question), 1, 0));
+			out.push(new Spacer(1));
+		}
+		return out;
+	}
+
+	bodyComponent(state: DialogState): Component {
+		const question = this.config.questions[state.currentTab];
+		const mso = this.config.tabsByIndex[state.currentTab]?.multiSelect;
+		if (question?.multiSelect === true && mso) return mso;
+		return this.config.getPreviewPane();
+	}
+
+	bodyHeight(width: number, _state: DialogState): number {
+		return this.config.getCurrentBodyHeight(width);
+	}
+
+	midRows(state: DialogState): Component[] {
+		if (!state.notesVisible) return [];
+		return [
+			new Text(this.config.theme.fg("muted", t("notes.header", NOTES_HEADER)), 1, 0),
+			this.config.notesInput,
+			new Spacer(1),
+		];
+	}
+
+	footerRows(state: DialogState): Component[] {
+		const question = this.config.questions[state.currentTab];
+		// OneLineClippedText (not pi-tui `Text`) — `buildHintText` now includes the
+		// collapse affordance, pushing the rendered string past 80 columns; `Text` would
+		// wrap and break the strategy's `footerRowCount = 4` invariant. Clipping on
+		// narrow terminals drops the trailing parts (collapse hint first, then cancel)
+		// with `…`.
+		return [
+			new Spacer(1),
+			this.config.chatRow,
+			new Spacer(1),
+			new OneLineClippedText(this.config.theme.fg("dim", buildHintText(question, this.config.isMulti, state)), 1),
+		];
+	}
+
+	focusedItemRowRange(width: number, state: DialogState): [number, number] | undefined {
+		const question = this.config.questions[state.currentTab];
+		const mso = this.config.tabsByIndex[state.currentTab]?.multiSelect;
+		if (question?.multiSelect === true && mso) return mso.focusedItemRowRange(width);
+		return (this.config.getPreviewPane() as unknown as PreviewPane).focusedItemRowRange(width);
+	}
+}
+
+export interface SubmitTabStrategyConfig {
+	theme: Theme;
+	questions: readonly QuestionData[];
+	submitPicker: Component | undefined;
+}
+
+export class SubmitTabStrategy implements TabContentStrategy {
+	/** Spacer(1) + Text(prompt, 1) + Spacer(1) + submitPicker(2) = 5 rendered rows. Fallback path lands at 5 via 2 trailing Spacer(1)s. */
+	readonly footerRowCount = 5;
+
+	constructor(private readonly config: SubmitTabStrategyConfig) {}
+
+	headingRows(_state: DialogState): Component[] {
+		return [
+			new Text(this.config.theme.bold(this.config.theme.fg("accent", t("review.heading", REVIEW_HEADING))), 1, 0),
+			new Spacer(1),
+		];
+	}
+
+	bodyComponent(state: DialogState): Component {
+		const c = new Container();
+		for (let i = 0; i < this.config.questions.length; i++) {
+			const q = this.config.questions[i];
+			const a = state.answers.get(i);
+			if (!a) continue;
+			const label = q.header && q.header.length > 0 ? q.header : `Q${i + 1}`;
+			const answerText = formatAnswerScalar(a, "summary");
+			c.addChild(new Text(this.config.theme.fg("muted", ` ● ${label}`), 1, 0));
+			c.addChild(
+				new Text(`   ${this.config.theme.fg("muted", "→")} ${this.config.theme.fg("text", answerText)}`, 1, 0),
+			);
+			if (a.notes && a.notes.length > 0) {
+				c.addChild(new Text(this.config.theme.fg("dim", `     notes: ${a.notes}`), 1, 0));
+			}
+		}
+		return c;
+	}
+
+	bodyHeight(width: number, state: DialogState): number {
+		return this.bodyComponent(state).render(width).length;
+	}
+
+	midRows(_state: DialogState): Component[] {
+		return [];
+	}
+
+	footerRows(state: DialogState): Component[] {
+		const missing: string[] = [];
+		for (let i = 0; i < this.config.questions.length; i++) {
+			const q = this.config.questions[i];
+			if (!state.answers.has(i)) {
+				missing.push(q.header && q.header.length > 0 ? q.header : `Q${i + 1}`);
+			}
+		}
+		const promptText =
+			missing.length === 0
+				? this.config.theme.fg("muted", t("review.ready", READY_PROMPT))
+				: this.config.theme.fg(
+						"warning",
+						`${t("review.incomplete", INCOMPLETE_WARNING_PREFIX)} ${missing.join(", ")}`,
+					);
+		const out: Component[] = [new Spacer(1), new Text(promptText, 1, 0), new Spacer(1)];
+		if (this.config.submitPicker) {
+			out.push(this.config.submitPicker);
+		} else {
+			// Padding when the picker isn't wired — keeps rendered row count at footerRowCount=5.
+			out.push(new Spacer(1));
+			out.push(new Spacer(1));
+		}
+		return out;
+	}
+
+	focusedItemRowRange(_width: number, _state: DialogState): [number, number] | undefined {
+		return undefined;
+	}
+}
+
+/**
+ * Build the controls hint line. Order:
+ *   Enter · ↑/↓ [· Space toggle] [· n notes] [· Tab switch] · Esc · Ctrl+] collapse
+ *
+ * `HINT_SINGLE` / `HINT_MULTI` are the CORE prefix that must always render — the
+ * collapse affordance is appended last so the core stays a contiguous substring even
+ * when the trailing part is clipped by `OneLineClippedText` on terminals < ~95 cols.
+ * This is the trade we picked over wrapping (which would inflate `footerRowCount`
+ * and desync the height math in `DialogView.render`).
+ */
+export function buildHintText(question: QuestionData | undefined, isMulti: boolean, state: DialogState): string {
+	const parts: string[] = [t("hint.enter", HINT_PART_ENTER), t("hint.navigate", HINT_PART_NAV)];
+	if (question?.multiSelect === true) parts.push(t("hint.toggle", HINT_PART_TOGGLE));
+	if (question && question.multiSelect !== true && state.focusedOptionHasPreview && !state.notesVisible) {
+		parts.push(t("hint.notes", HINT_PART_NOTES));
+	}
+	if (isMulti) parts.push(t("hint.tab", HINT_PART_TAB));
+	parts.push(t("hint.cancel", HINT_PART_CANCEL));
+	parts.push(t("hint.collapse", HINT_PART_COLLAPSE));
+	return parts.join(" · ");
+}

--- a/packages/slack-bridge/package.json
+++ b/packages/slack-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-slack-bridge",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "PI extension that bridges the active Pi session to a Slack thread: mirrors messages both ways, one Slack thread per Pi session",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/slack-bridge/slack-app-manifest.yaml
+++ b/packages/slack-bridge/slack-app-manifest.yaml
@@ -20,6 +20,7 @@ oauth_config:
     bot:
       - chat:write
       - assistant:write
+      - files:write
       - im:history
       - im:read
       - im:write

--- a/packages/slack-bridge/src/bridge.ts
+++ b/packages/slack-bridge/src/bridge.ts
@@ -9,13 +9,15 @@ import {
 } from "./slack.js";
 import {
   buildQuestionBlocks,
-  consolidateAnswers,
-  isQuestionTool,
   parseActionId,
-  parseQuestions,
+  questionsFromPromptEvent,
   toSlackMarkdown,
   type NormalizedQuestion,
 } from "./format.js";
+import { buildDiffShot } from "./codeshot.js";
+
+export const ASK_USER_PROMPT_EVENT = "arvore:ask-user:prompt";
+export const ASK_USER_ANSWER_EVENT = "arvore:ask-user:answer";
 
 export interface SlackTransport {
   start(): Promise<void>;
@@ -25,6 +27,7 @@ export interface SlackTransport {
   postBlocks(threadTs: string, text: string, blocks: unknown[]): Promise<string | undefined>;
   updateBlocks(ts: string, text: string, blocks: unknown[]): Promise<void>;
   updateText(ts: string, text: string): Promise<void>;
+  uploadImage(threadTs: string, png: Buffer, title: string, comment?: string): Promise<void>;
   setStatus(threadTs: string, status: string): Promise<void>;
   clearStatus(threadTs: string): Promise<void>;
   resolveBotUserId(): Promise<string | undefined>;
@@ -129,6 +132,7 @@ export class SlackBridge {
   private pendingQuestions: NormalizedQuestion[] | undefined;
   private questionAnswers = new Map<number, string>();
   private questionMessageTs: string | undefined;
+  private questionPromptId: string | undefined;
   private readonly toolMessages = new Map<string, { ts: string; summary: string }>();
 
   constructor(
@@ -207,14 +211,26 @@ export class SlackBridge {
 
   async recordTool(toolCallId: string, toolName: string, args: unknown): Promise<void> {
     if (!this.threadTs || !this.gateway) return;
-    if (isQuestionTool(toolName)) {
-      await this.postQuestions(args);
-      return;
-    }
     const summary = formatToolCall(toolName, args);
     this.pushStatus(summary);
     const thread = this.threadTs;
     const gateway = this.gateway;
+
+    const shot = buildDiffShot(toolName, args);
+    if (shot) {
+      this.enqueueStatus(async () => {
+        try {
+          const { renderCodeshot } = await import("./codeshot.js");
+          const png = await renderCodeshot(shot.title, shot.diff);
+          await gateway.uploadImage(thread, png, shot.title, summary);
+        } catch (err) {
+          console.warn(`slack-bridge: codeshot upload failed \u2014 ${(err as Error).message}`);
+          await gateway.postToThread(thread, summary).catch(() => {});
+        }
+      });
+      return;
+    }
+
     this.enqueueStatus(async () => {
       const ts = await gateway.postToThread(thread, summary);
       if (ts) this.toolMessages.set(toolCallId, { ts, summary });
@@ -234,15 +250,21 @@ export class SlackBridge {
     this.enqueueStatus(() => gateway.updateText(entry.ts, body));
   }
 
-  private async postQuestions(args: unknown): Promise<void> {
-    const questions = parseQuestions(args);
+  async handlePromptEvent(payload: unknown): Promise<void> {
+    const data = (payload ?? {}) as { promptId?: unknown };
+    const promptId = typeof data.promptId === "string" ? data.promptId : undefined;
+    if (!promptId) return;
+    const questions = questionsFromPromptEvent(payload as never);
     if (questions.length === 0) return;
+    const thread = await this.ensureThread();
+    const gateway = this.gateway;
+    if (!thread || !gateway) return;
+
     this.pendingQuestions = questions;
     this.questionAnswers = new Map();
     this.questionMessageTs = undefined;
-    const thread = this.threadTs;
-    const gateway = this.gateway;
-    if (!thread || !gateway) return;
+    this.questionPromptId = promptId;
+
     const { text, blocks } = buildQuestionBlocks(questions, this.questionAnswers);
     this.enqueueStatus(async () => {
       const ts = await gateway.postBlocks(thread, text, blocks);
@@ -250,6 +272,11 @@ export class SlackBridge {
       await gateway.setStatus(thread, "aguardando sua resposta\u2026");
     });
     await this.statusPromise;
+  }
+
+  private emitAnswer(payload: { cancelled?: boolean; answers?: unknown[] }): void {
+    if (!this.questionPromptId) return;
+    this.pi.events.emit(ASK_USER_ANSWER_EVENT, { promptId: this.questionPromptId, ...payload });
   }
 
   private async handleAction(action: BlockAction): Promise<void> {
@@ -275,14 +302,16 @@ export class SlackBridge {
     const allAnswered = questions.every((_, i) => answers.has(i));
     if (!allAnswered) return;
 
-    const outgoing = consolidateAnswers(questions, answers);
+    this.emitAnswer({
+      answers: questions.map((_, i) => ({ questionIndex: i, label: answers.get(i) })),
+    });
     this.finalizeQuestions();
-    this.dispatch(outgoing);
   }
 
   private finalizeQuestions(): void {
     this.pendingQuestions = undefined;
     this.questionMessageTs = undefined;
+    this.questionPromptId = undefined;
     this.questionAnswers = new Map();
     const thread = this.threadTs;
     if (thread && this.gateway) {
@@ -300,15 +329,24 @@ export class SlackBridge {
     }
   }
 
-  async finishTurn(message: unknown): Promise<void> {
-    this.turnActive = false;
+  async recordAssistantMessage(message: unknown): Promise<void> {
+    const msg = message as MessageLike;
+    if (msg?.role !== "assistant") return;
     const text = extractText(message);
+    if (!text) return;
     const thread = await this.ensureThread(text);
     if (!thread || !this.gateway) return;
     const gateway = this.gateway;
-    const body = text ? toSlackMarkdown(text) : "conclu\u00eddo";
+    const body = toSlackMarkdown(text);
+    this.enqueueStatus(() => gateway.postToThread(thread, body).then(() => {}));
+  }
+
+  async finishTurn(_message: unknown): Promise<void> {
+    this.turnActive = false;
+    const thread = this.threadTs;
+    if (!thread || !this.gateway) return;
+    const gateway = this.gateway;
     this.enqueueStatus(async () => {
-      await gateway.postToThread(thread, body);
       if (!this.pendingQuestions) await gateway.clearStatus(thread);
     });
     await this.statusPromise;
@@ -341,7 +379,11 @@ export class SlackBridge {
       this.adoptThread(message.threadTs ?? message.ts);
     }
 
-    if (this.pendingQuestions) this.finalizeQuestions();
+    if (this.pendingQuestions) {
+      this.emitAnswer({ answers: [{ questionIndex: 0, text }] });
+      this.finalizeQuestions();
+      return;
+    }
 
     this.dispatch(text);
   }

--- a/packages/slack-bridge/src/codeshot.ts
+++ b/packages/slack-bridge/src/codeshot.ts
@@ -1,0 +1,206 @@
+import sharp from "sharp";
+
+interface DiffRow {
+  kind: "add" | "del" | "ctx";
+  text: string;
+}
+
+const BG = "#0d1117";
+const CARD = "#161b22";
+const HEADER = "#1c2128";
+const TEXT = "#c9d1d9";
+const LINE_NO = "#636e7b";
+const ADD_BG = "#1a3326";
+const DEL_BG = "#3a1d1f";
+const ADD_MARK = "#3fb950";
+const DEL_MARK = "#f85149";
+const GREEN = "#7ee787";
+const RED = "#ff7b72";
+
+const FONT_SIZE = 15;
+const LINE_H = 22;
+const PAD = 20;
+const HEADER_H = 40;
+const GUTTER = 54;
+const CHAR_W = 9.02;
+const MARGIN = 16;
+const MAX_ROWS = 60;
+const MAX_COLS = 120;
+
+function escapeXml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function parseDiffRows(diff: string): DiffRow[] {
+  const rows: DiffRow[] = [];
+  for (const raw of diff.replace(/\n$/, "").split("\n")) {
+    let kind: DiffRow["kind"] = "ctx";
+    let s = raw;
+    if (raw.startsWith("+")) {
+      kind = "add";
+      s = raw.slice(1);
+    } else if (raw.startsWith("-")) {
+      kind = "del";
+      s = raw.slice(1);
+    } else if (raw.startsWith(" ")) {
+      s = raw.slice(1);
+    }
+    rows.push({ kind, text: s.replace(/\t/g, "    ") });
+  }
+  return rows;
+}
+
+export function buildUnifiedDiff(oldText: string, newText: string): string {
+  const a = oldText.split("\n");
+  const b = newText.split("\n");
+  const n = a.length;
+  const m = b.length;
+
+  const lcs: number[][] = Array.from({ length: n + 1 }, () => new Array(m + 1).fill(0));
+  for (let i = n - 1; i >= 0; i--) {
+    for (let j = m - 1; j >= 0; j--) {
+      lcs[i][j] = a[i] === b[j] ? lcs[i + 1][j + 1] + 1 : Math.max(lcs[i + 1][j], lcs[i][j + 1]);
+    }
+  }
+
+  const rows: string[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < n && j < m) {
+    if (a[i] === b[j]) {
+      rows.push(` ${a[i]}`);
+      i++;
+      j++;
+    } else if (lcs[i + 1][j] >= lcs[i][j + 1]) {
+      rows.push(`-${a[i]}`);
+      i++;
+    } else {
+      rows.push(`+${b[j]}`);
+      j++;
+    }
+  }
+  while (i < n) rows.push(`-${a[i++]}`);
+  while (j < m) rows.push(`+${b[j++]}`);
+  return rows.join("\n");
+}
+
+export interface DiffShot {
+  title: string;
+  diff: string;
+}
+
+function basename(path: string): string {
+  const parts = path.split(/[\\/]/);
+  return parts[parts.length - 1] || path;
+}
+
+export function buildDiffShot(toolName: string, args: unknown): DiffShot | undefined {
+  const a = (args ?? {}) as Record<string, unknown>;
+  if (toolName === "edit") {
+    const path = typeof a.path === "string" ? a.path : "";
+    const edits = Array.isArray(a.edits) ? a.edits : [];
+    const chunks: string[] = [];
+    for (const raw of edits) {
+      const e = raw as { oldText?: unknown; newText?: unknown };
+      const oldText = typeof e?.oldText === "string" ? e.oldText : "";
+      const newText = typeof e?.newText === "string" ? e.newText : "";
+      if (!oldText && !newText) continue;
+      chunks.push(buildUnifiedDiff(oldText, newText));
+    }
+    if (chunks.length === 0) return undefined;
+    return { title: basename(path), diff: chunks.join("\n") };
+  }
+  if (toolName === "write") {
+    const path = typeof a.path === "string" ? a.path : "";
+    const content = typeof a.content === "string" ? a.content : "";
+    if (!content) return undefined;
+    const diff = content
+      .split("\n")
+      .map((l) => `+${l}`)
+      .join("\n");
+    return { title: basename(path), diff };
+  }
+  return undefined;
+}
+
+export async function renderCodeshot(title: string, diff: string): Promise<Buffer> {
+  let rows = parseDiffRows(diff);
+  let truncatedRows = false;
+  if (rows.length > MAX_ROWS) {
+    rows = rows.slice(0, MAX_ROWS);
+    truncatedRows = true;
+  }
+
+  const displayRows = rows.map((r) => ({
+    ...r,
+    text: r.text.length > MAX_COLS ? `${r.text.slice(0, MAX_COLS)}\u2026` : r.text,
+  }));
+
+  const widestCols = displayRows.reduce((m, r) => Math.max(m, r.text.length), title.length);
+  const cardW = Math.max(360, Math.ceil(GUTTER + widestCols * CHAR_W + PAD));
+  const bodyRows = displayRows.length + (truncatedRows ? 1 : 0);
+  const cardH = HEADER_H + PAD * 2 + bodyRows * LINE_H;
+  const w = cardW + MARGIN * 2;
+  const h = cardH + MARGIN * 2;
+
+  const parts: string[] = [];
+  parts.push(`<rect x="0" y="0" width="${w}" height="${h}" fill="${BG}"/>`);
+  parts.push(`<rect x="${MARGIN}" y="${MARGIN}" width="${cardW}" height="${cardH}" rx="10" fill="${CARD}"/>`);
+  parts.push(
+    `<path d="M${MARGIN},${MARGIN + 10} a10,10 0 0 1 10,-10 h${cardW - 20} a10,10 0 0 1 10,10 v30 h-${cardW} z" fill="${HEADER}"/>`,
+  );
+
+  const dots = ["#ff5f56", "#ffbd2e", "#27c93f"];
+  dots.forEach((c, i) => {
+    parts.push(`<circle cx="${MARGIN + 20 + i * 20}" cy="${MARGIN + 20}" r="6" fill="${c}"/>`);
+  });
+  parts.push(
+    `<text x="${MARGIN + cardW / 2}" y="${MARGIN + 25}" fill="${LINE_NO}" font-family="Menlo,monospace" font-size="${FONT_SIZE}" text-anchor="middle">${escapeXml(title)}</text>`,
+  );
+
+  const bodyTop = MARGIN + HEADER_H + PAD;
+  let ln = 0;
+  displayRows.forEach((r, i) => {
+    const ry = bodyTop + i * LINE_H;
+    let color = TEXT;
+    let mark = " ";
+    if (r.kind === "add") {
+      color = GREEN;
+      mark = "+";
+      parts.push(`<rect x="${MARGIN + 1}" y="${ry - 3}" width="${cardW - 2}" height="${LINE_H}" fill="${ADD_BG}"/>`);
+      parts.push(`<rect x="${MARGIN + 1}" y="${ry - 3}" width="3" height="${LINE_H}" fill="${ADD_MARK}"/>`);
+    } else if (r.kind === "del") {
+      color = RED;
+      mark = "-";
+      parts.push(`<rect x="${MARGIN + 1}" y="${ry - 3}" width="${cardW - 2}" height="${LINE_H}" fill="${DEL_BG}"/>`);
+      parts.push(`<rect x="${MARGIN + 1}" y="${ry - 3}" width="3" height="${LINE_H}" fill="${DEL_MARK}"/>`);
+    }
+    const baseline = ry + FONT_SIZE;
+    if (r.kind !== "del") {
+      ln += 1;
+      parts.push(
+        `<text x="${MARGIN + 14}" y="${baseline}" fill="${LINE_NO}" font-family="Menlo,monospace" font-size="${FONT_SIZE}">${ln}</text>`,
+      );
+    }
+    parts.push(
+      `<text x="${MARGIN + GUTTER - 16}" y="${baseline}" fill="${color}" font-family="Menlo,monospace" font-size="${FONT_SIZE}">${mark}</text>`,
+    );
+    parts.push(
+      `<text x="${MARGIN + GUTTER}" y="${baseline}" fill="${color}" font-family="Menlo,monospace" font-size="${FONT_SIZE}" xml:space="preserve">${escapeXml(r.text)}</text>`,
+    );
+  });
+
+  if (truncatedRows) {
+    const ry = bodyTop + displayRows.length * LINE_H;
+    parts.push(
+      `<text x="${MARGIN + GUTTER}" y="${ry + FONT_SIZE}" fill="${LINE_NO}" font-family="Menlo,monospace" font-size="${FONT_SIZE}">\u2026 (truncated)</text>`,
+    );
+  }
+
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}" viewBox="0 0 ${w} ${h}">${parts.join("")}</svg>`;
+  return sharp(Buffer.from(svg)).png().toBuffer();
+}

--- a/packages/slack-bridge/src/format.ts
+++ b/packages/slack-bridge/src/format.ts
@@ -66,6 +66,37 @@ export function parseQuestions(args: unknown): NormalizedQuestion[] {
   return questions;
 }
 
+export interface PromptEventLike {
+  questions?: ReadonlyArray<{
+    question?: string;
+    header?: string;
+    multiSelect?: boolean;
+    options?: ReadonlyArray<{ label?: string; description?: string }>;
+  }>;
+}
+
+export function questionsFromPromptEvent(payload: PromptEventLike): NormalizedQuestion[] {
+  const rawQuestions = Array.isArray(payload?.questions) ? payload.questions : [];
+  const questions: NormalizedQuestion[] = [];
+  for (const q of rawQuestions) {
+    const prompt = asString(q?.question);
+    if (!prompt) continue;
+    const rawOptions: unknown[] = Array.isArray(q?.options) ? (q.options as unknown[]) : [];
+    const options: NormalizedOption[] = [];
+    for (const raw of rawOptions) {
+      const opt = normalizeOption(raw);
+      if (opt) options.push(opt);
+    }
+    questions.push({
+      prompt,
+      header: asString(q?.header) || undefined,
+      options,
+      multiSelect: q?.multiSelect === true,
+    });
+  }
+  return questions;
+}
+
 export const QUESTION_ACTION_PREFIX = "sbq";
 
 export function buildActionId(questionIndex: number, optionIndex: number): string {

--- a/packages/slack-bridge/src/index.ts
+++ b/packages/slack-bridge/src/index.ts
@@ -73,10 +73,21 @@ export default function (pi: ExtensionAPI): void {
     await bridge.recordToolResult(event.toolCallId, event.result, event.isError).catch(() => {});
   });
 
+  pi.on("message_end", async (event, ctx) => {
+    captureContext(ctx);
+    if (!bridge) return;
+    await bridge.recordAssistantMessage(event.message).catch(() => {});
+  });
+
   pi.on("turn_end", async (event, ctx) => {
     captureContext(ctx);
     if (!bridge) return;
     await bridge.finishTurn(event.message).catch(() => {});
+  });
+
+  pi.events.on("arvore:ask-user:prompt", (payload) => {
+    if (!bridge) return;
+    void bridge.handlePromptEvent(payload).catch(() => {});
   });
 
   pi.on("session_shutdown", async () => {

--- a/packages/slack-bridge/src/slack.ts
+++ b/packages/slack-bridge/src/slack.ts
@@ -125,6 +125,17 @@ export class SlackGateway {
     await this.web.chat.update({ channel: this.config.channel, ts, text });
   }
 
+  async uploadImage(threadTs: string, png: Buffer, title: string, comment?: string): Promise<void> {
+    await this.web.files.uploadV2({
+      channel_id: this.config.channel,
+      thread_ts: threadTs,
+      file: png,
+      filename: `${title.replace(/[^\w.-]+/g, "_").slice(0, 60) || "diff"}.png`,
+      title,
+      initial_comment: comment,
+    });
+  }
+
   async setStatus(threadTs: string, status: string): Promise<void> {
     await this.web.apiCall("assistant.threads.setStatus", {
       channel_id: this.config.channel,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,24 @@ importers:
         specifier: ^5.3.0
         version: 5.9.3
 
+  packages/ask-user-question:
+    devDependencies:
+      '@earendil-works/pi-coding-agent':
+        specifier: latest
+        version: 0.80.3(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-tui':
+        specifier: 0.79.5
+        version: 0.79.5
+      '@types/node':
+        specifier: ^20.10.0
+        version: 20.19.39
+      typebox:
+        specifier: ^1.2.6
+        version: 1.3.4
+      typescript:
+        specifier: ^5.3.0
+        version: 5.9.3
+
   packages/bee-context:
     devDependencies:
       '@earendil-works/pi-ai':
@@ -2643,6 +2661,9 @@ packages:
   typebox@1.1.38:
     resolution: {integrity: sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==}
 
+  typebox@1.3.4:
+    resolution: {integrity: sha512-j3MCKfJMIHdrr4ZQMzaJnvXrUbMNuncwssmQkny3Cv5vxrDE1o1WhZFEqGSlU884xtYS5sAa3O/XsUPbUbPWKQ==}
+
   typescript-eslint@8.59.3:
     resolution: {integrity: sha512-KgusgyDgG4LI8Ih/sWaCtZ06tckLAS5CvT5A4D1Q7bYVoAAyzwiZvE4BmwDHkhRVkvhRBepKeASoFzQetha7Fg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -5251,6 +5272,8 @@ snapshots:
   typebox@0.0.1: {}
 
   typebox@1.1.38: {}
+
+  typebox@1.3.4: {}
 
   typescript-eslint@8.59.3(eslint@10.4.0(jiti@2.7.0))(typescript@5.9.3):
     dependencies:


### PR DESCRIPTION
## Contexto

Testando a slack-bridge (#127/#128/#129) percebemos que o `ask_user_question` (do pacote de terceiros `@juicesharp/rpiv-ask-user-question`) resolve só no `done()` do overlay do terminal. Quando a pessoa respondia pelo Slack, a resposta virava um novo turno (`steer`) e o overlay do terminal ficava **órfão/travado**. Não dava pra interceptar sem forkar o pacote.

Este PR forka esse pacote pra dentro do monorepo e adiciona um **canal de resposta externa**, além de melhorias visuais na bridge.

## Novo pacote `@arvoretech/pi-ask-user-question`

Fork de `@juicesharp/rpiv-ask-user-question` (MIT). Roda `.ts` cru como as outras extensões (`pi.extensions: ["./index.ts"]`).

- TUI completo do questionário preservado (views, state machine, i18n).
- Dependências de terceiros removidas: `rpiv-config` inlinado no `config.ts`; i18n continua opcional (dynamic import com fallback pra inglês).
- **Contrato de eventos** estável e documentado (`events.ts`):
  - `arvore:ask-user:prompt` — emitido quando a pergunta abre (com `promptId` + questões normalizadas), pra listeners externos (ex: Slack).
  - `arvore:ask-user:answer` — emitido por um listener externo pra responder de fora (por `promptId`; aceita label única, múltiplas labels ou texto livre; `cancelled` pra declinar).
- `execute()` faz um **race** entre o overlay do terminal e o evento de resposta externa: quem resolver primeiro vence, o outro é desmontado (`handle.hide()`). Sem overlay órfão, sem travamento.

## slack-bridge (1.4.0 → 1.5.0)

- **Perguntas via contrato de eventos**: escuta `arvore:ask-user:prompt`, posta as opções como **botões Block Kit**; no clique (ou texto) emite `arvore:ask-user:answer` com o `promptId`.
- **Codeshot**: chamadas de `edit`/`write` renderizam uma **imagem de diff** estilo janela macOS (SVG via `sharp`), com diff **LCS de verdade** (linhas de contexto + só as mudadas marcadas com `+`/`-`), postada junto com o resumo da tool como comentário da imagem (uma mensagem só).
- **Ordering**: texto do assistant postado no `message_end`, ficando na ordem correta em relação às mensagens de tool (antes só saía no `turn_end`, sempre depois das tools).
- Scope `files:write` no manifest (necessário pro upload da imagem).

## Como testei

- `lsp_diagnostics` limpo nos arquivos alterados
- `pnpm lint` (ask-user-question) e `pnpm build` (slack-bridge) ok
- Codeshot E2E: render do SVG→PNG e `files.uploadV2` validados contra o canal real
- Diff LCS conferido: contexto preservado, só as linhas novas marcadas
- Boot da extensão nova validado (registra a tool sem crash)
- Fluxo de pergunta testado ao vivo: botão no Slack responde e o overlay do terminal fecha sozinho

## Notas

- O `settings.json` que aponta as extensões pra caminho local é do repo `arvore-hub`, não entra aqui.
- Pra ativar o pacote novo em produção: publicar no npm e trocar `npm:@juicesharp/rpiv-ask-user-question` por `npm:@arvoretech/pi-ask-user-question` no settings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new interactive “ask user question” flow with multi-question dialogs, previews, multi-select, review/submit, notes, and localized UI text.
  * Added Slack support for prompt-driven questions and richer code-diff image previews in threads.

* **Bug Fixes**
  * Improved answer handling and validation for structured responses, including cancellation and external completion paths.

* **Chores**
  * Updated the Slack bridge version and added required Slack permissions for file uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->