### PR TITLE
fix(slack-bridge): declare sharp as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,5 @@
   "packageManager": "pnpm@10.28.0",
   "engines": {
     "node": ">=20.0.0"
-  },
-  "dependencies": {
-    "sharp": "^0.34.5"
   }
 }

--- a/packages/slack-bridge/package.json
+++ b/packages/slack-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-slack-bridge",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "PI extension that bridges the active Pi session to a Slack thread: mirrors messages both ways, one Slack thread per Pi session",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -19,6 +19,7 @@
   "dependencies": {
     "@slack/socket-mode": "2.0.7",
     "@slack/web-api": "7.17.0",
+    "sharp": "^0.34.5",
     "slackify-markdown": "5.0.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,10 +10,6 @@ overrides:
 importers:
 
   .:
-    dependencies:
-      sharp:
-        specifier: ^0.34.5
-        version: 0.34.5
     devDependencies:
       typescript:
         specifier: ^5.3.0
@@ -478,6 +474,9 @@ importers:
       '@slack/web-api':
         specifier: 7.17.0
         version: 7.17.0
+      sharp:
+        specifier: ^0.34.5
+        version: 0.34.5
       slackify-markdown:
         specifier: 5.0.0
         version: 5.0.0
@@ -2451,11 +2450,6 @@ packages:
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
-
-  semver@7.7.4:
-    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
-    engines: {node: '>=10'}
-    hasBin: true
 
   semver@7.8.0:
     resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
@@ -5092,15 +5086,13 @@ snapshots:
 
   safe-buffer@5.2.1: {}
 
-  semver@7.7.4: {}
-
   semver@7.8.0: {}
 
   sharp@0.34.5:
     dependencies:
       '@img/colour': 1.1.0
       detect-libc: 2.1.2
-      semver: 7.7.4
+      semver: 7.8.0
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.34.5
       '@img/sharp-darwin-x64': 0.34.5


### PR DESCRIPTION
## Summary
- `codeshot.ts` imports `sharp` directly, but it was only declared as a dependency at the monorepo root instead of in `packages/slack-bridge/package.json`. pnpm hoisting made it work in local dev/build, but the published npm tarball's `dependencies` field didn't include it, so a clean `npm install @arvoretech/pi-slack-bridge` crashed with `Cannot find module 'sharp'`.
- Moved `sharp` from the root `package.json` into `packages/slack-bridge/package.json` (the only consumer), regenerated `pnpm-lock.yaml`.
- Bumped `@arvoretech/pi-slack-bridge` to `1.5.1`.

## Test plan
- [x] `pnpm install` at repo root resolves cleanly
- [x] `pnpm build` in `packages/slack-bridge` compiles with no errors
- [x] Verified `sharp` now installs as a direct dependency of `pi-slack-bridge` when installed standalone (reproduced the original crash in a downstream consumer, confirmed it's gone after this fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)