### PR TITLE
feat(git-review): subir server sob demanda quando ha PR aberto no prs-tracker

### DIFF
--- a/packages/git-review/src/index.ts
+++ b/packages/git-review/src/index.ts
@@ -1,6 +1,6 @@
 import { platform } from "node:os";
 import { tmpdir } from "node:os";
-import { writeFileSync, unlinkSync } from "node:fs";
+import { existsSync, writeFileSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { WebSocket } from "ws";
@@ -20,6 +20,8 @@ const PORT_RANGE_START = 9890;
 const PORT_RANGE_END = 9899;
 
 const DISCOVERY_FILE = join(tmpdir(), `pi-git-review-${process.pid}.json`);
+const REQUEST_FILE = join(tmpdir(), `pi-git-review-request-${process.pid}.json`);
+const REQUEST_POLL_MS = 1_000;
 
 function publishServerInfo(srv: { url: string; token: string; port: number }): void {
   try {
@@ -42,6 +44,14 @@ function unpublishServerInfo(): void {
   try {
     unlinkSync(DISCOVERY_FILE);
   } catch {}
+}
+
+function consumeServerRequest(): boolean {
+  if (!existsSync(REQUEST_FILE)) return false;
+  try {
+    unlinkSync(REQUEST_FILE);
+  } catch {}
+  return true;
 }
 
 function openBrowser(pi: ExtensionAPI, url: string): void {
@@ -204,6 +214,7 @@ export default function (pi: ExtensionAPI) {
   let server: GitReviewServer | null = null;
   const clients: Set<WebSocket> = new Set();
   let isIdle: () => boolean = () => true;
+  let requestTimer: ReturnType<typeof setInterval> | null = null;
 
   const handleMessage = (msg: IncomingMessage_) => {
     let message: string;
@@ -242,6 +253,25 @@ export default function (pi: ExtensionAPI) {
     return null;
   }
 
+  function startRequestWatcher(ctx: {
+    ui: { notify: (m: string, type?: "error" | "warning" | "info") => void };
+  }): void {
+    if (requestTimer) return;
+    requestTimer = setInterval(() => {
+      if (server) return;
+      if (!consumeServerRequest()) return;
+      void ensureServer(ctx);
+    }, REQUEST_POLL_MS);
+    if (typeof requestTimer.unref === "function") requestTimer.unref();
+  }
+
+  function stopRequestWatcher(): void {
+    if (requestTimer) {
+      clearInterval(requestTimer);
+      requestTimer = null;
+    }
+  }
+
   pi.registerCommand("review", {
     description:
       "Open a browser-based git diff & PR reviewer. Usage: /review [<pr-number> | working|staged|branch [base] | prs]",
@@ -274,9 +304,12 @@ export default function (pi: ExtensionAPI) {
 
   pi.on("session_start", async (_event, ctx) => {
     isIdle = () => ctx.isIdle();
+    startRequestWatcher(ctx);
   });
 
   pi.on("session_shutdown", async () => {
+    stopRequestWatcher();
+    consumeServerRequest();
     unpublishServerInfo();
     server?.close();
     server = null;

--- a/packages/git-review/src/index.ts
+++ b/packages/git-review/src/index.ts
@@ -215,6 +215,7 @@ export default function (pi: ExtensionAPI) {
   const clients: Set<WebSocket> = new Set();
   let isIdle: () => boolean = () => true;
   let requestTimer: ReturnType<typeof setInterval> | null = null;
+  let serverStarting = false;
 
   const handleMessage = (msg: IncomingMessage_) => {
     let message: string;
@@ -242,15 +243,21 @@ export default function (pi: ExtensionAPI) {
     ui: { notify: (m: string, type?: "error" | "warning" | "info") => void };
   }): Promise<GitReviewServer | null> {
     if (server) return server;
-    for (let port = PORT_RANGE_START; port <= PORT_RANGE_END; port++) {
-      try {
-        server = await startGitReviewServer(port, pi, clients, handleMessage);
-        publishServerInfo(server);
-        return server;
-      } catch {}
+    if (serverStarting) return null;
+    serverStarting = true;
+    try {
+      for (let port = PORT_RANGE_START; port <= PORT_RANGE_END; port++) {
+        try {
+          server = await startGitReviewServer(port, pi, clients, handleMessage);
+          publishServerInfo(server);
+          return server;
+        } catch {}
+      }
+      ctx.ui.notify("git-review: no available port in range", "warning");
+      return null;
+    } finally {
+      serverStarting = false;
     }
-    ctx.ui.notify("git-review: no available port in range", "warning");
-    return null;
   }
 
   function startRequestWatcher(ctx: {
@@ -258,7 +265,7 @@ export default function (pi: ExtensionAPI) {
   }): void {
     if (requestTimer) return;
     requestTimer = setInterval(() => {
-      if (server) return;
+      if (server || serverStarting) return;
       if (!consumeServerRequest()) return;
       void ensureServer(ctx);
     }, REQUEST_POLL_MS);

--- a/packages/prs-tracker/src/index.ts
+++ b/packages/prs-tracker/src/index.ts
@@ -38,6 +38,8 @@ interface TrackedPr {
 
 const POLL_INTERVAL_MS = 60_000;
 const MERGED_RETENTION_MS = 24 * 60 * 60 * 1000;
+const GIT_REVIEW_DISCOVERY_FILE = join(tmpdir(), `pi-git-review-${process.pid}.json`);
+const GIT_REVIEW_REQUEST_FILE = join(tmpdir(), `pi-git-review-request-${process.pid}.json`);
 const PR_URL_RE = /https?:\/\/github\.com\/([^/\s]+\/[^/\s]+)\/pull\/(\d+)/g;
 const STATE_DIR = ".pi/prs-tracker-sessions";
 const DEPLOY_WORKFLOW_RE = /deploy|publish|release/i;
@@ -97,10 +99,9 @@ interface GitReviewInfo {
 }
 
 function readGitReviewInfo(): GitReviewInfo | null {
-  const path = join(tmpdir(), `pi-git-review-${process.pid}.json`);
-  if (!existsSync(path)) return null;
+  if (!existsSync(GIT_REVIEW_DISCOVERY_FILE)) return null;
   try {
-    const info = JSON.parse(readFileSync(path, "utf-8")) as {
+    const info = JSON.parse(readFileSync(GIT_REVIEW_DISCOVERY_FILE, "utf-8")) as {
       baseUrl?: string;
       token?: string;
       port?: number;
@@ -116,6 +117,26 @@ function gitReviewUrlFor(pr: TrackedPr): string | null {
   const info = readGitReviewInfo();
   if (!info) return null;
   return `${info.baseUrl}/?token=${info.token}&mode=prs&pr=${pr.number}`;
+}
+
+function hasOpenPr(): boolean {
+  for (const pr of tracked.values()) {
+    if (pr.state === "OPEN") return true;
+  }
+  return false;
+}
+
+function requestGitReviewServer(): void {
+  if (existsSync(GIT_REVIEW_DISCOVERY_FILE)) return;
+  if (existsSync(GIT_REVIEW_REQUEST_FILE)) return;
+  if (!hasOpenPr()) return;
+  try {
+    writeFileSync(
+      GIT_REVIEW_REQUEST_FILE,
+      JSON.stringify({ pid: process.pid, reason: "open-pr", ts: Date.now() }),
+      { mode: 0o600 },
+    );
+  } catch {}
 }
 
 function saveState(cwd: string): void {
@@ -622,6 +643,7 @@ function startPolling(ctx: any): void {
       saveState(ctx?.cwd ?? uiCtx?.cwd ?? process.cwd());
       updateWidget(ctx);
     }
+    requestGitReviewServer();
   }, POLL_INTERVAL_MS);
   if (typeof pollTimer.unref === "function") pollTimer.unref();
 }
@@ -640,6 +662,7 @@ export default function prsTrackerExtension(pi: ExtensionAPI): void {
     if (tracked.size > 0) refreshAll();
     startPolling(ctx);
     updateWidget(ctx);
+    requestGitReviewServer();
   });
 
   pi.on("session_shutdown", async () => {
@@ -677,6 +700,7 @@ export default function prsTrackerExtension(pi: ExtensionAPI): void {
     if (tracked.size !== before || JSON.stringify([...tracked.values()]) !== beforeSnapshot) {
       saveState(cwd);
       updateWidget(ctx);
+      requestGitReviewServer();
     }
   });
 


### PR DESCRIPTION
## Contexto

O `prs-tracker` já trocava o link do GitHub pelo link do `git-review` no widget de PRs — mas só quando o servidor do `git-review` já estava de pé (após rodar `/review`). Antes disso o link não existia (porta + token só são gerados dentro de `ensureServer()`), então o link "Open in git-review" quase nunca aparecia na prática.

Este PR faz o `git-review` subir o servidor **sob demanda, apenas quando há um PR aberto rastreado**, para que o link no widget seja sempre clicável e abra direto na UI do `git-review`.

## Como funciona

Canal de coordenação entre as duas extensões (que rodam no mesmo processo) via um request file em `/tmp`, keyed por `process.pid` — mesmo padrão do discovery file já existente.

- **prs-tracker (produtor):** `requestGitReviewServer()` escreve `/tmp/pi-git-review-request-<pid>.json` quando há PR `OPEN` rastreado, o server ainda não está de pé e não há request pendente. Disparado em `session_start`, `tool_execution_end` (novos PRs captados) e no poll de 60s. Idempotente e barato.
- **git-review (consumidor):** watcher (poll de 1s, `unref`) iniciado no `session_start` consome o request e chama `ensureServer()` silenciosamente (sem abrir browser nem notificar), publicando o discovery file.

Com o server de pé, o widget passa a mostrar "Open in git-review" com link válido (`?mode=prs&pr=N`); o cliente web busca os dados via `/api/prs`, então basta o server existir. Se o server já estava ativo, `ensureServer()` é idempotente e reusa a mesma porta/token — abre na mesma sessão.

## Mudanças

- `packages/git-review/src/index.ts`: `REQUEST_FILE`, `consumeServerRequest()`, watcher (`startRequestWatcher`/`stopRequestWatcher`), cleanup no `session_shutdown`.
- `packages/prs-tracker/src/index.ts`: constantes `GIT_REVIEW_DISCOVERY_FILE`/`GIT_REVIEW_REQUEST_FILE`, `hasOpenPr()`, `requestGitReviewServer()` plugado nos pontos de mudança de estado.

## Verificação

- `lsp_diagnostics` limpo nos dois arquivos.
- `pnpm --filter ./packages/git-review build` → exit 0
- `pnpm --filter ./packages/prs-tracker build` → exit 0

## Observações

- Há uma janela de ~1s entre detectar o PR e o server subir; nesse intervalo o widget ainda mostra o link do GitHub (fallback) até o próximo `updateWidget`. O poll corrige em seguida.
- Sem PR aberto, nada sobe (atende ao "só quando há PR aberto").


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a background request flow that helps the Git review server start automatically when needed.
  * Improved PR tracking so the app can request server startup during refreshes, session start, and after certain command failures.

* **Bug Fixes**
  * Reduced cases where open pull requests could be missed before the server was available.
  * Cleaned up pending startup requests on session shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->