### PR TITLE
fix(prs-tracker): fallback de URL visível para terminais sem OSC 8 (Warp)

### DIFF
--- a/packages/prs-tracker/package.json
+++ b/packages/prs-tracker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-prs-tracker",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "PI extension that keeps open/recently-merged PRs pinned in the chat as a persistent widget",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/prs-tracker/src/index.ts
+++ b/packages/prs-tracker/src/index.ts
@@ -498,6 +498,15 @@ function osc8(url: string | null, label: string): string {
   return `\u001b]8;;${url}\u0007${label}\u001b]8;;\u0007`;
 }
 
+function linkWithFallback(
+  url: string | null,
+  label: string,
+  fg: (c: string, s: string) => string,
+): string {
+  if (!url) return label;
+  return `${osc8(url, label)} ${fg("dim", url)}`;
+}
+
 function ciLine(pr: TrackedPr, fg: (c: string, s: string) => string): string | null {
   const ci = pr.ci;
   if (!ci || ci.state === "NONE") return null;
@@ -558,7 +567,9 @@ function renderWidget(width: number, theme: any): string[] {
     if (status) lines.push(`      ${status}`);
     const reviewUrl = gitReviewUrlFor(pr);
     if (reviewUrl) {
-      lines.push(`      ${osc8(reviewUrl, fg("mdLinkUrl", "Open in git-review"))}`);
+      lines.push(
+        `      ${linkWithFallback(reviewUrl, fg("mdLinkUrl", "Open in git-review"), fg)}`,
+      );
     } else {
       lines.push(`      ${fg("mdLinkUrl", trunc(pr.url))}`);
     }


### PR DESCRIPTION
## O que

Corrige o link **"Open in git-review"** do widget do `prs-tracker`, que aparecia como texto não-clicável no terminal **Warp**.

## Por quê

O link era emitido apenas como hyperlink **OSC 8** (`ESC ] 8 ; ; URL BEL label ...`). O Warp [não suporta OSC 8](https://github.com/warpdotdev/warp/pull/9850) — ele faz detecção de URL própria por regex sobre o texto puro. Como a URL ficava escondida dentro do label do hyperlink, o Warp não tinha nenhuma URL visível para tornar clicável, mostrando só o texto "Open in git-review".

Não é bug do nosso código: é limitação do terminal (issue aberta upstream, PR #9850 ainda em análise).

## O que mudou

- Nova função `linkWithFallback`: mantém o hyperlink OSC 8 (funciona em iTerm2, Kitty, WezTerm, Ghostty, etc.) **e** imprime a URL crua em `dim` ao lado. Assim terminais sem suporte a OSC 8 (Warp, Terminal.app antigo) detectam/copiam/clicam a URL via detecção nativa.
- Aplicado apenas na linha do git-review (linha dedicada, sem risco de quebrar o layout compacto de CI/deploy). `trunc()` não incide nessa linha, então a sequência OSC 8 não corre risco de ser cortada no meio.
- Bump `@arvoretech/pi-prs-tracker` 1.7.0 → 1.7.1.

## Testes

- `pnpm lint` (tsc --noEmit) ✅
- `pnpm build` (tsc) ✅


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the “Open in git-review” link display so it now shows a clickable label with the URL visible alongside it.
  * Added a fallback so the link still renders cleanly when no review URL is available.
* **Chores**
  * Bumped the `prs-tracker` package version to `1.7.1`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->