### PR TITLE
fix(recap): rodar auto recap em background para não travar o input

### DIFF
--- a/packages/recap/package.json
+++ b/packages/recap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-recap",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "PI extension that drafts a one-line recap of where you left off — on demand with /recap and automatically when you return to an idle session",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/recap/src/index.ts
+++ b/packages/recap/src/index.ts
@@ -40,12 +40,14 @@ export default function recapExtension(pi: ExtensionAPI): void {
     if (countUserTurns(entries) < MIN_TURNS) return;
 
     showedRecapSinceActivity = true;
-    try {
-      const recap = await generateRecap(ctx);
-      if (recap) ctx.ui.notify(`Recap: ${recap}`, "info");
-    } catch {
-      // recap is best-effort; never block the turn
-    }
+    void (async () => {
+      try {
+        const recap = await generateRecap(ctx);
+        if (recap) ctx.ui.notify(`Recap: ${recap}`, "info");
+      } catch {
+        // recap is best-effort; never block the turn
+      }
+    })();
   });
 
   pi.registerCommand("recap", {


### PR DESCRIPTION
## Contexto

A extensão \`@arvoretech/pi-recap\` gera o recap automático dentro do handler \`before_agent_start\`. O pi **aguarda** os handlers desse evento terminarem antes de iniciar o turno do agente.

O handler fazia \`await generateRecap(ctx)\`, que dispara uma chamada LLM (\`summarizeRecap\`). Resultado: após 3min de idle, toda mensagem enviada ficava bloqueada esperando o recap gerar — travando o input.

## Mudança

- No \`before_agent_start\`, o recap agora roda fire-and-forget (\`void (async () => {...})()\`), sem \`await\`. O turno inicia imediatamente e a notificação do recap aparece quando ficar pronta.
- \`showedRecapSinceActivity = true\` continua sendo setado de forma síncrona antes do disparo, então não há duplicação.
- O comando manual \`/recap\` mantém o \`await\` (correto — o usuário pediu explicitamente e usa \`setWorkingMessage\`).
- Bump de versão: \`1.0.0\` → \`1.0.1\`.

## Testes

- \`pnpm build\` (tsc) passa sem erros.
- \`lsp_diagnostics\` limpo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup responsiveness by letting recap generation run in the background instead of delaying the main flow.
  * Recap notifications still appear when content is available, with errors safely ignored as before.

* **Chores**
  * Bumped the package version to `1.0.1`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->