### PR TITLE
fix(catch-the-fox): raposa cortada por limite de linhas do widget

### DIFF
--- a/packages/catch-the-fox/package.json
+++ b/packages/catch-the-fox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-catch-the-fox",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "PI extension: uma raposa em pixel-art que reage ao que o agente está fazendo (farejando, cavando, executando, dormindo)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/catch-the-fox/src/index.ts
+++ b/packages/catch-the-fox/src/index.ts
@@ -89,8 +89,12 @@ export default function catchTheFoxExtension(pi: ExtensionAPI): void {
     }
     const frames = RENDERED[state];
     const frame = frames[frameIndex % frames.length];
+    const lines = [` ${ANIMS[state].label}`, "", ...frame];
     try {
-      ui.setWidget(widgetId, [` ${ANIMS[state].label}`, "", ...frame]);
+      ui.setWidget(widgetId, () => ({
+        render: () => lines,
+        invalidate: () => {},
+      }));
     } catch {}
   }
 


### PR DESCRIPTION
## O que

Corrige a raposa da extensão `catch-the-fox` que aparecia cortada no rodapé do pi, com a mensagem `... (widget truncated)`.

## Por quê

A TUI do pi trunca widgets passados como **array de strings** em `MAX_WIDGET_LINES = 10` (`interactive-mode.js:1526`). O sprite da raposa tem 20 linhas de grid → `gridToAnsi` empacota 2 linhas por caractere (`▀`/`▄`) = 10 linhas renderizadas. Somado ao header `[label, "", ...frame]` = 12 linhas, estourando o limite e cortando patas/cauda.

Os sprites estavam corretos — o problema era exclusivamente o limite de renderização do widget.

## Como

Troquei a forma de array de strings pela forma **factory-function** (`{ render, invalidate }`), que o pi renderiza verbatim, sem cap:

```ts
ui.setWidget(widgetId, () => ({
  render: () => lines,
  invalidate: () => {},
}));
```

## Testado

- `pnpm build` (tsc) limpo
- `lsp_diagnostics` sem erros

Bump: `0.5.0` → `0.5.1`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved widget updates so the displayed animation label and frame remain synchronized during rendering.

* **Chores**
  * Updated the extension version to 0.5.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->