### PR TITLE
fix(catch-the-fox): sprites detalhados e ajuste de espaçamento do widget

### DIFF
--- a/packages/catch-the-fox/package.json
+++ b/packages/catch-the-fox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-catch-the-fox",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "PI extension: uma raposa em pixel-art que reage ao que o agente está fazendo (farejando, cavando, executando, dormindo)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/catch-the-fox/src/index.ts
+++ b/packages/catch-the-fox/src/index.ts
@@ -36,10 +36,27 @@ export function gridToAnsi(grid: string[]): string[] {
   return lines;
 }
 
+function isBlankRow(row: string): boolean {
+  return /^\.*$/.test(row);
+}
+
+function trimLeadingBlankRows(grids: string[][]): string[][] {
+  let blankRows = Infinity;
+  for (const grid of grids) {
+    let count = 0;
+    while (count < grid.length && isBlankRow(grid[count])) count += 1;
+    blankRows = Math.min(blankRows, count);
+  }
+  if (!Number.isFinite(blankRows) || blankRows <= 0) return grids;
+  const evenBlankRows = blankRows - (blankRows % 2);
+  if (evenBlankRows <= 0) return grids;
+  return grids.map((grid) => grid.slice(evenBlankRows));
+}
+
 const RENDERED = Object.fromEntries(
   Object.entries(ANIMS).map(([state, animation]) => [
     state,
-    animation.grids.map(gridToAnsi),
+    trimLeadingBlankRows(animation.grids).map(gridToAnsi),
   ]),
 ) as Record<FoxState, string[][]>;
 
@@ -89,7 +106,7 @@ export default function catchTheFoxExtension(pi: ExtensionAPI): void {
     }
     const frames = RENDERED[state];
     const frame = frames[frameIndex % frames.length];
-    const lines = [` ${ANIMS[state].label}`, "", ...frame];
+    const lines = [` ${ANIMS[state].label}`, ...frame];
     try {
       ui.setWidget(widgetId, () => ({
         render: () => lines,


### PR DESCRIPTION
## O que muda

Melhorias no widget `catch-the-fox`:

- **Pixel art detalhada** da raposa em todos os estados (sleep, sniff, dig, run, jump, caught, error, sad)
- **Renderização via factory** para evitar o truncamento em 10 linhas
- **Remoção do espaço grande** entre o label e a arte: apara as linhas em branco no topo de cada animação (em quantidade par, preservando o pareamento do `gridToAnsi`) e remove a linha vazia espaçadora

Bump: `0.5.1` → `0.5.2`.

## Como testar

```bash
cd packages/catch-the-fox
pnpm build && node preview.mjs
```

Ou carregue a extensão localmente e rode `/fox <estado>`.

## Antes / Depois

O label agora fica colado na raposa, sem o gap vertical grande. Nenhum pixel da arte é cortado.