### PR TITLE
fix(git-review-bridge): use deployed cloud URL

### DIFF
--- a/packages/git-review-bridge/README.md
+++ b/packages/git-review-bridge/README.md
@@ -25,14 +25,14 @@ No inbound ports are opened locally. The bridge dials out to the cloud.
 
 ```jsonc
 {
-  "cloudUrl": "https://git-review.arvore.com.br",
+  "cloudUrl": "https://git-review.arvore.dev",
   "bridgeToken": "…",   // written by /review-cloud-login
   "login": "you"
 }
 ```
 
 `cloudUrl` can also be set with the `GIT_REVIEW_CLOUD_URL` env var. Defaults to
-`https://git-review.arvore.com.br`.
+`https://git-review.arvore.dev`.
 
 ## How repos are discovered
 

--- a/packages/git-review-bridge/package.json
+++ b/packages/git-review-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-git-review-bridge",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "PI extension that bridges a local pi session to the git-review-cloud PR reviewer: browser comments are delivered to the agent in real time over WebSocket",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -11,7 +11,8 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
-    "lint": "tsc --noEmit"
+    "lint": "tsc --noEmit",
+    "test": "pnpm build && node --test test/*.test.mjs"
   },
   "peerDependencies": {
     "@earendil-works/pi-coding-agent": ">=0.74.0"

--- a/packages/git-review-bridge/src/config.ts
+++ b/packages/git-review-bridge/src/config.ts
@@ -12,21 +12,21 @@ export interface BridgeConfig {
 const CONFIG_DIR = join(homedir(), ".config", "pi");
 const CONFIG_FILE = join(CONFIG_DIR, "git-review-cloud.json");
 
-const DEFAULT_CLOUD_URL =
-  process.env.GIT_REVIEW_CLOUD_URL || "https://git-review.arvore.com.br";
+export const DEFAULT_CLOUD_URL = "https://git-review.arvore.dev";
+const CONFIGURED_CLOUD_URL = process.env.GIT_REVIEW_CLOUD_URL || DEFAULT_CLOUD_URL;
 
 export async function loadConfig(): Promise<BridgeConfig> {
-  if (!existsSync(CONFIG_FILE)) return { cloudUrl: DEFAULT_CLOUD_URL };
+  if (!existsSync(CONFIG_FILE)) return { cloudUrl: CONFIGURED_CLOUD_URL };
   try {
     const raw = await readFile(CONFIG_FILE, "utf-8");
     const parsed = JSON.parse(raw) as Partial<BridgeConfig>;
     return {
-      cloudUrl: parsed.cloudUrl || DEFAULT_CLOUD_URL,
+      cloudUrl: parsed.cloudUrl || CONFIGURED_CLOUD_URL,
       bridgeToken: parsed.bridgeToken,
       login: parsed.login,
     };
   } catch {
-    return { cloudUrl: DEFAULT_CLOUD_URL };
+    return { cloudUrl: CONFIGURED_CLOUD_URL };
   }
 }
 

--- a/packages/git-review-bridge/src/index.ts
+++ b/packages/git-review-bridge/src/index.ts
@@ -64,6 +64,11 @@ interface DevicePollResponse {
   error?: string;
 }
 
+function describeError(error: unknown): string {
+  if (!(error instanceof Error)) return String(error);
+  return error.cause instanceof Error ? error.cause.message : error.message;
+}
+
 async function runDeviceLogin(
   cloudUrl: string,
   notify: (m: string, t?: "info" | "warning" | "error") => void,
@@ -171,7 +176,16 @@ export default function (pi: ExtensionAPI) {
     description: "Authenticate this machine with git-review-cloud (GitHub device flow)",
     handler: async (_args, ctx) => {
       config = await loadConfig();
-      const result = await runDeviceLogin(config.cloudUrl, ctx.ui.notify, pi);
+      let result: Awaited<ReturnType<typeof runDeviceLogin>>;
+      try {
+        result = await runDeviceLogin(config.cloudUrl, ctx.ui.notify, pi);
+      } catch (error) {
+        ctx.ui.notify(
+          `git-review-cloud: could not reach ${config.cloudUrl} (${describeError(error)})`,
+          "error",
+        );
+        return;
+      }
       if (!result) return;
       config = { ...config, bridgeToken: result.bridgeToken, login: result.login };
       await saveConfig(config);

--- a/packages/git-review-bridge/test/config.test.mjs
+++ b/packages/git-review-bridge/test/config.test.mjs
@@ -1,0 +1,69 @@
+import test, { after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const originalHome = process.env.HOME;
+const originalCloudUrl = process.env.GIT_REVIEW_CLOUD_URL;
+const isolatedHome = mkdtempSync(join(tmpdir(), "git-review-bridge-test-"));
+process.env.HOME = isolatedHome;
+delete process.env.GIT_REVIEW_CLOUD_URL;
+
+const { DEFAULT_CLOUD_URL, loadConfig } = await import("../dist/config.js");
+const { default: registerExtension } = await import("../dist/index.js");
+
+after(() => {
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  if (originalCloudUrl === undefined) delete process.env.GIT_REVIEW_CLOUD_URL;
+  else process.env.GIT_REVIEW_CLOUD_URL = originalCloudUrl;
+  rmSync(isolatedHome, { recursive: true, force: true });
+});
+
+test("uses the deployed git-review cloud URL by default", async () => {
+  assert.equal(DEFAULT_CLOUD_URL, "https://git-review.arvore.dev");
+  assert.deepEqual(await loadConfig(), { cloudUrl: DEFAULT_CLOUD_URL });
+});
+
+test("turns a rejected login request into a useful notification", async () => {
+  const commands = new Map();
+  const notifications = [];
+  const pi = {
+    registerCommand(name, command) {
+      commands.set(name, command);
+    },
+    on() {},
+    exec: async () => ({ stdout: "", stderr: "", code: 0 }),
+    sendUserMessage() {},
+    getSessionName: () => undefined,
+  };
+  registerExtension(pi);
+
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => {
+    throw new TypeError("fetch failed", { cause: new Error("simulated connection refused") });
+  };
+
+  try {
+    const command = commands.get("review-cloud-login");
+    assert.ok(command);
+    await command.handler("", {
+      ui: {
+        notify(message, type) {
+          notifications.push({ message, type });
+        },
+      },
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  assert.deepEqual(notifications, [
+    {
+      message:
+        "git-review-cloud: could not reach https://git-review.arvore.dev (simulated connection refused)",
+      type: "error",
+    },
+  ]);
+});

--- a/packages/git-review-cloud/deploy/README.md
+++ b/packages/git-review-cloud/deploy/README.md
@@ -36,7 +36,7 @@ Install the App on the org/repos you want reviewable. Note the **App ID**,
 | `GITHUB_CLIENT_ID` | yes | App client id |
 | `GITHUB_CLIENT_SECRET` | yes | App client secret |
 | `GITHUB_APP_PRIVATE_KEY` | yes | PEM contents (with real newlines or `\n`-escaped), **or** base64 of the PEM |
-| `PUBLIC_URL` | yes | e.g. `https://git-review.arvore.com.br` |
+| `PUBLIC_URL` | yes | e.g. `https://git-review.arvore.dev` |
 | `GITHUB_ALLOWED_ORG` | recommended | only members of this org can log in |
 | `GITHUB_WEBHOOK_SECRET` | no | only if you wire webhooks later |
 | `PORT` | no | defaults to `8080` |
@@ -54,7 +54,7 @@ extension and point it at the deployed URL:
 
 ```jsonc
 // ~/.config/pi/git-review-cloud.json
-{ "cloudUrl": "https://git-review.arvore.com.br" }
+{ "cloudUrl": "https://git-review.arvore.dev" }
 ```
 
 Then inside pi:


### PR DESCRIPTION
## Contexto

O `/review-cloud-login` usava `https://git-review.arvore.com.br`, domínio que retorna NXDOMAIN, embora o serviço esteja implantado em `https://git-review.arvore.dev`. Isso fazia o primeiro `POST /auth/device/start` falhar com `TypeError: fetch failed`.

## Alterações

- corrige a URL padrão para o domínio de produção implantado
- mantém a precedência da variável `GIT_REVIEW_CLOUD_URL` e da configuração local
- transforma falhas de rede do login em uma notificação com URL e causa original
- atualiza a documentação do bridge e do deploy
- adiciona regressões para URL padrão, fallback de configuração e erro de rede
- incrementa o pacote do bridge para `0.1.1`

## Validação

- `pnpm --filter @arvoretech/pi-git-review-bridge test`
- `lsp_diagnostics` sem erros em `src/config.ts` e `src/index.ts`
- `GET https://git-review.arvore.dev/healthz` → HTTP 200
- `POST https://git-review.arvore.dev/auth/device/start` → HTTP 200 com o contrato esperado


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved login error messages when the cloud service cannot be reached, including the affected URL and failure reason.
  * Updated the default cloud service address to `https://git-review.arvore.dev`.

* **Documentation**
  * Updated configuration and deployment examples with the new cloud service address.

* **Chores**
  * Added automated tests for default configuration and login connection errors.
  * Bumped the bridge package version to 0.1.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->