### PR TITLE
fix: support OpenAI to Kiro conversation handoffs

### DIFF
--- a/packages/kiro-provider/package.json
+++ b/packages/kiro-provider/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@arvoretech/pi-kiro-provider",
-	"version": "0.8.3",
+	"version": "0.8.4",
 	"description": "Pi extension for the Kiro API, maintained by Arvore",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/kiro-provider/src/stream.ts
+++ b/packages/kiro-provider/src/stream.ts
@@ -57,6 +57,7 @@ import {
 	type KiroToolSpec,
 	type KiroUserInputMessage,
 	normalizeMessages,
+	normalizeToolUseId,
 	sanitizeSurrogates,
 	TOOL_RESULT_LIMIT,
 	truncate,
@@ -396,7 +397,7 @@ export function streamKiro(
 								const tc = b as ToolCall;
 								armToolUses.push({
 									name: tc.name,
-									toolUseId: tc.id,
+									toolUseId: normalizeToolUseId(tc.id),
 									input:
 										typeof tc.arguments === "string"
 											? JSON.parse(tc.arguments)
@@ -438,7 +439,7 @@ export function streamKiro(
 									{ text: truncate(getContentText(m), toolResultLimit) },
 								],
 								status: trm.isError ? "error" : "success",
-								toolUseId: trm.toolCallId,
+								toolUseId: normalizeToolUseId(trm.toolCallId),
 							});
 							if (Array.isArray(trm.content))
 								for (const c of trm.content)
@@ -466,7 +467,7 @@ export function streamKiro(
 									{ text: truncate(getContentText(m), toolResultLimit) },
 								],
 								status: trm.isError ? "error" : "success",
-								toolUseId: trm.toolCallId,
+								toolUseId: normalizeToolUseId(trm.toolCallId),
 							});
 							if (Array.isArray(trm.content))
 								for (const c of trm.content)

--- a/packages/kiro-provider/src/transform.ts
+++ b/packages/kiro-provider/src/transform.ts
@@ -1,5 +1,6 @@
 // Feature 5: Message Transformation
 
+import { createHash } from "node:crypto";
 import type {
 	AssistantMessage,
 	ImageContent,
@@ -52,6 +53,12 @@ export interface KiroHistoryEntry {
 }
 
 export const TOOL_RESULT_LIMIT = 250000;
+
+export function normalizeToolUseId(toolUseId: string): string {
+	if (!toolUseId.includes("|")) return toolUseId;
+	const digest = createHash("sha256").update(toolUseId).digest("hex").slice(0, 32);
+	return `call_${digest.slice(0, 8)}-${digest.slice(8, 12)}-${digest.slice(12, 16)}-${digest.slice(16, 20)}-${digest.slice(20)}`;
+}
 
 export function sanitizeSurrogates(text: string): string {
 	// Replace unpaired high surrogates (0xD800-0xDBFF not followed by low surrogate)
@@ -189,7 +196,7 @@ export function buildHistory(
 						const tc = block as ToolCall;
 						armToolUses.push({
 							name: tc.name,
-							toolUseId: tc.id,
+							toolUseId: normalizeToolUseId(tc.id),
 							input:
 								typeof tc.arguments === "string"
 									? JSON.parse(tc.arguments)
@@ -211,7 +218,7 @@ export function buildHistory(
 				{
 					content: [{ text: truncate(getContentText(msg), toolResultLimit) }],
 					status: trMsg.isError ? "error" : "success",
-					toolUseId: trMsg.toolCallId,
+					toolUseId: normalizeToolUseId(trMsg.toolCallId),
 				},
 			];
 			const trImages: ImageContent[] = [];
@@ -227,7 +234,7 @@ export function buildHistory(
 				toolResults.push({
 					content: [{ text: truncate(getContentText(next), toolResultLimit) }],
 					status: next.isError ? "error" : "success",
-					toolUseId: next.toolCallId,
+					toolUseId: normalizeToolUseId(next.toolCallId),
 				});
 				if (Array.isArray(next.content))
 					for (const c of next.content)

--- a/packages/kiro-provider/test/transform.test.ts
+++ b/packages/kiro-provider/test/transform.test.ts
@@ -196,6 +196,50 @@ describe("Feature 5: Message Transformation", () => {
 			expect(entry?.assistantResponseMessage?.toolUses?.[0].name).toBe("bash");
 		});
 
+		it("normalizes OpenAI Responses tool IDs for Kiro history", () => {
+			const firstId = "call_first|fc_first";
+			const secondId = "call_second|fc_second";
+			const a = assistant("", {
+				api: "openai-codex-responses",
+				provider: "openai-codex",
+				model: "gpt-5.6-terra",
+			});
+			a.content = [
+				{ type: "toolCall", id: firstId, name: "read", arguments: { path: "a" } },
+				{ type: "toolCall", id: secondId, name: "read", arguments: { path: "b" } },
+			];
+			const msgs: Message[] = [
+				user("read both"),
+				a,
+				toolResult(firstId, "a"),
+				toolResult(secondId, "b"),
+				user("continue"),
+			];
+
+			const { history } = buildHistory(msgs, "M");
+			const toolUses = history.flatMap(
+				(entry) => entry.assistantResponseMessage?.toolUses ?? [],
+			);
+			const results = history.flatMap(
+				(entry) =>
+					entry.userInputMessage?.userInputMessageContext?.toolResults ?? [],
+			);
+
+			const normalizedToolUseIds = toolUses.map(
+				(toolUse) => toolUse.toolUseId,
+			);
+			expect(normalizedToolUseIds).toHaveLength(2);
+			expect(normalizedToolUseIds[0]).not.toBe(normalizedToolUseIds[1]);
+			for (const toolUseId of normalizedToolUseIds) {
+				expect(toolUseId).toMatch(
+					/^call_[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/,
+				);
+			}
+			expect(results.map((result) => result.toolUseId)).toEqual(
+				normalizedToolUseIds,
+			);
+		});
+
 		it("batches consecutive tool results", () => {
 			const a = assistant("");
 			a.content = [


### PR DESCRIPTION
## O que mudou

- normaliza IDs de tool calls do OpenAI Responses para o formato aceito pelo Kiro
- mantém o mesmo ID normalizado entre cada tool call e seu respectivo resultado
- aplica a compatibilidade tanto ao histórico quanto ao turno atual
- adiciona regressão com múltiplas tool calls vindas do OpenAI
- incrementa a versão do pacote para `0.8.4`

## Como validar

- iniciar ou retomar uma conversa usando GPT-5.6 pelo provider OpenAI Codex
- trocar para o mesmo modelo pelo provider Kiro e enviar uma nova mensagem
- `cd packages/kiro-provider && pnpm exec vitest run`
- `cd packages/kiro-provider && pnpm run build`

## Evidências

- 288 testes passando
- build TypeScript concluído sem erros
- LSP sem diagnósticos nos arquivos TypeScript alterados
- handoff sintético OpenAI → Kiro aceito pela API real
- `git diff --check` sem erros


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with tool calls from Responses-style APIs by normalizing tool-use identifiers.
  * Preserved accurate matching between tool calls and their corresponding results during streaming and history reconstruction.

* **Tests**
  * Added coverage verifying unique, consistent normalized identifiers for multiple tool calls.

* **Chores**
  * Updated the package version to 0.8.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->