### PR TITLE
fix(worktree): support standalone repositories

### DIFF
--- a/packages/worktree/package.json
+++ b/packages/worktree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-worktree",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "description": "PI extension to manage git worktrees across multi-repo workspaces with tree-themed names",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -11,7 +11,8 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
-    "lint": "tsc --noEmit"
+    "lint": "tsc --noEmit",
+    "test": "node --test --experimental-strip-types --disable-warning=ExperimentalWarning test/*.test.ts"
   },
   "peerDependencies": {
     "@earendil-works/pi-coding-agent": ">=0.74.0"

--- a/packages/worktree/src/index.ts
+++ b/packages/worktree/src/index.ts
@@ -3,6 +3,7 @@ import { Type } from "@earendil-works/pi-ai";
 import { execSync, spawnSync, spawn } from "node:child_process";
 import { existsSync, readFileSync, appendFileSync, readdirSync, statSync, symlinkSync, writeFileSync, mkdirSync, openSync, closeSync } from "node:fs";
 import { join, resolve, basename } from "node:path";
+import { discoverRepos, findWorkspaceRoot } from "./repository-discovery.js";
 import {
   isOrcaSession,
   runOrca,
@@ -85,7 +86,7 @@ interface SetupConfig {
 }
 
 function getSetupDir(repoPath: string): string {
-  const root = findHubRoot(repoPath) || repoPath;
+  const root = findWorkspaceRoot(repoPath) || repoPath;
   return join(root, SETUP_DIR);
 }
 
@@ -128,32 +129,6 @@ function ensureGitignore(repoPath: string): void {
   }
 }
 
-function isGitRepo(dir: string): boolean {
-  return existsSync(join(dir, ".git"));
-}
-
-function discoverRepos(cwd: string): string[] {
-  const hubRoot = findHubRoot(cwd);
-  if (!hubRoot) return isGitRepo(cwd) ? [cwd] : [];
-
-  const repos: string[] = [];
-  for (const entry of readdirSync(hubRoot)) {
-    const full = join(hubRoot, entry);
-    if (statSync(full).isDirectory() && isGitRepo(full)) repos.push(full);
-  }
-  return repos.sort((a, b) => basename(a).localeCompare(basename(b)));
-}
-
-function findHubRoot(cwd: string): string | null {
-  let dir = cwd;
-  let prev = "";
-  while (dir !== prev) {
-    if (existsSync(join(dir, "AGENTS.md")) || existsSync(join(dir, "hub.config.ts"))) return dir;
-    prev = dir;
-    dir = resolve(dir, "..");
-  }
-  return null;
-}
 
 function getCurrentBranch(repoPath: string): string {
   try {
@@ -465,7 +440,7 @@ interface WorktreeState {
 }
 
 function getStatePath(cwd: string, sessionId: string): string | null {
-  const root = findHubRoot(cwd);
+  const root = findWorkspaceRoot(cwd);
   return root ? join(root, STATE_DIR, `${sessionId}.json`) : null;
 }
 

--- a/packages/worktree/src/repository-discovery.ts
+++ b/packages/worktree/src/repository-discovery.ts
@@ -1,0 +1,57 @@
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { basename, join, resolve } from "node:path";
+
+function isGitRepo(dir: string): boolean {
+  return existsSync(join(dir, ".git"));
+}
+
+function discoverChildRepos(dir: string): string[] {
+  try {
+    return readdirSync(dir)
+      .map((entry) => join(dir, entry))
+      .filter((entry) => statSync(entry).isDirectory() && isGitRepo(entry))
+      .sort((a, b) => basename(a).localeCompare(basename(b)));
+  } catch {
+    return [];
+  }
+}
+
+function findHubRoot(cwd: string): string | null {
+  let dir = resolve(cwd);
+  let previous = "";
+
+  while (dir !== previous) {
+    const hasExplicitConfig = existsSync(join(dir, "hub.config.ts"));
+    const hasHubLayout = !isGitRepo(dir) && existsSync(join(dir, "AGENTS.md")) && discoverChildRepos(dir).length > 0;
+    if (hasExplicitConfig || hasHubLayout) return dir;
+    previous = dir;
+    dir = resolve(dir, "..");
+  }
+
+  return null;
+}
+
+function findGitRoot(cwd: string): string | null {
+  let dir = resolve(cwd);
+  let previous = "";
+
+  while (dir !== previous) {
+    if (isGitRepo(dir)) return dir;
+    previous = dir;
+    dir = resolve(dir, "..");
+  }
+
+  return null;
+}
+
+export function findWorkspaceRoot(cwd: string): string | null {
+  return findHubRoot(cwd) || findGitRoot(cwd);
+}
+
+export function discoverRepos(cwd: string): string[] {
+  const hubRoot = findHubRoot(cwd);
+  if (hubRoot) return discoverChildRepos(hubRoot);
+
+  const gitRoot = findGitRoot(cwd);
+  return gitRoot ? [gitRoot] : [];
+}

--- a/packages/worktree/test/repository-discovery.test.ts
+++ b/packages/worktree/test/repository-discovery.test.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+import { afterEach, test } from "node:test";
+import { discoverRepos, findWorkspaceRoot } from "../src/repository-discovery.ts";
+
+const temporaryDirectories: string[] = [];
+
+function createTemporaryDirectory(): string {
+  const directory = mkdtempSync(join(tmpdir(), "pi-worktree-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+function createGitRepo(directory: string): void {
+  mkdirSync(join(directory, ".git"), { recursive: true });
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("discovers a standalone repository containing AGENTS.md", () => {
+  const repository = createTemporaryDirectory();
+  createGitRepo(repository);
+  writeFileSync(join(repository, "AGENTS.md"), "# Project\n");
+
+  assert.deepEqual(discoverRepos(repository), [repository]);
+  assert.equal(findWorkspaceRoot(repository), repository);
+});
+
+test("discovers the enclosing standalone repository from a nested directory", () => {
+  const repository = createTemporaryDirectory();
+  const nestedDirectory = join(repository, "src", "editor");
+  createGitRepo(repository);
+  mkdirSync(nestedDirectory, { recursive: true });
+  writeFileSync(join(repository, "AGENTS.md"), "# Project\n");
+
+  assert.deepEqual(discoverRepos(nestedDirectory), [repository]);
+  assert.equal(findWorkspaceRoot(nestedDirectory), repository);
+});
+
+test("discovers immediate child repositories in an AGENTS.md hub", () => {
+  const hub = createTemporaryDirectory();
+  const firstRepository = join(hub, "alpha");
+  const secondRepository = join(hub, "beta");
+  mkdirSync(firstRepository);
+  mkdirSync(secondRepository);
+  createGitRepo(firstRepository);
+  createGitRepo(secondRepository);
+  writeFileSync(join(hub, "AGENTS.md"), "# Hub\n");
+
+  assert.deepEqual(discoverRepos(firstRepository), [firstRepository, secondRepository]);
+  assert.equal(findWorkspaceRoot(firstRepository), hub);
+});
+
+test("does not treat a standalone repository with a nested repository as a hub", () => {
+  const repository = createTemporaryDirectory();
+  const nestedRepository = join(repository, "vendor");
+  createGitRepo(repository);
+  mkdirSync(nestedRepository);
+  createGitRepo(nestedRepository);
+  writeFileSync(join(repository, "AGENTS.md"), "# Project\n");
+
+  assert.deepEqual(discoverRepos(repository), [repository]);
+  assert.equal(findWorkspaceRoot(repository), repository);
+});
+
+test("uses hub.config.ts as an explicit hub marker", () => {
+  const hub = createTemporaryDirectory();
+  const repository = join(hub, "app");
+  mkdirSync(repository);
+  createGitRepo(repository);
+  writeFileSync(join(hub, "hub.config.ts"), "export default {};\n");
+
+  assert.deepEqual(discoverRepos(repository).map((path) => basename(path)), ["app"]);
+  assert.equal(findWorkspaceRoot(repository), hub);
+});


### PR DESCRIPTION
## Contexto

O `@arvoretech/pi-worktree` interpretava qualquer diretório com `AGENTS.md` como um hub multi-repositório. Em projetos standalone, isso fazia a descoberta procurar apenas repositórios filhos e retornar uma lista vazia.

## O que mudou

- diferencia hubs explícitos ou com layout multi-repo de repositórios standalone
- resolve o Git root mesmo quando o Pi é iniciado em um subdiretório
- usa o workspace resolvido para setup e persistência de estado
- adiciona cobertura para standalone, cwd aninhado, hub multi-repo e repositório Git aninhado
- atualiza `@arvoretech/pi-worktree` para `1.11.2`

## Como validar

```bash
cd packages/worktree
pnpm test
pnpm lint
```

## Resultado

- 5 testes passando
- TypeScript sem erros
- smoke test validado em `/home/rick/Projects/Repos/markdown-thing`
