### PR TITLE
Lazy-load Slack bridge dependencies

### DIFF
--- a/packages/slack-bridge/package.json
+++ b/packages/slack-bridge/package.json
@@ -11,7 +11,8 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
-    "lint": "tsc --noEmit"
+    "lint": "tsc --noEmit",
+    "test": "vitest run"
   },
   "peerDependencies": {
     "@earendil-works/pi-coding-agent": ">=0.74.0"
@@ -26,7 +27,8 @@
     "@earendil-works/pi-coding-agent": "latest",
     "@earendil-works/pi-ai": "latest",
     "@types/node": "^20.10.0",
-    "typescript": "^5.3.0"
+    "typescript": "^5.3.0",
+    "vitest": "^3.2.6"
   },
   "pi": {
     "extensions": [

--- a/packages/slack-bridge/package.json
+++ b/packages/slack-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-slack-bridge",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "PI extension that bridges the active Pi session to a Slack thread: mirrors messages both ways, one Slack thread per Pi session",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/slack-bridge/src/codeshot.ts
+++ b/packages/slack-bridge/src/codeshot.ts
@@ -1,5 +1,3 @@
-import sharp from "sharp";
-
 interface DiffRow {
   kind: "add" | "del" | "ctx";
   text: string;
@@ -128,6 +126,7 @@ export function buildDiffShot(toolName: string, args: unknown): DiffShot | undef
 }
 
 export async function renderCodeshot(title: string, diff: string): Promise<Buffer> {
+  const { default: sharp } = await import("sharp");
   let rows = parseDiffRows(diff);
   let truncatedRows = false;
   if (rows.length > MAX_ROWS) {

--- a/packages/slack-bridge/src/index.ts
+++ b/packages/slack-bridge/src/index.ts
@@ -1,11 +1,33 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { SlackBridgeConfig } from "./config.js";
 import { loadConfig } from "./config.js";
-import { SlackBridge } from "./bridge.js";
+import type { SlackBridge } from "./bridge.js";
 
-export default function (pi: ExtensionAPI): void {
+type Bridge = Pick<
+  SlackBridge,
+  | "bindContext"
+  | "restoreFromEntries"
+  | "start"
+  | "stop"
+  | "mirrorUserInput"
+  | "beginTurn"
+  | "recordTool"
+  | "recordToolResult"
+  | "recordAssistantMessage"
+  | "finishTurn"
+  | "handlePromptEvent"
+>;
+type SlackBridgeConstructor = new (pi: ExtensionAPI, config: SlackBridgeConfig) => Bridge;
+type BridgeModule = { SlackBridge: SlackBridgeConstructor };
+export type BridgeLoader = () => Promise<BridgeModule>;
+
+const defaultBridgeLoader: BridgeLoader = () => import("./bridge.js");
+
+export default function (pi: ExtensionAPI, bridgeLoader: BridgeLoader = defaultBridgeLoader): void {
   const { config, missing } = loadConfig();
 
-  let bridge: SlackBridge | undefined;
+  let bridge: Bridge | undefined;
+  let bridgeModulePromise: Promise<BridgeModule> | undefined;
   let lastContext: ExtensionContext | undefined;
   let starting: Promise<void> | undefined;
 
@@ -17,17 +39,29 @@ export default function (pi: ExtensionAPI): void {
     lastContext?.ui.setStatus("slack-bridge", on ? "\ud83d\udfe2 Slack" : undefined);
   }
 
+  async function loadBridgeModule(): Promise<BridgeModule> {
+    if (!bridgeModulePromise) {
+      bridgeModulePromise = bridgeLoader().catch((error) => {
+        bridgeModulePromise = undefined;
+        throw error;
+      });
+    }
+    return bridgeModulePromise;
+  }
+
   async function startBridge(ctx: ExtensionContext): Promise<void> {
     if (!config) return;
     captureContext(ctx);
-    if (bridge) return;
     if (starting) return starting;
-    const instance = new SlackBridge(pi, config);
-    instance.bindContext(() => lastContext);
-    instance.restoreFromEntries(ctx);
-    bridge = instance;
-    starting = instance
-      .start()
+    if (bridge) return;
+    starting = loadBridgeModule()
+      .then(({ SlackBridge }) => {
+        const instance = new SlackBridge(pi, config);
+        instance.bindContext(() => lastContext);
+        instance.restoreFromEntries(ctx);
+        bridge = instance;
+        return instance.start();
+      })
       .then(() => {
         setIndicator(true);
         ctx.ui.notify("Slack bridge conectada para esta sessão.", "info");
@@ -43,6 +77,7 @@ export default function (pi: ExtensionAPI): void {
   }
 
   async function stopBridge(): Promise<void> {
+    await starting?.catch(() => {});
     await bridge?.stop().catch(() => {});
     bridge = undefined;
     setIndicator(false);
@@ -104,7 +139,7 @@ export default function (pi: ExtensionAPI): void {
       }
       const action = args.trim().toLowerCase();
       if (action === "off" || action === "stop") {
-        if (!bridge) {
+        if (!bridge && !starting) {
           ctx.ui.notify("Slack bridge já está desligada.", "info");
           return;
         }

--- a/packages/slack-bridge/test/index.test.ts
+++ b/packages/slack-bridge/test/index.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import slackBridgeExtension, { type BridgeLoader } from "../src/index.js";
+
+type Handler = (...args: any[]) => unknown;
+
+const configKeys = [
+  "SLACK_BRIDGE_BOT_TOKEN",
+  "SLACK_BRIDGE_APP_TOKEN",
+  "SLACK_BRIDGE_CHANNEL",
+  "SLACK_BRIDGE_USER_IDS",
+  "SLACK_BOT_TOKEN",
+  "SLACK_APP_TOKEN",
+] as const;
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function createHarness() {
+  const handlers = new Map<string, Handler>();
+  const commands = new Map<string, { handler: Handler }>();
+  const eventHandlers = new Map<string, Handler>();
+  const notifications: Array<[string, string]> = [];
+  const statuses: Array<[string, string | undefined]> = [];
+  const context = {
+    isIdle: () => true,
+    sessionManager: { getEntries: () => [] },
+    ui: {
+      notify: (message: string, level: string) => notifications.push([message, level]),
+      setStatus: (key: string, value: string | undefined) => statuses.push([key, value]),
+    },
+  };
+  const pi = {
+    appendEntry: vi.fn(),
+    sendUserMessage: vi.fn(),
+    on: vi.fn((event: string, handler: Handler) => handlers.set(event, handler)),
+    registerCommand: vi.fn((name: string, command: { handler: Handler }) => commands.set(name, command)),
+    events: {
+      emit: vi.fn(),
+      on: vi.fn((event: string, handler: Handler) => eventHandlers.set(event, handler)),
+    },
+  };
+
+  return { commands, context, eventHandlers, handlers, notifications, pi, statuses };
+}
+
+function createBridgeModule(startImplementation: () => Promise<void> = async () => {}) {
+  const instances: FakeBridge[] = [];
+
+  class FakeBridge {
+    bindContext = vi.fn();
+    restoreFromEntries = vi.fn();
+    start = vi.fn(startImplementation);
+    stop = vi.fn(async () => {});
+    mirrorUserInput = vi.fn(async () => {});
+    beginTurn = vi.fn(async () => {});
+    recordTool = vi.fn(async () => {});
+    recordToolResult = vi.fn(async () => {});
+    recordAssistantMessage = vi.fn(async () => {});
+    finishTurn = vi.fn(async () => {});
+    handlePromptEvent = vi.fn(async () => {});
+
+    constructor() {
+      instances.push(this);
+    }
+  }
+
+  return { module: { SlackBridge: FakeBridge }, instances };
+}
+
+describe("slack bridge extension", () => {
+  const originalEnv = new Map<string, string | undefined>();
+
+  beforeEach(() => {
+    for (const key of configKeys) originalEnv.set(key, process.env[key]);
+    process.env.SLACK_BRIDGE_BOT_TOKEN = "bot-token";
+    process.env.SLACK_BRIDGE_APP_TOKEN = "app-token";
+    process.env.SLACK_BRIDGE_CHANNEL = "channel";
+  });
+
+  afterEach(() => {
+    for (const [key, value] of originalEnv) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    originalEnv.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("registers commands and handlers without loading the bridge", async () => {
+    const harness = createHarness();
+    const loader = vi.fn<BridgeLoader>();
+
+    slackBridgeExtension(harness.pi as never, loader);
+
+    expect(harness.commands.has("slack-bridge")).toBe(true);
+    expect(harness.handlers.has("session_shutdown")).toBe(true);
+    expect(harness.eventHandlers.has("arvore:ask-user:prompt")).toBe(true);
+    expect(loader).not.toHaveBeenCalled();
+
+    await harness.commands.get("slack-bridge")!.handler("status", harness.context);
+    expect(loader).not.toHaveBeenCalled();
+  });
+
+  it("does not load the bridge when configuration is missing", async () => {
+    delete process.env.SLACK_BRIDGE_BOT_TOKEN;
+    delete process.env.SLACK_BRIDGE_APP_TOKEN;
+    delete process.env.SLACK_BRIDGE_CHANNEL;
+    const harness = createHarness();
+    const loader = vi.fn<BridgeLoader>();
+
+    slackBridgeExtension(harness.pi as never, loader);
+    await harness.commands.get("slack-bridge")!.handler("on", harness.context);
+
+    expect(loader).not.toHaveBeenCalled();
+    expect(harness.notifications.at(-1)?.[1]).toBe("warning");
+  });
+
+  it("shares one lazy load and one start across concurrent activation", async () => {
+    const activation = deferred<void>();
+    const fake = createBridgeModule(() => activation.promise);
+    const loader = vi.fn<BridgeLoader>().mockResolvedValue(fake.module as never);
+    const harness = createHarness();
+
+    slackBridgeExtension(harness.pi as never, loader);
+    const command = harness.commands.get("slack-bridge")!.handler;
+    const first = command("on", harness.context) as Promise<void>;
+    const second = command("on", harness.context) as Promise<void>;
+    await vi.waitFor(() => expect(fake.instances).toHaveLength(1));
+    const third = command("on", harness.context) as Promise<void>;
+
+    expect(loader).toHaveBeenCalledTimes(1);
+    expect(fake.instances[0].start).toHaveBeenCalledTimes(1);
+
+    activation.resolve();
+    await Promise.all([first, second, third]);
+    await harness.handlers.get("input")!({ source: "user", text: "hello" }, harness.context);
+
+    expect(fake.instances[0].mirrorUserInput).toHaveBeenCalledWith("hello");
+    expect(harness.notifications).toContainEqual(["Slack bridge conectada para esta sessão.", "info"]);
+  });
+
+  it("retries after a lazy import failure", async () => {
+    const fake = createBridgeModule();
+    const loader = vi
+      .fn<BridgeLoader>()
+      .mockRejectedValueOnce(new Error("import failed"))
+      .mockResolvedValueOnce(fake.module as never);
+    const harness = createHarness();
+
+    slackBridgeExtension(harness.pi as never, loader);
+    const command = harness.commands.get("slack-bridge")!.handler;
+    await command("on", harness.context);
+    await command("on", harness.context);
+
+    expect(loader).toHaveBeenCalledTimes(2);
+    expect(fake.instances).toHaveLength(1);
+    expect(fake.instances[0].start).toHaveBeenCalledTimes(1);
+  });
+
+  it("waits for activation before shutting down", async () => {
+    const activation = deferred<void>();
+    const fake = createBridgeModule(() => activation.promise);
+    const loader = vi.fn<BridgeLoader>().mockResolvedValue(fake.module as never);
+    const harness = createHarness();
+
+    slackBridgeExtension(harness.pi as never, loader);
+    const start = harness.commands.get("slack-bridge")!.handler("on", harness.context) as Promise<void>;
+    await vi.waitFor(() => expect(fake.instances).toHaveLength(1));
+    const shutdown = harness.handlers.get("session_shutdown")!() as Promise<void>;
+
+    expect(fake.instances[0].stop).not.toHaveBeenCalled();
+    activation.resolve();
+    await Promise.all([start, shutdown]);
+
+    expect(fake.instances[0].stop).toHaveBeenCalledTimes(1);
+    expect(harness.statuses.at(-1)).toEqual(["slack-bridge", undefined]);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -276,7 +276,7 @@ importers:
     devDependencies:
       '@earendil-works/pi-coding-agent':
         specifier: 0.79.1
-        version: 0.79.1
+        version: 0.79.1(ws@8.20.0)(zod@4.4.3)
       '@types/node':
         specifier: ^20.10.0
         version: 20.19.39
@@ -540,6 +540,9 @@ importers:
       typescript:
         specifier: ^5.3.0
         version: 5.9.3
+      vitest:
+        specifier: ^3.2.6
+        version: 3.2.6(@types/debug@4.1.13)(@types/node@20.19.39)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)
 
   packages/slack-tracker:
     devDependencies:
@@ -3333,7 +3336,7 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-coding-agent@0.79.1':
+  '@earendil-works/pi-coding-agent@0.79.1(ws@8.20.0)(zod@4.4.3)':
     dependencies:
       '@earendil-works/pi-agent-core': 0.79.6(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-ai': 0.79.6(ws@8.20.0)(zod@4.4.3)
@@ -4202,6 +4205,14 @@ snapshots:
       '@vitest/utils': 3.2.6
       chai: 5.3.3
       tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.6(vite@7.3.6(@types/node@20.19.39)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 3.2.6
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.6(@types/node@20.19.39)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)
 
   '@vitest/mocker@3.2.6(vite@7.3.6(@types/node@22.20.0)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))':
     dependencies:
@@ -5465,6 +5476,27 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vite-node@3.2.4(@types/node@20.19.39)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.6(@types/node@20.19.39)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vite-node@3.2.4(@types/node@22.20.0)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0):
     dependencies:
       cac: 6.7.14
@@ -5486,6 +5518,21 @@ snapshots:
       - tsx
       - yaml
 
+  vite@7.3.6(@types/node@20.19.39)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0):
+    dependencies:
+      esbuild: 0.28.1
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.16
+      rollup: 4.62.2
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 20.19.39
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      tsx: 4.23.0
+      yaml: 2.9.0
+
   vite@7.3.6(@types/node@22.20.0)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.28.1
@@ -5500,6 +5547,48 @@ snapshots:
       jiti: 2.7.0
       tsx: 4.23.0
       yaml: 2.9.0
+
+  vitest@3.2.6(@types/debug@4.1.13)(@types/node@20.19.39)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.6
+      '@vitest/mocker': 3.2.6(vite@7.3.6(@types/node@20.19.39)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 3.2.6
+      '@vitest/runner': 3.2.6
+      '@vitest/snapshot': 3.2.6
+      '@vitest/spy': 3.2.6
+      '@vitest/utils': 3.2.6
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.16
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.6(@types/node@20.19.39)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)
+      vite-node: 3.2.4(@types/node@20.19.39)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.13
+      '@types/node': 20.19.39
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   vitest@3.2.6(@types/debug@4.1.13)(@types/node@22.20.0)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0):
     dependencies:


### PR DESCRIPTION
## Summary
- lazy-load the Slack bridge implementation on first `/slack-bridge on`
- share concurrent activation and reset failed module loads for retry
- defer `sharp` until a codeshot is actually rendered
- add lifecycle tests for registration, configuration, concurrent starts, retry, and shutdown

## Why
Slack SDKs and `sharp` were loaded during every Pi startup even when the bridge was disabled. Profiling showed that moving the implementation behind the activation command saves about 78 ms in the complete extension stack.

## Validation
- `pnpm --filter @arvoretech/pi-slack-bridge test` (5 tests)
- `pnpm --filter @arvoretech/pi-slack-bridge build`
- inspected emitted JavaScript for dynamic `bridge.js` and `sharp` imports
- fresh Pi RPC load from `dist/index.js`
- executed `/slack-bridge status` with no configuration and confirmed immediate registration without a Slack connection
