### PR TITLE
Defer questionnaire i18n initialization

### DIFF
--- a/packages/ask-user-question/ask-user-question.ts
+++ b/packages/ask-user-question/ask-user-question.ts
@@ -7,7 +7,7 @@ import {
 	type AskUserPromptEventPayload,
 } from "./events.js";
 import { externalAnswerToResult } from "./tool/external-answer.js";
-import { displayLabel } from "./state/i18n-bridge.js";
+import { displayLabel, initializeI18n } from "./state/i18n-bridge.js";
 import { sentinelsToAppend } from "./state/row-intent.js";
 import { buildQuestionnaireResponse, buildToolResult } from "./tool/response-envelope.js";
 import {
@@ -102,6 +102,8 @@ Preview content is rendered as markdown in a monospace box. Multi-line text with
 					error: validation.error,
 				});
 			}
+
+			await initializeI18n();
 
 			// Emit event for external listeners (e.g., Slack bridge). The promptId
 			// correlates an external answer back to this specific invocation.

--- a/packages/ask-user-question/index.ts
+++ b/packages/ask-user-question/index.ts
@@ -1,42 +1,5 @@
-/**
- * rpiv-ask-user-question — Pi extension. Registers the `ask_user_question`
- * tool: a structured option selector with a free-text "Other" fallback.
- *
- * Sentinel labels and TUI chrome strings localize at render time via the i18n
- * bridge. Strings are registered with rpiv-i18n here, once, at module init —
- * but only when the SDK is actually installed. If `@juicesharp/rpiv-i18n` is
- * missing (standalone install of just this package), the dynamic-load shim
- * no-ops and the bridge's `t(key, fallback)` returns the inline English literal
- * at every call site. The extension stays online either way.
- *
- * Adding a locale: drop `locales/<code>.json` next to en.json (mirroring the
- * key set). No edit needed here — `registerLocalesFromDir` iterates
- * `SUPPORTED_LOCALES` from the SDK. See `@juicesharp/rpiv-i18n` README →
- * "Contributing translations" for the full convention.
- */
-
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { registerAskUserQuestionTool } from "./ask-user-question.js";
-import { I18N_NAMESPACE } from "./state/i18n-bridge.js";
-
-type I18nLoader = {
-	registerLocalesFromDir: (namespace: string, packageUrl: string, options?: { label?: string }) => void;
-};
-
-// Dynamic import keeps `@juicesharp/rpiv-i18n` a soft optional peer: when the
-// SDK is installed alongside this package the strings register and
-// `/languages` flips them live; when it isn't, the import rejects here, we
-// no-op, and the bridge's English-fallback shim keeps the extension online.
-//
-// The `/loader` subpath is used instead of the SDK entry so the i18n-ui +
-// pi-tui modules are not pulled into our load graph just to register strings.
-try {
-	const i18nModule = "@juicesharp/rpiv-i18n/loader";
-	const sdk = (await import(i18nModule)) as I18nLoader;
-	sdk.registerLocalesFromDir(I18N_NAMESPACE, import.meta.url, { label: "rpiv-ask-user-question" });
-} catch {
-	// SDK absent — extension still loads with English-only UI.
-}
 
 export {
 	ASK_USER_PROMPT_EVENT,

--- a/packages/ask-user-question/package.json
+++ b/packages/ask-user-question/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-ask-user-question",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "PI extension. A structured questionnaire the model can put to the user, answerable from the terminal overlay OR externally (e.g. Slack buttons) via an event channel. Fork of @juicesharp/rpiv-ask-user-question (MIT) with an external-answer race.",
   "type": "module",
   "exports": {

--- a/packages/ask-user-question/package.json
+++ b/packages/ask-user-question/package.json
@@ -10,7 +10,8 @@
   "license": "MIT",
   "author": "Arvore",
   "scripts": {
-    "lint": "tsc --noEmit"
+    "lint": "tsc --noEmit",
+    "test": "vitest run"
   },
   "files": [
     "ask-user-question.ts",
@@ -39,7 +40,8 @@
     "@earendil-works/pi-tui": "latest",
     "@types/node": "^20.10.0",
     "typebox": "^1.2.6",
-    "typescript": "^5.3.0"
+    "typescript": "^5.3.0",
+    "vitest": "^3.2.6"
   },
   "keywords": [
     "pi-package",

--- a/packages/ask-user-question/state/i18n-bridge.ts
+++ b/packages/ask-user-question/state/i18n-bridge.ts
@@ -12,9 +12,7 @@
  *   with the canonical English `ROW_INTENT_META[kind].label` as fallback so
  *   nothing renders blank if the namespace isn't registered.
  *
- * Strings are registered ONCE at extension load (see ../index.ts). Call sites
- * MUST use this module at render time — never bake the result into a top-level
- * `const X = displayLabel(...)`.
+ * Call sites resolve strings at render time so live locale changes propagate.
  *
  * Reserved-label validation stays English-locked: `RESERVED_LABEL_SET` checks
  * the canonical `ROW_INTENT_META[kind].label`, never `displayLabel(kind)`.
@@ -26,26 +24,46 @@ export const I18N_NAMESPACE = "@juicesharp/rpiv-ask-user-question";
 
 type ScopeFn = (key: string, fallback: string) => string;
 type I18nSDK = { scope: (namespace: string) => ScopeFn };
+type I18nLoader = {
+	registerLocalesFromDir: (namespace: string, packageUrl: string, options?: { label?: string }) => void;
+};
 
-// Prefer the live SDK if installed: closures it returns track the active
-// locale, so /languages picker propagates to our render call sites. If the
-// SDK isn't installed (standalone install of this extension without
-// rpiv-i18n), the dynamic import fails, every t(key, fallback) returns the
-// canonical English literal, and the extension stays online.
-//
-// Top-level await is required so a synchronous `t(...)` call from any
-// downstream module sees the resolved scope; ESM module loading awaits this
-// before evaluating any importer.
-let scopeImpl: ScopeFn;
-try {
-	const i18nModule = "@juicesharp/rpiv-i18n";
-	const sdk = (await import(i18nModule)) as I18nSDK;
-	scopeImpl = sdk.scope(I18N_NAMESPACE);
-} catch {
-	scopeImpl = (_key, fallback) => fallback;
+export interface I18nDependencies {
+	loadSdk: () => Promise<I18nSDK>;
+	loadLoader: () => Promise<I18nLoader>;
 }
 
-export const t: ScopeFn = scopeImpl;
+const sdkModule = "@juicesharp/rpiv-i18n";
+const loaderModule = "@juicesharp/rpiv-i18n/loader";
+const defaultDependencies: I18nDependencies = {
+	loadSdk: () => import(sdkModule) as Promise<I18nSDK>,
+	loadLoader: () => import(loaderModule) as Promise<I18nLoader>,
+};
+
+let scopeImpl: ScopeFn = (_key, fallback) => fallback;
+let initialization: Promise<void> | undefined;
+
+export function initializeI18n(dependencies: I18nDependencies = defaultDependencies): Promise<void> {
+	initialization ??= Promise.all([
+		dependencies
+			.loadSdk()
+			.then((sdk) => {
+				scopeImpl = sdk.scope(I18N_NAMESPACE);
+			})
+			.catch(() => {}),
+		dependencies
+			.loadLoader()
+			.then((loader) => {
+				loader.registerLocalesFromDir(I18N_NAMESPACE, new URL("../index.ts", import.meta.url).href, {
+					label: "rpiv-ask-user-question",
+				});
+			})
+			.catch(() => {}),
+	]).then(() => {});
+	return initialization;
+}
+
+export const t: ScopeFn = (key, fallback) => scopeImpl(key, fallback);
 
 export function displayLabel(kind: SentinelKind): string {
 	return t(`sentinel.${kind}`, ROW_INTENT_META[kind].label);

--- a/packages/ask-user-question/test/i18n.test.ts
+++ b/packages/ask-user-question/test/i18n.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+
+describe("i18n bridge", () => {
+	beforeEach(() => {
+		vi.resetModules();
+	});
+
+	it("uses English fallback before initialization and when the SDK is absent", async () => {
+		const { displayLabel, initializeI18n } = await import("../state/i18n-bridge.js");
+		const dependencies = {
+			loadSdk: vi.fn().mockRejectedValue(new Error("missing")),
+			loadLoader: vi.fn().mockRejectedValue(new Error("missing")),
+		};
+
+		expect(displayLabel("other")).toBe("Type something.");
+		await initializeI18n(dependencies);
+		expect(displayLabel("other")).toBe("Type something.");
+	});
+
+	it("shares initialization and keeps locale changes live", async () => {
+		const { displayLabel, initializeI18n, I18N_NAMESPACE } = await import("../state/i18n-bridge.js");
+		let locale = "pt";
+		const registerLocalesFromDir = vi.fn();
+		const dependencies = {
+			loadSdk: vi.fn().mockResolvedValue({
+				scope: vi.fn().mockReturnValue((_key: string, fallback: string) =>
+					locale === "pt" ? "Digite algo." : fallback,
+				),
+			}),
+			loadLoader: vi.fn().mockResolvedValue({ registerLocalesFromDir }),
+		};
+
+		await Promise.all([initializeI18n(dependencies), initializeI18n(dependencies)]);
+
+		expect(dependencies.loadSdk).toHaveBeenCalledTimes(1);
+		expect(dependencies.loadLoader).toHaveBeenCalledTimes(1);
+		expect(registerLocalesFromDir).toHaveBeenCalledWith(
+			I18N_NAMESPACE,
+			expect.stringContaining("/index.ts"),
+			{ label: "rpiv-ask-user-question" },
+		);
+		expect(displayLabel("other")).toBe("Digite algo.");
+
+		locale = "en";
+		expect(displayLabel("other")).toBe("Type something.");
+	});
+});

--- a/packages/ask-user-question/test/interactive-i18n.test.ts
+++ b/packages/ask-user-question/test/interactive-i18n.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const validQuestion = {
+	question: "Which option?",
+	header: "Choice",
+	options: [
+		{ label: "First", description: "Use the first option" },
+		{ label: "Second", description: "Use the second option" },
+	],
+};
+
+const i18nMock = vi.hoisted(() => ({
+	initializeI18n: vi.fn<() => Promise<void>>(),
+}));
+
+vi.mock("../state/i18n-bridge.js", async (importOriginal) => {
+	const original = await importOriginal<typeof import("../state/i18n-bridge.js")>();
+	return { ...original, initializeI18n: i18nMock.initializeI18n };
+});
+
+vi.mock("../state/questionnaire-session.js", () => ({
+	QuestionnaireSession: class {
+		component = {};
+	},
+}));
+
+describe("interactive initialization", () => {
+	beforeEach(() => {
+		i18nMock.initializeI18n.mockReset().mockResolvedValue();
+	});
+
+	it("registers the tool synchronously without initializing i18n", async () => {
+		const { default: extension } = await import("../index.js");
+		const registerTool = vi.fn();
+
+		extension({ registerTool } as never);
+
+		expect(registerTool).toHaveBeenCalledTimes(1);
+		expect(i18nMock.initializeI18n).not.toHaveBeenCalled();
+	});
+
+	async function createTool() {
+		const { registerAskUserQuestionTool } = await import("../ask-user-question.js");
+		let tool: any;
+		const answerListeners: Array<(payload: unknown) => void> = [];
+		const pi = {
+			registerTool: (registered: unknown) => {
+				tool = registered;
+			},
+			events: {
+				emit: vi.fn(),
+				on: vi.fn((_event: string, listener: (payload: unknown) => void) => {
+					answerListeners.push(listener);
+					return vi.fn();
+				}),
+			},
+		};
+		registerAskUserQuestionTool(pi as never);
+		return { answerListeners, pi, tool };
+	}
+
+	it("keeps no-UI and invalid executions cold", async () => {
+		const { tool } = await createTool();
+
+		await tool.execute("call", { questions: [validQuestion] }, undefined, undefined, { hasUI: false });
+		await tool.execute("call", { questions: [] }, undefined, undefined, { hasUI: true });
+
+		expect(i18nMock.initializeI18n).not.toHaveBeenCalled();
+	});
+
+	it("awaits initialization before exposing the interactive prompt", async () => {
+		let finishInitialization!: () => void;
+		i18nMock.initializeI18n.mockReturnValue(
+			new Promise<void>((resolve) => {
+				finishInitialization = resolve;
+			}),
+		);
+		const { answerListeners, pi, tool } = await createTool();
+		const custom = vi.fn(() => new Promise(() => {}));
+		const execution = tool.execute("call", { questions: [validQuestion] }, undefined, undefined, {
+			hasUI: true,
+			ui: { custom },
+		});
+
+		await Promise.resolve();
+		expect(pi.events.emit).not.toHaveBeenCalled();
+		expect(custom).not.toHaveBeenCalled();
+
+		finishInitialization();
+		await vi.waitFor(() => expect(pi.events.emit).toHaveBeenCalledTimes(1));
+		const [, prompt] = pi.events.emit.mock.calls[0];
+		await vi.waitFor(() => expect(answerListeners).toHaveLength(1));
+		answerListeners[0]({
+			promptId: prompt.promptId,
+			answers: [{ questionIndex: 0, label: "First" }],
+		});
+
+		await expect(execution).resolves.toBeDefined();
+		expect(i18nMock.initializeI18n).toHaveBeenCalledTimes(1);
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       typescript:
         specifier: ^5.3.0
         version: 5.9.3
+      vitest:
+        specifier: ^3.2.6
+        version: 3.2.6(@types/debug@4.1.13)(@types/node@20.19.39)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)
 
   packages/bee-context:
     devDependencies:
@@ -4203,6 +4206,14 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
+  '@vitest/mocker@3.2.6(vite@7.3.6(@types/node@20.19.39)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 3.2.6
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.6(@types/node@20.19.39)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)
+
   '@vitest/mocker@3.2.6(vite@7.3.6(@types/node@22.20.0)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 3.2.6
@@ -5465,6 +5476,27 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vite-node@3.2.4(@types/node@20.19.39)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.6(@types/node@20.19.39)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vite-node@3.2.4(@types/node@22.20.0)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0):
     dependencies:
       cac: 6.7.14
@@ -5486,6 +5518,21 @@ snapshots:
       - tsx
       - yaml
 
+  vite@7.3.6(@types/node@20.19.39)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0):
+    dependencies:
+      esbuild: 0.28.1
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.16
+      rollup: 4.62.2
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 20.19.39
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      tsx: 4.23.0
+      yaml: 2.9.0
+
   vite@7.3.6(@types/node@22.20.0)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.28.1
@@ -5500,6 +5547,48 @@ snapshots:
       jiti: 2.7.0
       tsx: 4.23.0
       yaml: 2.9.0
+
+  vitest@3.2.6(@types/debug@4.1.13)(@types/node@20.19.39)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.6
+      '@vitest/mocker': 3.2.6(vite@7.3.6(@types/node@20.19.39)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 3.2.6
+      '@vitest/runner': 3.2.6
+      '@vitest/snapshot': 3.2.6
+      '@vitest/spy': 3.2.6
+      '@vitest/utils': 3.2.6
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.16
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.6(@types/node@20.19.39)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)
+      vite-node: 3.2.4(@types/node@20.19.39)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.13
+      '@types/node': 20.19.39
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   vitest@3.2.6(@types/debug@4.1.13)(@types/node@22.20.0)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0):
     dependencies:


### PR DESCRIPTION
## Summary
- defer optional i18n SDK and locale registration until the first valid interactive questionnaire
- keep synchronous English fallback before initialization and when the optional SDK is absent
- memoize concurrent initialization while preserving live locale changes
- add tests for registration, fallback, optional SDK absence, memoization, interactive ordering, and no-UI behavior

## Why
The questionnaire loaded optional i18n modules during every Pi startup even when the tool was never used. Deferring initialization removes that startup work while preserving immediate tool registration and localized interactive rendering.

## Validation
- `pnpm --filter @arvoretech/pi-ask-user-question test` (5 tests)
- confirmed the startup import graph has no top-level await
- `pnpm pack` tarball inspection
- clean temporary installation from the tarball
- fresh Pi RPC load through the package's public `index.ts` export

## Note
LSP diagnostics were unavailable for this package in the current environment. Vitest transpilation and the fresh Pi runtime load were used as the available TypeScript/runtime checks.
