### PR TITLE
feat(secret-firewall): custom token patterns via config

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Monorepo for custom PI extensions used across Arvore projects.
 | `@arvoretech/pi-memory` | Cloud-based memory with RAG (Qdrant + GitHub OAuth) |
 | `@arvoretech/pi-monitor` | Watches a background process and pushes matching output lines to the agent as notifications (no polling) |
 | `@arvoretech/pi-recap` | Drafts a one-line recap of where you left off — on demand with `/recap` and automatically when you return to an idle session |
+| `@arvoretech/pi-secret-firewall` | Keeps secret values out of the model context, exposing them only as `$SECRET_*` shell env vars; supports custom token patterns via config |
 | `@arvoretech/pi-warp-tab-title` | Renames Warp terminal tab to reflect current task focus |
 | `@arvoretech/pi-worktree` | Manages git worktrees across multi-repo workspaces with tree-themed names |
 

--- a/packages/secret-firewall/README.md
+++ b/packages/secret-firewall/README.md
@@ -43,6 +43,36 @@ model sees `... read it in bash as "$SECRET_JWT"` and can use it via
 `curl -H "Authorization: Bearer $SECRET_JWT"` without ever seeing the value.
 Captured names show up under `/secret-firewall` status.
 
+### Custom patterns
+
+The built-in pattern list can be extended with your own regexes via a JSON
+config file, so internal or vendor-specific token shapes are also caught and
+auto-exported. Config is read from, in order of precedence (both are merged;
+global first, then project):
+
+- `~/.pi/agent/secret-firewall.json` — global, applies to every project.
+- `<cwd>/.pi/secret-firewall.json` — project-local.
+
+```json
+{
+  "patterns": [
+    { "name": "ACME", "regex": "acme-[0-9a-f]{12}" },
+    { "name": "INTERNAL_TOKEN", "regex": "int_[A-Za-z0-9]{24}", "flags": "i" }
+  ]
+}
+```
+
+- `name` — used to build the exported shell var (`$SECRET_ACME`,
+  `$SECRET_ACME_2` for a second distinct match). Sanitized to `[A-Za-z0-9_]`.
+- `regex` — the pattern to match. The `g` flag is always applied.
+- `flags` — optional extra RegExp flags (e.g. `i`).
+
+Invalid regexes and malformed entries are skipped silently rather than crashing
+the firewall. Custom patterns behave exactly like the built-in ones: matches are
+masked, captured, and exported to the shell. Keep patterns specific — a
+too-broad regex will redact large chunks of normal output and degrade the agent,
+and a pathological regex runs on every tool result (ReDoS risk).
+
 ### Standing guidance in the system prompt
 
 A `before_agent_start` hook appends a short section to the system prompt every

--- a/packages/secret-firewall/package.json
+++ b/packages/secret-firewall/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-secret-firewall",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Redacts secrets (env vars, .env files, token patterns) from the model context and tool outputs, exposing them only as $SECRET_* shell env vars the model can reference but never read",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/secret-firewall/src/index.ts
+++ b/packages/secret-firewall/src/index.ts
@@ -1,6 +1,6 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { TextContent, ImageContent } from "@earendil-works/pi-ai";
-import { discoverSecrets, type SecretEntry } from "./secrets.js";
+import { discoverSecrets, loadCustomPatterns, type SecretEntry } from "./secrets.js";
 import { createRedactor } from "./redact.js";
 
 type ContentBlock = TextContent | ImageContent;
@@ -27,6 +27,7 @@ export default function (pi: ExtensionAPI) {
 
   function rescan(cwd: string): void {
     entries = discoverSecrets(cwd);
+    redactor.refreshPatterns(loadCustomPatterns(cwd));
     redactor.refresh(entries);
     exportToShell(entries);
     stats.lastScan = entries.length;

--- a/packages/secret-firewall/src/redact.ts
+++ b/packages/secret-firewall/src/redact.ts
@@ -6,9 +6,16 @@ export interface DynamicSecret {
   value: string;
 }
 
+export interface CustomPattern {
+  name: string;
+  regex: string;
+  flags?: string;
+}
+
 export interface Redactor {
   redactString(text: string): { text: string; hits: number };
   refresh(entries: SecretEntry[]): void;
+  refreshPatterns(patterns: CustomPattern[]): void;
   drainCaptured(): DynamicSecret[];
   knownPlaceholders(): string[];
 }
@@ -35,8 +42,34 @@ function escapeRe(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-export function createRedactor(initial: SecretEntry[]): Redactor {
+function sanitizePatternName(raw: string): string {
+  const cleaned = String(raw ?? "")
+    .replace(/[^A-Za-z0-9_]/g, "_")
+    .replace(/^_+|_+$/g, "");
+  return cleaned || "CUSTOM";
+}
+
+function compileCustomPatterns(patterns: CustomPattern[]): PatternRule[] {
+  const rules: PatternRule[] = [];
+  for (const p of patterns) {
+    if (!p || typeof p.regex !== "string" || p.regex.length === 0) continue;
+    let flags = typeof p.flags === "string" ? p.flags : "";
+    if (!flags.includes("g")) flags += "g";
+    try {
+      rules.push({ name: sanitizePatternName(p.name), re: new RegExp(p.regex, flags) });
+    } catch {
+      /* invalid regex, skip */
+    }
+  }
+  return rules;
+}
+
+export function createRedactor(
+  initial: SecretEntry[],
+  customPatterns: CustomPattern[] = [],
+): Redactor {
   let valueRules: { re: RegExp; placeholder: string }[] = [];
+  let patternRules: PatternRule[] = [...PATTERN_RULES, ...compileCustomPatterns(customPatterns)];
 
   const captured = new Map<string, DynamicSecret>();
   const takenNames = new Set<string>();
@@ -47,6 +80,10 @@ export function createRedactor(initial: SecretEntry[]): Redactor {
       .filter((e) => e.value.length > 0)
       .map((e) => ({ re: new RegExp(escapeRe(e.value), "g"), placeholder: e.placeholder }));
     for (const e of entries) takenNames.add(e.name);
+  }
+
+  function refreshPatterns(patterns: CustomPattern[]): void {
+    patternRules = [...PATTERN_RULES, ...compileCustomPatterns(patterns)];
   }
 
   function allocateName(patternName: string): string {
@@ -84,7 +121,7 @@ export function createRedactor(initial: SecretEntry[]): Redactor {
         return placeholder;
       });
     }
-    for (const { name, re } of PATTERN_RULES) {
+    for (const { name, re } of patternRules) {
       out = out.replace(re, (match) => {
         hits++;
         return capture(name, match);
@@ -105,5 +142,5 @@ export function createRedactor(initial: SecretEntry[]): Redactor {
   }
 
   refresh(initial);
-  return { redactString, refresh, drainCaptured, knownPlaceholders };
+  return { redactString, refresh, refreshPatterns, drainCaptured, knownPlaceholders };
 }

--- a/packages/secret-firewall/src/secrets.ts
+++ b/packages/secret-firewall/src/secrets.ts
@@ -1,11 +1,22 @@
 import { readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
+import { homedir } from "node:os";
 
 export interface SecretEntry {
   name: string;
   placeholder: string;
   value: string;
   source: "env" | "dotenv" | "pattern";
+}
+
+export interface CustomPatternConfig {
+  name: string;
+  regex: string;
+  flags?: string;
+}
+
+export interface FirewallConfig {
+  patterns: CustomPatternConfig[];
 }
 
 const SENSITIVE_NAME = /(SECRET|TOKEN|PASSWORD|PASSWD|PWD|API[_-]?KEY|APIKEY|ACCESS[_-]?KEY|PRIVATE[_-]?KEY|CLIENT[_-]?SECRET|AUTH|CREDENTIAL|DSN|DATABASE_URL|CONNECTION_STRING|SESSION|COOKIE|SIGNING|ENCRYPT|SALT|BEARER)/i;
@@ -66,6 +77,43 @@ function parseDotenv(path: string): Map<string, string> {
     /* unreadable file, skip */
   }
   return out;
+}
+
+const CONFIG_FILENAME = "secret-firewall.json";
+
+function configPaths(cwd: string): string[] {
+  return [join(homedir(), ".pi", "agent", CONFIG_FILENAME), join(cwd, ".pi", CONFIG_FILENAME)];
+}
+
+function parsePatterns(raw: unknown): CustomPatternConfig[] {
+  if (!raw || typeof raw !== "object") return [];
+  const list = (raw as Record<string, unknown>).patterns;
+  if (!Array.isArray(list)) return [];
+  const out: CustomPatternConfig[] = [];
+  for (const item of list) {
+    if (!item || typeof item !== "object") continue;
+    const p = item as Record<string, unknown>;
+    if (typeof p.regex !== "string" || p.regex.length === 0) continue;
+    out.push({
+      name: typeof p.name === "string" && p.name.length > 0 ? p.name : "CUSTOM",
+      regex: p.regex,
+      flags: typeof p.flags === "string" ? p.flags : undefined,
+    });
+  }
+  return out;
+}
+
+export function loadCustomPatterns(cwd: string): CustomPatternConfig[] {
+  const merged: CustomPatternConfig[] = [];
+  for (const path of configPaths(cwd)) {
+    if (!existsSync(path)) continue;
+    try {
+      merged.push(...parsePatterns(JSON.parse(readFileSync(path, "utf8"))));
+    } catch {
+      /* unreadable or invalid JSON, skip */
+    }
+  }
+  return merged;
 }
 
 export function discoverSecrets(cwd: string): SecretEntry[] {

--- a/packages/secret-firewall/test/smoke.test.ts
+++ b/packages/secret-firewall/test/smoke.test.ts
@@ -1,9 +1,9 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { discoverSecrets } from "../dist/secrets.js";
+import { discoverSecrets, loadCustomPatterns } from "../dist/secrets.js";
 import { createRedactor } from "../dist/redact.js";
 
 function fakeJwt(seed: string): string {
@@ -117,4 +117,48 @@ test("distinct pattern matches get distinct placeholders", () => {
   assert.ok(out.text.includes('"$SECRET_JWT_2"'));
   const captured = r.drainCaptured();
   assert.equal(captured.length, 2);
+});
+
+test("loads custom patterns from .pi/secret-firewall.json", () => {
+  const dir = mkdtempSync(join(tmpdir(), "sf-test-"));
+  try {
+    mkdirSync(join(dir, ".pi"));
+    writeFileSync(
+      join(dir, ".pi", "secret-firewall.json"),
+      JSON.stringify({ patterns: [{ name: "ACME", regex: "acme-[0-9a-f]{12}" }] }),
+    );
+    const patterns = loadCustomPatterns(dir);
+    assert.equal(patterns.length, 1);
+    assert.equal(patterns[0].name, "ACME");
+    assert.equal(patterns[0].regex, "acme-[0-9a-f]{12}");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("redactor catches and captures custom pattern matches", () => {
+  const r = createRedactor([], [{ name: "ACME", regex: "acme-[0-9a-f]{12}" }]);
+  const token = "acme-0123456789ab";
+  const out = r.redactString(`token is ${token} ok`);
+  assert.ok(!out.text.includes(token));
+  assert.ok(out.text.includes('"$SECRET_ACME"'));
+  const captured = r.drainCaptured();
+  assert.equal(captured.length, 1);
+  assert.equal(captured[0].name, "SECRET_ACME");
+  assert.equal(captured[0].value, token);
+});
+
+test("custom patterns are forced to global and coexist with defaults", () => {
+  const r = createRedactor([], [{ name: "ACME", regex: "acme-[0-9a-f]{12}", flags: "i" }]);
+  const out = r.redactString("acme-aaaaaaaaaaaa and acme-bbbbbbbbbbbb");
+  assert.ok(out.text.includes('"$SECRET_ACME"'));
+  assert.ok(out.text.includes('"$SECRET_ACME_2"'));
+  assert.equal(r.drainCaptured().length, 2);
+});
+
+test("invalid custom regex is skipped without throwing", () => {
+  const r = createRedactor([], [{ name: "BAD", regex: "([" }]);
+  const out = r.redactString("nothing to redact here");
+  assert.equal(out.hits, 0);
+  assert.equal(out.text, "nothing to redact here");
 });


### PR DESCRIPTION
## Summary

Adds support for user-defined token patterns to `@arvoretech/pi-secret-firewall`, extending the built-in pattern detection (AWS keys, JWTs, `sk-...`, GitHub/Slack tokens, PEM keys) so internal and vendor-specific token shapes are also caught, masked, and auto-exported to the shell.

Closes #151.

## Config

Read and merged from two locations (global first, then project — both optional):

- `~/.pi/agent/secret-firewall.json` — global, applies to every project
- `<cwd>/.pi/secret-firewall.json` — project-local

```json
{
  "patterns": [
    { "name": "ACME_TOKEN", "regex": "acme-[0-9a-f]{16}" },
    { "name": "INTERNAL", "regex": "int_[A-Za-z0-9]{24}", "flags": "i" }
  ]
}
```

- `name` → shell var (`$SECRET_ACME_TOKEN`, `$SECRET_ACME_TOKEN_2` for a second distinct match); sanitized to `[A-Za-z0-9_]`.
- `regex` → matched pattern; the `g` flag is always applied.
- `flags` → optional extra RegExp flags.

Custom patterns share the exact capture/auto-export path as the built-ins, so matches become usable via `$SECRET_*` without the model ever seeing the value.

## Guardrails

- Invalid regexes and malformed entries are skipped silently — the firewall never crashes on bad config.
- `g` flag forced so `String.replace` iterates.
- Pattern name sanitized + collision-safe.
- README documents the ReDoS / over-broad-regex caveat (patterns run on every tool result).
- `/secret-firewall-rescan` reloads config live.

## Tested

- 4 new unit tests (config loading, capture/export, multi-match naming, invalid-regex safety); all 13 tests pass.
- Manually verified end-to-end: a token matching a custom `.pi/secret-firewall.json` pattern is redacted to `$SECRET_ACME_TOKEN` in the live session.

Version bumped to 0.4.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for custom secret-detection patterns through `secret-firewall.json` configuration files.
  - Custom matches are masked and exposed through `$SECRET_*` placeholders, alongside built-in detections.
  - Supports global and project-level configuration, merged automatically.
  - Invalid configurations and patterns are safely ignored.

- **Documentation**
  - Added setup guidance, pattern behavior details, and warnings about overly broad or inefficient expressions.
  - Listed the secret firewall extension in the package overview.

- **Chores**
  - Updated the extension version to 0.4.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->