### PR TITLE
feat(kiro-provider): add Claude Opus 5

### DIFF
--- a/packages/kiro-provider/package.json
+++ b/packages/kiro-provider/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@arvoretech/pi-kiro-provider",
-	"version": "0.8.4",
+	"version": "0.8.5",
 	"description": "Pi extension for the Kiro API, maintained by Arvore",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/kiro-provider/src/models.ts
+++ b/packages/kiro-provider/src/models.ts
@@ -8,6 +8,7 @@ const CACHE_PATH = join(homedir(), ".kiro-models-cache.json");
 
 // Valid Kiro model IDs - API accepts friendly names directly
 export const KIRO_MODEL_IDS = new Set([
+	"claude-opus-5",
 	"claude-opus-4.8",
 	"claude-opus-4.7",
 	"claude-opus-4.6",
@@ -231,6 +232,7 @@ export function resolveApiRegion(ssoRegion: string | undefined): string {
  */
 const MODELS_BY_REGION: Record<string, Set<string>> = {
 	"us-east-1": new Set([
+		"claude-opus-5",
 		"claude-opus-4-8",
 		"claude-opus-4-7",
 		"claude-opus-4-6",
@@ -252,6 +254,7 @@ const MODELS_BY_REGION: Record<string, Set<string>> = {
 	]),
 	// API-verified 2026-04-14 (eu-west-1 IdC token), glm-5 removed 2026-05-05 (us-east-1 only)
 	"eu-central-1": new Set([
+		"claude-opus-5",
 		"claude-opus-4-8",
 		"claude-opus-4-7",
 		"claude-opus-4-6",
@@ -295,6 +298,20 @@ const ZERO_COST = Object.freeze({
 });
 
 export const kiroModels = [
+	{
+		id: "claude-opus-5",
+		name: "Claude Opus 5",
+		api: "kiro-api" as const,
+		provider: "kiro" as const,
+		baseUrl: BASE_URL,
+		reasoning: true,
+		thinkingLevelMap: { xhigh: "xhigh" },
+		input: ["text", "image"] as ("text" | "image")[],
+		cost: ZERO_COST,
+		contextWindow: 1000000,
+		maxTokens: 128000,
+		firstTokenTimeout: 180_000,
+	},
 	{
 		id: "claude-opus-4-8",
 		name: "Claude Opus 4.8",

--- a/packages/kiro-provider/test/models.test.ts
+++ b/packages/kiro-provider/test/models.test.ts
@@ -11,6 +11,7 @@ describe("Feature 2: Model Definitions", () => {
 	describe("resolveKiroModel", () => {
 		it.each([
 			// Claude models - dash to dot conversion
+			["claude-opus-5", "claude-opus-5"],
 			["claude-opus-4-8", "claude-opus-4.8"],
 			["claude-opus-4-7", "claude-opus-4.7"],
 			["claude-opus-4-6", "claude-opus-4.6"],
@@ -40,8 +41,8 @@ describe("Feature 2: Model Definitions", () => {
 	});
 
 	describe("KIRO_MODEL_IDS", () => {
-		it("contains 18 model IDs", () => {
-			expect(KIRO_MODEL_IDS.size).toBe(18);
+		it("contains 19 model IDs", () => {
+			expect(KIRO_MODEL_IDS.size).toBe(19);
 		});
 	});
 
@@ -91,8 +92,8 @@ describe("Feature 2: Model Definitions", () => {
 	});
 
 	describe("model catalog", () => {
-		it("defines 18 models", () => {
-			expect(kiroModels).toHaveLength(18);
+		it("defines 19 models", () => {
+			expect(kiroModels).toHaveLength(19);
 		});
 
 		it("claude-haiku-4-5 has reasoning=false", () => {
@@ -194,6 +195,7 @@ describe("Feature 2: Model Definitions", () => {
 		}
 
 		const EXTENDED_MODELS = [
+			"claude-opus-5",
 			"claude-opus-4-8",
 			"claude-opus-4-7",
 			"claude-opus-4-6",

--- a/packages/kiro-provider/test/registration.test.ts
+++ b/packages/kiro-provider/test/registration.test.ts
@@ -26,13 +26,13 @@ describe("Feature 1: Extension Registration", () => {
 		expect(registerProvider.mock.calls[0][0]).toBe("kiro");
 	});
 
-	it("registers 14 models", async () => {
+	it("registers 19 models", async () => {
 		const mod = await import("../src/index.js");
 		const { pi, registerProvider } = mockPi();
 		mod.default(pi);
 
 		const config = registerProvider.mock.calls[0][1];
-		expect(config.models).toHaveLength(18);
+		expect(config.models).toHaveLength(19);
 	});
 
 	it("registers OAuth with name 'Kiro (Builder ID / Google / GitHub)'", async () => {


### PR DESCRIPTION
## Summary
Adiciona suporte ao **Claude Opus 5** no kiro provider, seguindo o mesmo padrão dos demais modelos Claude Opus.

## Changes
- `src/models.ts`:
  - Novo modelo `claude-opus-5` no catálogo `kiroModels` (reasoning, `thinkingLevelMap: { xhigh }`, input text+image, contextWindow 1M, maxTokens 128000, firstTokenTimeout 180s — idêntico ao Opus 4.8)
  - Registrado em `KIRO_MODEL_IDS`
  - Adicionado às regiões `us-east-1` e `eu-central-1` em `MODELS_BY_REGION`
- `test/models.test.ts`: contagem 18 → 19, mapeamento de resolução e lista de thinking estendido atualizados
- `package.json`: bump 0.8.4 → 0.8.5

## Tested
- `vitest run test/models.test.ts` → 39 passed
- `tsc` build limpo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Claude Opus 5 model.
  * Claude Opus 5 is available in supported regions and includes extended thinking capabilities.

* **Bug Fixes**
  * Updated model availability and catalog validation to accurately include the new model.

* **Chores**
  * Bumped the Kiro provider version to 0.8.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->