### PR TITLE
feat: pi-scheduler package + fix pi-memory stale ctx crash

### DIFF
--- a/packages/pi-memory/package.json
+++ b/packages/pi-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arvoretech/pi-memory",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "PI extension for cloud-based memory with RAG (Qdrant + GitHub OAuth)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/pi-memory/src/index.ts
+++ b/packages/pi-memory/src/index.ts
@@ -2,7 +2,7 @@ import { execFile } from "node:child_process";
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
 import { randomUUID } from "node:crypto";
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { clearCredentials, getCredentials, saveCredentials } from "./auth.js";
 import { getConfig } from "./config.js";
 import { registerMemoryTools } from "./tools.js";
@@ -47,6 +47,20 @@ let sessionId = "";
 let lastFlushedTurn = -1;
 let flushTimer: ReturnType<typeof setTimeout> | null = null;
 let lastSearchResults: SearchResult[] = [];
+
+function isStaleCtxError(error: unknown): boolean {
+  return /stale after session replacement/.test(String(error));
+}
+
+function staleSafeSetStatus(ctx: ExtensionContext): (key: string, text: string) => void {
+  return (key, text) => {
+    try {
+      ctx.ui.setStatus(key, text);
+    } catch (error) {
+      if (!isStaleCtxError(error)) throw error;
+    }
+  };
+}
 
 function openBrowser(url: string): void {
   if (process.platform === "darwin") {
@@ -318,7 +332,14 @@ export default function piMemoryExtension(pi: ExtensionAPI): void {
       clearTimeout(flushTimer);
     }
     flushTimer = setTimeout(() => {
-      void flush(ctx.sessionManager.getEntries(), false, (k, t) => ctx.ui.setStatus(k, t));
+      let entries: unknown[];
+      try {
+        entries = ctx.sessionManager.getEntries();
+      } catch (error) {
+        if (isStaleCtxError(error)) return;
+        throw error;
+      }
+      void flush(entries, false, staleSafeSetStatus(ctx));
     }, FLUSH_DEBOUNCE_MS);
   });
 
@@ -326,8 +347,12 @@ export default function piMemoryExtension(pi: ExtensionAPI): void {
     if (flushTimer) {
       clearTimeout(flushTimer);
     }
-    await flush(ctx.sessionManager.getEntries(), true, (k, t) => ctx.ui.setStatus(k, t));
-    disposeMemoryWidget(ctx);
+    try {
+      await flush(ctx.sessionManager.getEntries(), true, staleSafeSetStatus(ctx));
+      disposeMemoryWidget(ctx);
+    } catch (error) {
+      if (!isStaleCtxError(error)) throw error;
+    }
   });
 
   pi.registerCommand("memory-login", {

--- a/packages/scheduler/README.md
+++ b/packages/scheduler/README.md
@@ -1,0 +1,67 @@
+# @arvoretech/pi-scheduler
+
+Schedule prompts to run automatically from within pi — like a cron job for your
+agent. Tasks fire as **headless pi sessions** or get **appended to the session
+they were scheduled from**.
+
+## Schedule types
+
+- `cron` — 5 or 6-field cron expressions, e.g. `0 9 * * 1-5` (weekdays at 9am)
+- `once` — ISO timestamp or relative delay, e.g. `+10m`, `+2h`, `2026-08-01T09:00:00Z`
+- `interval` — fixed durations, e.g. `30s`, `5m`, `1h`, `1d`
+
+## Delivery modes
+
+- `new-session` — spawns `pi --print "<prompt>"` as a fresh, autonomous headless
+  session. Output is captured; non-zero exit or timeout marks the run as failed.
+- `origin-session` — spawns `pi --print --session <origin-session-id> "<prompt>"`,
+  appending the run to the session the task was scheduled from. If that session
+  is the one currently open in this process, the prompt is instead delivered
+  in-process as a follow-up user message (avoids two writers on the same
+  session file).
+
+Scheduled prompts run non-interactively — write them self-contained, with all
+context and file paths included.
+
+## Usage
+
+Ask the agent in natural language ("every weekday at 9am, check the deploy
+status"), or manage tasks directly:
+
+- LLM tools: `scheduler_create`, `scheduler_list`, `scheduler_get`,
+  `scheduler_update`, `scheduler_delete`, `scheduler_run_now`
+- Slash command: `/cron status|list|get|run|enable|disable|delete`
+
+The status line shows how many enabled tasks the scheduler is holding.
+
+## How it works
+
+- Tasks persist to `<dataDir>/tasks.json` (atomic writes), so they survive
+  restarts. `dataDir` defaults to `~/.pi/agent/scheduler`, overridable via
+  `PI_SCHEDULER_DATA_DIR`.
+- A PID-based file lock (`scheduler.lock`) ensures that when several pi
+  processes are open, only one fires tasks. The status line shows
+  `scheduler: idle (lock held elsewhere)` in the others.
+- Timers are process-local and `unref`'d: tasks only fire while a pi process
+  holding the lock is running. Missed runs during downtime are not caught up.
+- A task interrupted mid-run by a crash is marked as an error on the next
+  start (`lastStatus: running` at boot ⇒ "Process was interrupted").
+- `once` tasks auto-disable after firing. Run history keeps the last 25 runs.
+- Headless child runs get `PI_SCHEDULED_RUN=1` (plus
+  `PI_SCHEDULED_TASK_ID`/`PI_SCHEDULED_RUN_ID`); the extension does not start
+  the scheduler inside those children, so scheduled runs never nest.
+
+## Safety notes
+
+- `new-session` runs are fully autonomous — the child pi executes its prompt
+  with the tools available in print mode. Keep prompts scoped to what you
+  would let run unattended.
+- Default timeout is 30 minutes per run (`timeoutMs` on the task overrides);
+  timed-out children are SIGTERM'd, then SIGKILL'd after 5s.
+
+## Development
+
+```bash
+pnpm install
+pnpm build
+```

--- a/packages/scheduler/package.json
+++ b/packages/scheduler/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@arvoretech/pi-scheduler",
+  "version": "1.0.0",
+  "description": "PI extension that schedules prompts to run automatically (cron, one-time, interval) as headless pi sessions or appended to the session they were scheduled from",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "lint": "tsc --noEmit"
+  },
+  "dependencies": {
+    "croner": "^9.0.0"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": ">=0.74.0"
+  },
+  "devDependencies": {
+    "@earendil-works/pi-coding-agent": "latest",
+    "@earendil-works/pi-ai": "latest",
+    "@types/node": "^20.10.0",
+    "typescript": "^5.3.0"
+  },
+  "pi": {
+    "extensions": [
+      "./dist/index.js"
+    ]
+  },
+  "keywords": [
+    "pi-package",
+    "pi",
+    "extension",
+    "scheduler",
+    "cron",
+    "automation",
+    "headless"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/arvoreeducacao/arvore-pi-extensions.git",
+    "directory": "packages/scheduler"
+  },
+  "author": "Arvore",
+  "license": "MIT"
+}

--- a/packages/scheduler/src/index.ts
+++ b/packages/scheduler/src/index.ts
@@ -1,0 +1,224 @@
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { homedir } from "node:os";
+import path from "node:path";
+import { createPiRunner } from "./runner.js";
+import { PersistentTaskScheduler } from "./scheduler.js";
+import { FileSchedulerLock, JsonScheduledTaskStore } from "./store.js";
+import { createSchedulerTools } from "./tools.js";
+import type { ScheduledTask, TaskScheduler } from "./types.js";
+
+const STATUS_KEY = "scheduler";
+const ENV_DATA_DIR = "PI_SCHEDULER_DATA_DIR";
+const ENV_SCHEDULED_RUN = "PI_SCHEDULED_RUN";
+
+function resolveDataDir(): string {
+  return (
+    process.env[ENV_DATA_DIR]?.trim() || path.join(homedir(), ".pi", "agent", "scheduler")
+  );
+}
+
+export default function extension(pi: ExtensionAPI): void {
+  let scheduler: TaskScheduler | undefined;
+  let liveSessionId: string | undefined;
+
+  const refreshStatus = async (ctx: ExtensionContext) => {
+    if (!ctx.hasUI) {
+      return;
+    }
+    if (!scheduler) {
+      ctx.ui.setStatus(STATUS_KEY, undefined);
+      return;
+    }
+    if (!scheduler.isActive()) {
+      ctx.ui.setStatus(STATUS_KEY, "scheduler: idle (lock held elsewhere)");
+      return;
+    }
+    const tasks = await scheduler.list();
+    const enabled = tasks.filter((t) => t.enabled).length;
+    ctx.ui.setStatus(STATUS_KEY, `scheduler: ${enabled} task${enabled === 1 ? "" : "s"}`);
+  };
+
+  pi.on("session_start", async (_event, ctx) => {
+    liveSessionId = safeSessionId(ctx);
+    if (process.env[ENV_SCHEDULED_RUN] === "1") {
+      return;
+    }
+    if (scheduler) {
+      await refreshStatus(ctx);
+      return;
+    }
+    const dataDir = resolveDataDir();
+    const runner = createPiRunner({
+      isLiveSession: (sessionId) => sessionId !== undefined && sessionId === liveSessionId,
+      deliverToLiveSession: (prompt) => {
+        pi.sendUserMessage(prompt, { deliverAs: "followUp" });
+      },
+    });
+    const instance = new PersistentTaskScheduler(
+      new JsonScheduledTaskStore(path.join(dataDir, "tasks.json")),
+      new FileSchedulerLock(path.join(dataDir, "scheduler.lock")),
+      runner,
+    );
+    await instance.start();
+    scheduler = instance;
+    for (const tool of createSchedulerTools(scheduler)) {
+      pi.registerTool(tool);
+    }
+    await refreshStatus(ctx);
+  });
+
+  pi.on("session_tree", async (_event, ctx) => {
+    liveSessionId = safeSessionId(ctx);
+  });
+
+  pi.on("session_shutdown", async () => {
+    await scheduler?.stop();
+    scheduler = undefined;
+    liveSessionId = undefined;
+  });
+
+  pi.registerCommand("cron", {
+    description:
+      "Manage scheduled tasks. Subcommands: status, list, get, run, enable, disable, delete.",
+    getArgumentCompletions: (prefix) => {
+      const subcommands = ["status", "list", "get", "run", "enable", "disable", "delete"];
+      const matches = subcommands.filter((s) => s.startsWith(prefix.trim().toLowerCase()));
+      return matches.map((s) => ({ label: s, value: s }));
+    },
+    handler: async (args, ctx) => {
+      if (!ctx.hasUI) {
+        return;
+      }
+      if (!scheduler) {
+        ctx.ui.notify("Task scheduler is not running.", "warning");
+        return;
+      }
+      const parts = args.trim().split(/\s+/).filter(Boolean);
+      const subcommand = parts[0]?.toLowerCase() ?? "status";
+      const rest = parts.slice(1).join(" ").trim();
+
+      switch (subcommand) {
+        case "status": {
+          ctx.ui.notify(formatStatus(await scheduler.status()), "info");
+          break;
+        }
+        case "list": {
+          ctx.ui.notify(formatTaskList(await scheduler.list()), "info");
+          break;
+        }
+        case "get": {
+          if (!rest) {
+            ctx.ui.notify("Usage: /cron get <task-id>", "warning");
+            break;
+          }
+          const task = await scheduler.get(rest);
+          ctx.ui.notify(
+            task ? formatTaskDetail(task) : `Task not found: ${rest}`,
+            task ? "info" : "error",
+          );
+          break;
+        }
+        case "run": {
+          if (!rest) {
+            ctx.ui.notify("Usage: /cron run <task-id>", "warning");
+            break;
+          }
+          const task = await scheduler.runNow(rest);
+          ctx.ui.notify(
+            task ? `Triggered: ${task.name ?? task.id}` : `Task not found: ${rest}`,
+            task ? "info" : "error",
+          );
+          break;
+        }
+        case "enable":
+        case "disable": {
+          if (!rest) {
+            ctx.ui.notify(`Usage: /cron ${subcommand} <task-id>`, "warning");
+            break;
+          }
+          const task = await scheduler.update(rest, { enabled: subcommand === "enable" });
+          ctx.ui.notify(
+            task
+              ? `${subcommand === "enable" ? "Enabled" : "Disabled"}: ${task.name ?? task.id}`
+              : `Task not found: ${rest}`,
+            task ? "info" : "error",
+          );
+          break;
+        }
+        case "delete": {
+          if (!rest) {
+            ctx.ui.notify("Usage: /cron delete <task-id>", "warning");
+            break;
+          }
+          const deleted = await scheduler.delete(rest);
+          ctx.ui.notify(
+            deleted ? `Deleted: ${rest}` : `Task not found: ${rest}`,
+            deleted ? "info" : "error",
+          );
+          break;
+        }
+        default:
+          ctx.ui.notify(
+            "Unknown subcommand. Available: status, list, get, run, enable, disable, delete.",
+            "warning",
+          );
+      }
+    },
+  });
+}
+
+function safeSessionId(ctx: ExtensionContext): string | undefined {
+  try {
+    return ctx.sessionManager.getSessionId();
+  } catch {
+    return undefined;
+  }
+}
+
+function formatStatus(status: Awaited<ReturnType<TaskScheduler["status"]>>): string {
+  const lines = [
+    `Active: ${status.active}`,
+    `Tasks: ${status.taskCount}`,
+    `Timers: ${status.scheduledTimerCount}`,
+    `Crons: ${status.scheduledCronCount}`,
+  ];
+  if (status.runningTaskIds.length > 0) {
+    lines.push(`Running: ${status.runningTaskIds.join(", ")}`);
+  }
+  if (!status.lock.acquired && status.lock.holderPid !== undefined) {
+    lines.push(`Lock held by pid ${status.lock.holderPid}`);
+  }
+  return lines.join("\n");
+}
+
+function formatTaskList(tasks: ScheduledTask[]): string {
+  if (tasks.length === 0) {
+    return "No scheduled tasks.";
+  }
+  return tasks
+    .map((t) => {
+      const name = t.name ?? t.id.slice(0, 8);
+      const status = t.enabled ? (t.lastStatus ?? "pending") : "disabled";
+      const next = t.nextRunAt ? ` next: ${t.nextRunAt}` : "";
+      return `${t.id.slice(0, 8)} ${name} [${t.type}/${t.delivery}] ${status}${next}`;
+    })
+    .join("\n");
+}
+
+function formatTaskDetail(task: ScheduledTask): string {
+  const lines = [
+    `ID: ${task.id}`,
+    `Name: ${task.name ?? "(unnamed)"}`,
+    `Type: ${task.type}`,
+    `Schedule: ${task.schedule}`,
+    `Delivery: ${task.delivery}`,
+    `Enabled: ${task.enabled}`,
+    `Status: ${task.lastStatus ?? "pending"}`,
+    `Runs: ${task.runCount}`,
+  ];
+  if (task.originSessionId) lines.push(`Origin session: ${task.originSessionId}`);
+  if (task.nextRunAt) lines.push(`Next run: ${task.nextRunAt}`);
+  if (task.lastError) lines.push(`Last error: ${task.lastError}`);
+  lines.push(`Prompt: ${task.prompt}`);
+  return lines.join("\n");
+}

--- a/packages/scheduler/src/runner.ts
+++ b/packages/scheduler/src/runner.ts
@@ -1,0 +1,97 @@
+import { spawn } from "node:child_process";
+import type { ScheduledTask, ScheduledTaskRunContext } from "./types.js";
+
+const DEFAULT_TIMEOUT_MS = 30 * 60 * 1000;
+const OUTPUT_TAIL_LIMIT = 2000;
+const KILL_GRACE_MS = 5000;
+
+export type RunnerDeps = {
+  isLiveSession: (sessionId: string | undefined) => boolean;
+  deliverToLiveSession: (prompt: string) => void;
+};
+
+export function createPiRunner(deps: RunnerDeps) {
+  return async (task: ScheduledTask, run: ScheduledTaskRunContext): Promise<void> => {
+    if (task.delivery === "origin-session" && deps.isLiveSession(task.originSessionId)) {
+      deps.deliverToLiveSession(task.prompt);
+      return;
+    }
+    const output = await runHeadlessPi(task, run);
+    if (output.code !== 0 && !output.timedOut) {
+      throw new Error(
+        `Headless run exited with code ${output.code ?? "unknown"}: ${tail(output.stderr || output.stdout)}`,
+      );
+    }
+    if (output.timedOut) {
+      throw new Error(`Headless run timed out after ${task.timeoutMs ?? DEFAULT_TIMEOUT_MS}ms`);
+    }
+  };
+}
+
+function runHeadlessPi(
+  task: ScheduledTask,
+  run: ScheduledTaskRunContext,
+): Promise<{ code: number | null; stdout: string; stderr: string; timedOut: boolean }> {
+  return new Promise((resolve, reject) => {
+    const args = buildPiArgs(task);
+    const child = spawn(process.execPath, args, {
+      cwd: task.cwd,
+      env: {
+        ...process.env,
+        PI_SCHEDULED_RUN: "1",
+        PI_SCHEDULED_TASK_ID: task.id,
+        PI_SCHEDULED_RUN_ID: run.historyEntryId,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", reject);
+
+    const timeoutMs = task.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGTERM");
+      setTimeout(() => child.kill("SIGKILL"), KILL_GRACE_MS).unref();
+    }, timeoutMs);
+
+    child.on("close", (code) => {
+      clearTimeout(timeout);
+      resolve({ code, stdout, stderr, timedOut });
+    });
+  });
+}
+
+function buildPiArgs(task: ScheduledTask): string[] {
+  const args = [resolvePiCliEntry(), "--print"];
+  if (task.delivery === "origin-session" && task.originSessionId) {
+    args.push("--session", task.originSessionId);
+  }
+  args.push(task.prompt);
+  return args;
+}
+
+function resolvePiCliEntry(): string {
+  const entry = process.argv[1];
+  if (!entry) {
+    throw new Error("Could not resolve the pi CLI entry point from process.argv");
+  }
+  return entry;
+}
+
+function tail(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length <= OUTPUT_TAIL_LIMIT) {
+    return trimmed;
+  }
+  return `…${trimmed.slice(-OUTPUT_TAIL_LIMIT)}`;
+}

--- a/packages/scheduler/src/scheduler.ts
+++ b/packages/scheduler/src/scheduler.ts
@@ -1,0 +1,518 @@
+import { randomUUID } from "node:crypto";
+import { Cron } from "croner";
+import type {
+  ScheduledTask,
+  ScheduledTaskCreateInput,
+  ScheduledTaskRunHistoryEntry,
+  ScheduledTaskRunner,
+  ScheduledTaskStore,
+  ScheduledTaskType,
+  ScheduledTaskUpdate,
+  SchedulerLock,
+  TaskScheduler,
+  TaskSchedulerStatus,
+} from "./types.js";
+
+const RUN_HISTORY_LIMIT = 25;
+
+export class PersistentTaskScheduler implements TaskScheduler {
+  private readonly timers = new Map<string, NodeJS.Timeout>();
+  private readonly crons = new Map<string, Cron>();
+  private readonly runningTaskIds = new Set<string>();
+  private active = false;
+
+  constructor(
+    private readonly store: ScheduledTaskStore,
+    private readonly lock: SchedulerLock,
+    private readonly runner: ScheduledTaskRunner,
+  ) {}
+
+  async list(): Promise<ScheduledTask[]> {
+    return await this.store.list();
+  }
+
+  async get(taskId: string): Promise<ScheduledTask | undefined> {
+    return await this.store.get(taskId);
+  }
+
+  async status(): Promise<TaskSchedulerStatus> {
+    const tasks = await this.store.list();
+    const holderPid = this.lock.holderPid();
+    const lock: TaskSchedulerStatus["lock"] = {
+      path: this.lock.path,
+      acquired: this.lock.isAcquired(),
+    };
+    if (holderPid !== undefined) {
+      lock.holderPid = holderPid;
+    }
+    return {
+      active: this.active,
+      pid: process.pid,
+      taskCount: tasks.length,
+      scheduledTimerCount: this.timers.size,
+      scheduledCronCount: this.crons.size,
+      runningTaskIds: [...this.runningTaskIds],
+      lock,
+    };
+  }
+
+  isActive(): boolean {
+    return this.active;
+  }
+
+  async create(input: ScheduledTaskCreateInput): Promise<ScheduledTask> {
+    const now = new Date().toISOString();
+    const task = withNextRun({
+      id: randomUUID(),
+      ...input,
+      createdAt: now,
+      updatedAt: now,
+      runCount: 0,
+      runHistory:
+        input.enabled === false ? [createTaskHistoryEntry("paused", "Created paused")] : [],
+    });
+    const created = await this.store.create(task);
+    if (this.active) {
+      this.schedule(created);
+    }
+    return created;
+  }
+
+  async update(
+    taskId: string,
+    input: ScheduledTaskUpdate,
+  ): Promise<ScheduledTask | undefined> {
+    const existing = await this.store.get(taskId);
+    if (!existing) {
+      return undefined;
+    }
+    const nextTask: ScheduledTask = {
+      ...existing,
+      ...input,
+      updatedAt: new Date().toISOString(),
+    };
+    if (Object.hasOwn(input, "name") && input.name === undefined) {
+      delete nextTask.name;
+    }
+    if (Object.hasOwn(input, "originSessionId") && input.originSessionId === undefined) {
+      delete nextTask.originSessionId;
+    }
+    if (input.enabled !== undefined && input.enabled !== existing.enabled) {
+      nextTask.runHistory = appendTaskHistory(
+        existing.runHistory,
+        input.enabled
+          ? createTaskHistoryEntry("resumed", "Task resumed")
+          : createTaskHistoryEntry("paused", "Task paused"),
+      );
+    }
+    const task = withNextRun(nextTask);
+    if (input.enabled !== false && existing.lastStatus === "error") {
+      delete task.lastError;
+    }
+    const updated = await this.store.update(taskId, task);
+    if (this.active && updated) {
+      this.schedule(updated);
+    }
+    return updated;
+  }
+
+  async delete(taskId: string): Promise<boolean> {
+    this.unschedule(taskId);
+    return await this.store.delete(taskId);
+  }
+
+  async runNow(taskId: string): Promise<ScheduledTask | undefined> {
+    const task = await this.store.get(taskId);
+    if (!task) {
+      return undefined;
+    }
+    void this.execute(taskId);
+    return task;
+  }
+
+  async start(): Promise<void> {
+    if (this.active) {
+      return;
+    }
+    if (!this.lock.acquire()) {
+      return;
+    }
+    this.active = true;
+    const tasks = await this.store.list();
+    for (const task of tasks) {
+      if (task.lastStatus === "running") {
+        const fixed = withNextRun({
+          ...task,
+          lastStatus: "error" as const,
+          lastError: "Process was interrupted while task was running",
+          runHistory: updateTaskHistoryEntry(
+            task.runHistory,
+            findLastRunningEntryId(task.runHistory),
+            { status: "error", message: "Process was interrupted while task was running" },
+          ),
+          updatedAt: new Date().toISOString(),
+        });
+        await this.store.update(task.id, fixed).catch(() => undefined);
+        this.schedule(fixed);
+      } else {
+        const refreshed = withNextRun(task);
+        if (refreshed.nextRunAt !== task.nextRunAt) {
+          await this.store.update(task.id, refreshed).catch(() => undefined);
+        }
+        this.schedule(refreshed);
+      }
+    }
+  }
+
+  async stop(): Promise<void> {
+    for (const timer of this.timers.values()) {
+      clearTimeout(timer);
+      clearInterval(timer);
+    }
+    for (const cron of this.crons.values()) {
+      cron.stop();
+    }
+    this.timers.clear();
+    this.crons.clear();
+    this.active = false;
+    this.lock.release();
+  }
+
+  private schedule(task: ScheduledTask): void {
+    this.unschedule(task.id);
+    if (!this.active || !task.enabled) {
+      return;
+    }
+    if (task.type === "cron") {
+      try {
+        const cron = new Cron(task.schedule, { unref: true }, () => {
+          void this.execute(task.id);
+        });
+        this.crons.set(task.id, cron);
+        void this.refreshNextRun(task.id, cron.nextRun()?.toISOString());
+      } catch (error) {
+        void this.markScheduleError(task.id, error instanceof Error ? error.message : String(error));
+      }
+      return;
+    }
+    if (task.type === "once") {
+      const target = new Date(task.schedule);
+      const delayMs = target.getTime() - Date.now();
+      if (!Number.isFinite(delayMs) || delayMs <= 0) {
+        void this.markScheduleError(task.id, `Scheduled time ${task.schedule} is in the past`);
+        return;
+      }
+      const timer = setTimeout(() => {
+        void this.execute(task.id);
+      }, delayMs);
+      timer.unref();
+      this.timers.set(task.id, timer);
+      void this.refreshNextRun(task.id, target.toISOString());
+      return;
+    }
+    const timer = setInterval(() => {
+      void this.execute(task.id);
+    }, task.intervalSeconds * 1000);
+    timer.unref();
+    this.timers.set(task.id, timer);
+    void this.refreshNextRun(
+      task.id,
+      new Date(Date.now() + task.intervalSeconds * 1000).toISOString(),
+    );
+  }
+
+  private async execute(taskId: string): Promise<void> {
+    if (!this.active || this.runningTaskIds.has(taskId)) {
+      return;
+    }
+    const task = await this.store.get(taskId);
+    if (!task?.enabled) {
+      return;
+    }
+    this.runningTaskIds.add(taskId);
+    const startedAt = new Date().toISOString();
+    const runSessionId = createRunSessionId();
+    const runningEntry = createTaskHistoryEntry("running", "Run started", {
+      createdAt: startedAt,
+      sessionId: runSessionId,
+    });
+    const runningTask: ScheduledTask = {
+      ...task,
+      lastStatus: "running",
+      runHistory: appendTaskHistory(task.runHistory, runningEntry),
+      updatedAt: startedAt,
+    };
+    await this.store.update(taskId, runningTask);
+    try {
+      await this.runner(task, {
+        historyEntryId: runningEntry.id,
+        sessionId: runSessionId,
+        startedAt,
+      });
+      const latest = (await this.store.get(taskId)) ?? runningTask;
+      const completedAt = new Date().toISOString();
+      const updated = withNextRun({
+        ...latest,
+        enabled: latest.type === "once" ? false : latest.enabled,
+        lastRunAt: completedAt,
+        lastStatus: "success" as const,
+        runHistory: updateTaskHistoryEntry(latest.runHistory, runningEntry.id, {
+          status: "success",
+          message: "Run completed",
+        }),
+        runCount: latest.runCount + 1,
+        updatedAt: completedAt,
+      });
+      delete updated.lastError;
+      await this.store.update(taskId, updated);
+      if (updated.type === "once") {
+        this.unschedule(taskId);
+      }
+    } catch (error) {
+      const latest = (await this.store.get(taskId)) ?? runningTask;
+      const message = error instanceof Error ? error.message : String(error);
+      const updated = withNextRun({
+        ...latest,
+        lastStatus: "error" as const,
+        lastError: message,
+        runHistory: updateTaskHistoryEntry(latest.runHistory, runningEntry.id, {
+          status: "error",
+          message,
+        }),
+        updatedAt: new Date().toISOString(),
+      });
+      await this.store.update(taskId, updated);
+    } finally {
+      this.runningTaskIds.delete(taskId);
+    }
+  }
+
+  private unschedule(taskId: string): void {
+    const timer = this.timers.get(taskId);
+    if (timer) {
+      clearTimeout(timer);
+      clearInterval(timer);
+      this.timers.delete(taskId);
+    }
+    const cron = this.crons.get(taskId);
+    if (cron) {
+      cron.stop();
+      this.crons.delete(taskId);
+    }
+  }
+
+  private async refreshNextRun(taskId: string, nextRunAt: string | undefined): Promise<void> {
+    const task = await this.store.get(taskId);
+    if (!task || nextRunAt === task.nextRunAt) {
+      return;
+    }
+    const updated = { ...task, updatedAt: new Date().toISOString() };
+    if (nextRunAt) {
+      updated.nextRunAt = nextRunAt;
+    } else {
+      delete updated.nextRunAt;
+    }
+    await this.store.update(taskId, updated);
+  }
+
+  private async markScheduleError(taskId: string, error: string): Promise<void> {
+    const task = await this.store.get(taskId);
+    if (!task) {
+      return;
+    }
+    const updated = {
+      ...task,
+      enabled: false,
+      lastStatus: "error" as const,
+      lastError: error,
+      runHistory: appendTaskHistory(task.runHistory, createTaskHistoryEntry("error", error)),
+      updatedAt: new Date().toISOString(),
+    };
+    delete updated.nextRunAt;
+    await this.store.update(taskId, updated);
+  }
+}
+
+export function resolveScheduledTaskDefinition(input: {
+  type?: ScheduledTaskType;
+  schedule?: string;
+}): Pick<ScheduledTask, "type" | "schedule" | "intervalSeconds"> {
+  const type = input.type;
+  if (type !== "cron" && type !== "once" && type !== "interval") {
+    throw new Error("Scheduled task type is required and must be one of: cron, once, interval");
+  }
+  if (!input.schedule?.trim()) {
+    throw new Error(`${type} scheduled tasks require schedule`);
+  }
+  if (type === "interval") {
+    const intervalSeconds = parseIntervalSeconds(input.schedule);
+    if (!intervalSeconds) {
+      throw new Error(
+        `Invalid interval schedule: ${input.schedule}. Use formats like "30s", "5m", or "1h".`,
+      );
+    }
+    return { type, schedule: input.schedule.trim(), intervalSeconds };
+  }
+  if (type === "once") {
+    const schedule = resolveOnceSchedule(input.schedule);
+    const delaySeconds = Math.max(1, Math.ceil((new Date(schedule).getTime() - Date.now()) / 1000));
+    return { type, schedule, intervalSeconds: delaySeconds };
+  }
+  validateCronSchedule(input.schedule);
+  return { type, schedule: input.schedule.trim(), intervalSeconds: 0 };
+}
+
+export function computeNextRunAt(task: ScheduledTask): string | undefined {
+  if (!task.enabled) {
+    return undefined;
+  }
+  if (task.type === "interval") {
+    return new Date(Date.now() + task.intervalSeconds * 1000).toISOString();
+  }
+  if (task.type === "once") {
+    const target = new Date(task.schedule);
+    if (Number.isNaN(target.getTime()) || target.getTime() <= Date.now()) {
+      return undefined;
+    }
+    return target.toISOString();
+  }
+  try {
+    const cron = new Cron(task.schedule, { paused: true });
+    const next = cron.nextRun()?.toISOString();
+    cron.stop();
+    return next;
+  } catch {
+    return undefined;
+  }
+}
+
+export function createTaskHistoryEntry(
+  status: ScheduledTaskRunHistoryEntry["status"],
+  message?: string,
+  options: { createdAt?: string; sessionId?: string } = {},
+): ScheduledTaskRunHistoryEntry {
+  return {
+    id: randomUUID(),
+    status,
+    createdAt: options.createdAt ?? new Date().toISOString(),
+    ...(options.sessionId ? { sessionId: options.sessionId } : {}),
+    ...(message ? { message } : {}),
+  };
+}
+
+export function appendTaskHistory(
+  history: ScheduledTaskRunHistoryEntry[] | undefined,
+  entry: ScheduledTaskRunHistoryEntry,
+): ScheduledTaskRunHistoryEntry[] {
+  return [...(history ?? []), entry].slice(-RUN_HISTORY_LIMIT);
+}
+
+export function updateTaskHistoryEntry(
+  history: ScheduledTaskRunHistoryEntry[] | undefined,
+  entryId: string,
+  patch: Pick<ScheduledTaskRunHistoryEntry, "status"> &
+    Pick<Partial<ScheduledTaskRunHistoryEntry>, "message">,
+): ScheduledTaskRunHistoryEntry[] {
+  return (history ?? [])
+    .map((entry) => (entry.id === entryId ? { ...entry, ...patch } : entry))
+    .slice(-RUN_HISTORY_LIMIT);
+}
+
+export function createRunSessionId(): string {
+  return `scheduled-run-${randomUUID()}`;
+}
+
+function withNextRun<T extends ScheduledTask>(task: T): T {
+  const nextRunAt = computeNextRunAt(task);
+  const result: T = { ...task };
+  if (nextRunAt) {
+    result.nextRunAt = nextRunAt;
+  } else {
+    delete result.nextRunAt;
+  }
+  return result;
+}
+
+function findLastRunningEntryId(history: ScheduledTaskRunHistoryEntry[] | undefined): string {
+  const entries = history ?? [];
+  for (let i = entries.length - 1; i >= 0; i--) {
+    const entry = entries[i];
+    if (entry?.status === "running") {
+      return entry.id;
+    }
+  }
+  return "";
+}
+
+function sanitizeIntervalSeconds(value: number): number {
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error("intervalSeconds must be a positive number");
+  }
+  return Math.max(5, Math.floor(value));
+}
+
+function parseIntervalSeconds(value: string): number | undefined {
+  const match = value.trim().match(/^(\d+)(s|m|h|d)$/);
+  if (!match) {
+    return undefined;
+  }
+  const amount = Number(match[1]);
+  const unit = match[2] as string;
+  const multipliers: Record<string, number> = {
+    s: 1,
+    m: 60,
+    h: 60 * 60,
+    d: 24 * 60 * 60,
+  };
+  const multiplier = multipliers[unit];
+  if (!Number.isFinite(amount) || !multiplier) {
+    return undefined;
+  }
+  return sanitizeIntervalSeconds(amount * multiplier);
+}
+
+function resolveOnceSchedule(value: string): string {
+  const relative = parseRelativeSchedule(value);
+  if (relative) {
+    return relative;
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(
+      `Invalid once schedule: ${value}. Use an ISO timestamp or relative time like "+10m".`,
+    );
+  }
+  if (date.getTime() <= Date.now()) {
+    throw new Error(`Scheduled time is in the past: ${date.toISOString()}`);
+  }
+  return date.toISOString();
+}
+
+function parseRelativeSchedule(value: string): string | undefined {
+  const match = value.trim().match(/^\+(\d+)(s|m|h|d)$/);
+  if (!match) {
+    return undefined;
+  }
+  const amount = Number(match[1]);
+  const unit = match[2] as string;
+  const multipliers: Record<string, number> = {
+    s: 1000,
+    m: 60 * 1000,
+    h: 60 * 60 * 1000,
+    d: 24 * 60 * 60 * 1000,
+  };
+  const multiplier = multipliers[unit];
+  if (!Number.isFinite(amount) || !multiplier || amount <= 0) {
+    return undefined;
+  }
+  return new Date(Date.now() + amount * multiplier).toISOString();
+}
+
+function validateCronSchedule(value: string): void {
+  const fields = value.trim().split(/\s+/);
+  if (fields.length !== 5 && fields.length !== 6) {
+    throw new Error(`Cron schedule must have 5 or 6 fields, got ${fields.length}`);
+  }
+  const cron = new Cron(value.trim(), { paused: true });
+  cron.stop();
+}

--- a/packages/scheduler/src/store.ts
+++ b/packages/scheduler/src/store.ts
@@ -1,0 +1,153 @@
+import { mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import type { ScheduledTask, ScheduledTaskStore, SchedulerLock } from "./types.js";
+
+async function readJsonFile<T>(filePath: string, fallback: T): Promise<T> {
+  try {
+    const raw = readFileSync(filePath, "utf8");
+    return JSON.parse(raw) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+async function writeJsonFile(filePath: string, value: unknown): Promise<void> {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  const tmpPath = `${filePath}.${process.pid}.tmp`;
+  writeFileSync(tmpPath, JSON.stringify(value, null, 2));
+  renameSync(tmpPath, filePath);
+}
+
+export class JsonScheduledTaskStore implements ScheduledTaskStore {
+  private loaded = false;
+  private readonly tasks = new Map<string, ScheduledTask>();
+  private writeTail: Promise<unknown> = Promise.resolve();
+
+  constructor(private readonly filePath: string) {}
+
+  async list(): Promise<ScheduledTask[]> {
+    await this.load();
+    return Array.from(this.tasks.values());
+  }
+
+  async get(taskId: string): Promise<ScheduledTask | undefined> {
+    await this.load();
+    return this.tasks.get(taskId);
+  }
+
+  async create(task: ScheduledTask): Promise<ScheduledTask> {
+    await this.updateState(() => {
+      this.tasks.set(task.id, task);
+    });
+    return task;
+  }
+
+  async update(taskId: string, task: ScheduledTask): Promise<ScheduledTask | undefined> {
+    const updated = await this.updateState(() => {
+      if (!this.tasks.has(taskId)) {
+        return false;
+      }
+      this.tasks.set(taskId, task);
+      return true;
+    });
+    return updated ? task : undefined;
+  }
+
+  async delete(taskId: string): Promise<boolean> {
+    return await this.updateState(() => this.tasks.delete(taskId));
+  }
+
+  private async load(): Promise<void> {
+    if (this.loaded) {
+      return;
+    }
+    const tasks = await readJsonFile<ScheduledTask[]>(this.filePath, []);
+    this.tasks.clear();
+    for (const task of tasks) {
+      this.tasks.set(task.id, task);
+    }
+    this.loaded = true;
+  }
+
+  private async save(): Promise<void> {
+    await writeJsonFile(this.filePath, Array.from(this.tasks.values()));
+  }
+
+  private async updateState<T>(mutator: () => T): Promise<T> {
+    const pending = this.writeTail.then(async () => {
+      await this.load();
+      const result = mutator();
+      await this.save();
+      return result;
+    });
+    this.writeTail = pending.catch(() => undefined);
+    return await pending;
+  }
+}
+
+export class FileSchedulerLock implements SchedulerLock {
+  private acquired = false;
+
+  constructor(readonly path: string) {}
+
+  acquire(): boolean {
+    mkdirSync(path.dirname(this.path), { recursive: true });
+    const holder = this.holderPid();
+    if (holder && holder !== process.pid) {
+      return false;
+    }
+    try {
+      unlinkSync(this.path);
+    } catch {}
+    try {
+      writeFileSync(this.path, String(process.pid), { flag: "wx" });
+      this.acquired = true;
+      return true;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+        this.acquired = false;
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  release(): void {
+    if (!this.acquired) {
+      return;
+    }
+    try {
+      const pid = Number(readFileSync(this.path, "utf8").trim());
+      if (pid === process.pid) {
+        unlinkSync(this.path);
+      }
+    } catch {}
+    this.acquired = false;
+  }
+
+  isAcquired(): boolean {
+    return this.acquired;
+  }
+
+  holderPid(): number | undefined {
+    try {
+      const pid = Number(readFileSync(this.path, "utf8").trim());
+      if (Number.isInteger(pid) && pid > 0 && isProcessAlive(pid)) {
+        return pid;
+      }
+      unlinkSync(this.path);
+      return undefined;
+    } catch {
+      return undefined;
+    }
+  }
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/scheduler/src/tools.ts
+++ b/packages/scheduler/src/tools.ts
@@ -1,0 +1,240 @@
+import type {
+  AgentToolResult,
+  ExtensionContext,
+  ToolDefinition,
+} from "@earendil-works/pi-coding-agent";
+import { Type } from "@earendil-works/pi-ai";
+import { resolveScheduledTaskDefinition } from "./scheduler.js";
+import type {
+  ScheduledTask,
+  ScheduledTaskCreateInput,
+  ScheduledTaskDelivery,
+  ScheduledTaskType,
+  TaskScheduler,
+} from "./types.js";
+
+function textResult(text: string): AgentToolResult<unknown> {
+  return { content: [{ type: "text" as const, text }], details: undefined };
+}
+
+function formatTaskSummary(task: ScheduledTask) {
+  return {
+    id: task.id,
+    name: task.name,
+    type: task.type,
+    schedule: task.schedule,
+    delivery: task.delivery,
+    enabled: task.enabled,
+    lastStatus: task.lastStatus ?? "pending",
+    nextRunAt: task.nextRunAt,
+    runCount: task.runCount,
+    prompt: task.prompt.length > 100 ? `${task.prompt.slice(0, 100)}…` : task.prompt,
+  };
+}
+
+const taskTypeSchema = Type.Union([
+  Type.Literal("cron"),
+  Type.Literal("once"),
+  Type.Literal("interval"),
+]);
+
+const deliverySchema = Type.Union([
+  Type.Literal("new-session"),
+  Type.Literal("origin-session"),
+]);
+
+const PROMPT_GUIDELINES = [
+  "Use scheduler_create when the user asks for something to run later, repeatedly, or at a specific time of day — phrase the schedule as a cron expression, a relative delay like +10m, or an interval like 1h.",
+  "scheduler_create requires a delivery mode: use new-session to run the prompt in a fresh autonomous headless pi session, or origin-session to append it to the current session when it fires.",
+  "Prompts for scheduled tasks must be fully self-contained: they run non-interactively later, so include all context, file paths, and acceptance criteria in the prompt itself.",
+  "Use scheduler_list to show the user their scheduled tasks and scheduler_run_now to trigger one immediately for testing.",
+  "When the user schedules a task, confirm the parsed schedule, next run time, and delivery mode back to them.",
+];
+
+export function createSchedulerTools(scheduler: TaskScheduler): ToolDefinition[] {
+  return [
+    {
+      name: "scheduler_create",
+      label: "Scheduler",
+      description:
+        "Schedule a prompt to be executed automatically at a future time or on a recurring basis. Supports cron expressions (e.g. \"0 9 * * 1-5\"), one-time schedules (ISO timestamp or relative like \"+10m\"), and fixed intervals (\"30s\", \"5m\", \"1h\"). The prompt runs non-interactively: delivery \"new-session\" spawns a fresh headless pi session, \"origin-session\" appends the prompt to the session it was scheduled from. Use this whenever the user wants something to happen later, repeatedly, or on a timer.",
+      promptSnippet:
+        "Schedule prompts to run automatically later via cron, one-time delay, or fixed interval, delivered as headless pi sessions",
+      promptGuidelines: PROMPT_GUIDELINES,
+      parameters: Type.Object({
+        type: taskTypeSchema,
+        schedule: Type.String({
+          description:
+            "Schedule expression. Cron: \"0 9 * * 1-5\"; Once: ISO timestamp or \"+10m\"; Interval: \"30s\", \"5m\", \"1h\".",
+        }),
+        prompt: Type.String({
+          description:
+            "The prompt to execute when triggered. Must be self-contained because it runs non-interactively.",
+        }),
+        delivery: deliverySchema,
+        name: Type.Optional(
+          Type.String({ description: "Human-readable name for this scheduled task." }),
+        ),
+        enabled: Type.Optional(
+          Type.Boolean({ description: "Whether the task is enabled. Default true." }),
+        ),
+        timeoutMs: Type.Optional(
+          Type.Number({
+            description: "Maximum execution time in milliseconds. Defaults to 30 minutes.",
+          }),
+        ),
+      }),
+      async execute(
+        _toolCallId: string,
+        params: Record<string, unknown>,
+        _signal: AbortSignal | undefined,
+        _onUpdate: unknown,
+        ctx: ExtensionContext,
+      ): Promise<AgentToolResult<unknown>> {
+        try {
+          const definition = resolveScheduledTaskDefinition({
+            type: params.type as ScheduledTaskType,
+            schedule: params.schedule as string,
+          });
+          const input: ScheduledTaskCreateInput = {
+            ...definition,
+            prompt: params.prompt as string,
+            delivery: params.delivery as ScheduledTaskDelivery,
+            cwd: ctx.cwd,
+            enabled: params.enabled !== false,
+            ...(params.name ? { name: params.name as string } : {}),
+            ...(typeof params.timeoutMs === "number"
+              ? { timeoutMs: params.timeoutMs as number }
+              : {}),
+          };
+          if (input.delivery === "origin-session") {
+            input.originSessionId = ctx.sessionManager.getSessionId();
+          }
+          const task = await scheduler.create(input);
+          return textResult(JSON.stringify(formatTaskSummary(task), null, 2));
+        } catch (error) {
+          return textResult(
+            `Failed to create task: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+      },
+    },
+    {
+      name: "scheduler_list",
+      label: "Scheduler",
+      description: "List all scheduled tasks with their status and next run time.",
+      promptSnippet: "List all scheduled tasks.",
+      parameters: Type.Object({}),
+      async execute(): Promise<AgentToolResult<unknown>> {
+        const tasks = await scheduler.list();
+        if (tasks.length === 0) {
+          return textResult("No scheduled tasks.");
+        }
+        return textResult(JSON.stringify(tasks.map(formatTaskSummary), null, 2));
+      },
+    },
+    {
+      name: "scheduler_get",
+      label: "Scheduler",
+      description:
+        "Get detailed information about a scheduled task, including its schedule, delivery mode, and run history.",
+      parameters: Type.Object({
+        taskId: Type.String({ description: "The scheduled-task ID to query." }),
+      }),
+      async execute(
+        _toolCallId: string,
+        params: Record<string, unknown>,
+      ): Promise<AgentToolResult<unknown>> {
+        const task = await scheduler.get(params.taskId as string);
+        if (!task) {
+          return textResult(`Task not found: ${params.taskId}`);
+        }
+        return textResult(JSON.stringify(task, null, 2));
+      },
+    },
+    {
+      name: "scheduler_update",
+      label: "Scheduler",
+      description:
+        "Update a scheduled task. Can change schedule, prompt text, name, delivery mode, or enable/disable it.",
+      parameters: Type.Object({
+        taskId: Type.String({ description: "The scheduled-task ID to update." }),
+        type: Type.Optional(taskTypeSchema),
+        schedule: Type.Optional(Type.String({ description: "New schedule expression." })),
+        prompt: Type.Optional(Type.String({ description: "New prompt." })),
+        name: Type.Optional(Type.String({ description: "New name." })),
+        delivery: Type.Optional(deliverySchema),
+        enabled: Type.Optional(Type.Boolean({ description: "Enable or disable." })),
+      }),
+      async execute(
+        _toolCallId: string,
+        params: Record<string, unknown>,
+      ): Promise<AgentToolResult<unknown>> {
+        const { taskId, type, schedule, ...rest } = params as {
+          taskId: string;
+          type?: string;
+          schedule?: string;
+          [key: string]: unknown;
+        };
+        const update: Record<string, unknown> = { ...rest };
+        if (type !== undefined || schedule !== undefined) {
+          try {
+            const existing = await scheduler.get(taskId);
+            if (!existing) {
+              return textResult(`Task not found: ${taskId}`);
+            }
+            const definition = resolveScheduledTaskDefinition({
+              type: (type ?? existing.type) as ScheduledTaskType,
+              schedule: schedule ?? existing.schedule,
+            });
+            Object.assign(update, definition);
+          } catch (error) {
+            return textResult(
+              `Invalid schedule: ${error instanceof Error ? error.message : String(error)}`,
+            );
+          }
+        }
+        const task = await scheduler.update(taskId, update);
+        if (!task) {
+          return textResult(`Task not found: ${taskId}`);
+        }
+        return textResult(JSON.stringify(formatTaskSummary(task), null, 2));
+      },
+    },
+    {
+      name: "scheduler_delete",
+      label: "Scheduler",
+      description: "Delete a scheduled task.",
+      parameters: Type.Object({
+        taskId: Type.String({ description: "The scheduled-task ID to delete." }),
+      }),
+      async execute(
+        _toolCallId: string,
+        params: Record<string, unknown>,
+      ): Promise<AgentToolResult<unknown>> {
+        const taskId = params.taskId as string;
+        const deleted = await scheduler.delete(taskId);
+        return textResult(deleted ? `Deleted task: ${taskId}` : `Task not found: ${taskId}`);
+      },
+    },
+    {
+      name: "scheduler_run_now",
+      label: "Scheduler",
+      description: "Trigger immediate execution of a scheduled task, ignoring its schedule.",
+      parameters: Type.Object({
+        taskId: Type.String({ description: "The scheduled-task ID to run immediately." }),
+      }),
+      async execute(
+        _toolCallId: string,
+        params: Record<string, unknown>,
+      ): Promise<AgentToolResult<unknown>> {
+        const taskId = params.taskId as string;
+        const task = await scheduler.runNow(taskId);
+        if (!task) {
+          return textResult(`Task not found: ${taskId}`);
+        }
+        return textResult(`Triggered: ${task.name ?? task.id}`);
+      },
+    },
+  ];
+}

--- a/packages/scheduler/src/types.ts
+++ b/packages/scheduler/src/types.ts
@@ -1,0 +1,120 @@
+export type ScheduledTaskType = "cron" | "once" | "interval";
+export type ScheduledTaskStatus = "success" | "error" | "running";
+export type ScheduledTaskDelivery = "new-session" | "origin-session";
+
+export type ScheduledTaskRunHistoryEntry = {
+  id: string;
+  status: ScheduledTaskStatus | "paused" | "resumed";
+  createdAt: string;
+  sessionId?: string;
+  message?: string;
+};
+
+export type ScheduledTaskRunContext = {
+  historyEntryId: string;
+  sessionId: string;
+  startedAt: string;
+};
+
+export type ScheduledTask = {
+  id: string;
+  name?: string;
+  prompt: string;
+  type: ScheduledTaskType;
+  schedule: string;
+  intervalSeconds: number;
+  enabled: boolean;
+  delivery: ScheduledTaskDelivery;
+  originSessionId?: string;
+  cwd: string;
+  createdAt: string;
+  updatedAt: string;
+  lastRunAt?: string;
+  nextRunAt?: string;
+  runCount: number;
+  timeoutMs?: number;
+  lastStatus?: ScheduledTaskStatus;
+  lastError?: string;
+  runHistory?: ScheduledTaskRunHistoryEntry[];
+};
+
+export type ScheduledTaskCreateInput = Omit<
+  ScheduledTask,
+  | "id"
+  | "createdAt"
+  | "updatedAt"
+  | "nextRunAt"
+  | "runCount"
+  | "lastStatus"
+  | "lastRunAt"
+  | "lastError"
+  | "runHistory"
+>;
+
+export type ScheduledTaskUpdate = Partial<
+  Omit<
+    ScheduledTask,
+    | "id"
+    | "createdAt"
+    | "updatedAt"
+    | "lastRunAt"
+    | "lastError"
+    | "nextRunAt"
+    | "runCount"
+    | "lastStatus"
+    | "runHistory"
+    | "name"
+    | "originSessionId"
+  >
+> & {
+  name?: string | undefined;
+  originSessionId?: string | undefined;
+};
+
+export type TaskSchedulerStatus = {
+  active: boolean;
+  pid: number;
+  taskCount: number;
+  scheduledTimerCount: number;
+  scheduledCronCount: number;
+  runningTaskIds: string[];
+  lock: {
+    path: string;
+    acquired: boolean;
+    holderPid?: number;
+  };
+};
+
+export interface TaskScheduler {
+  list(): Promise<ScheduledTask[]>;
+  get(taskId: string): Promise<ScheduledTask | undefined>;
+  status(): Promise<TaskSchedulerStatus>;
+  isActive(): boolean;
+  create(input: ScheduledTaskCreateInput): Promise<ScheduledTask>;
+  update(taskId: string, input: ScheduledTaskUpdate): Promise<ScheduledTask | undefined>;
+  delete(taskId: string): Promise<boolean>;
+  runNow(taskId: string): Promise<ScheduledTask | undefined>;
+  start(): Promise<void>;
+  stop(): Promise<void>;
+}
+
+export interface ScheduledTaskStore {
+  list(): Promise<ScheduledTask[]>;
+  get(taskId: string): Promise<ScheduledTask | undefined>;
+  create(task: ScheduledTask): Promise<ScheduledTask>;
+  update(taskId: string, task: ScheduledTask): Promise<ScheduledTask | undefined>;
+  delete(taskId: string): Promise<boolean>;
+}
+
+export interface SchedulerLock {
+  readonly path: string;
+  acquire(): boolean;
+  release(): void;
+  isAcquired(): boolean;
+  holderPid(): number | undefined;
+}
+
+export type ScheduledTaskRunner = (
+  task: ScheduledTask,
+  run: ScheduledTaskRunContext,
+) => Promise<void>;

--- a/packages/scheduler/tsconfig.json
+++ b/packages/scheduler/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -282,7 +282,7 @@ importers:
     devDependencies:
       '@earendil-works/pi-coding-agent':
         specifier: 0.79.1
-        version: 0.79.1(ws@8.20.0)(zod@4.4.3)
+        version: 0.79.1
       '@types/node':
         specifier: ^20.10.0
         version: 20.19.39
@@ -491,6 +491,25 @@ importers:
       '@earendil-works/pi-coding-agent':
         specifier: latest
         version: 0.80.3(ws@8.20.0)(zod@4.4.3)
+      '@types/node':
+        specifier: ^20.10.0
+        version: 20.19.39
+      typescript:
+        specifier: ^5.3.0
+        version: 5.9.3
+
+  packages/scheduler:
+    dependencies:
+      croner:
+        specifier: ^9.0.0
+        version: 9.1.0
+    devDependencies:
+      '@earendil-works/pi-ai':
+        specifier: latest
+        version: 0.82.1(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-coding-agent':
+        specifier: latest
+        version: 0.82.1(ws@8.20.0)(zod@4.4.3)
       '@types/node':
         specifier: ^20.10.0
         version: 20.19.39
@@ -824,6 +843,10 @@ packages:
     resolution: {integrity: sha512-Lvn89ko42h5ETUb6Z0Ku6ldskEqXaTdQBYvSa0+7bdG9V6rUEpXptv5e0OVZ1HDcvi8s6/2lGCQWsxKX+DFHNw==}
     engines: {node: '>=22.19.0'}
 
+  '@earendil-works/pi-agent-core@0.82.1':
+    resolution: {integrity: sha512-Z3kloziJIE2dmrisRckZX8zDca/gIv9/YdFAzeoqpHiLV2wsni6bL4hInNSjVKLbqT+4kqLIkph2JQLKvSepjg==}
+    engines: {node: '>=22.19.0'}
+
   '@earendil-works/pi-ai@0.75.5':
     resolution: {integrity: sha512-zf1F5kXk1pqZeFShXOqq9ibUk8QdtRoLCDPAjO+hj44e3EUs9/GFO2qnhTC5+JA2uwVCx+WCNe1PiCjlBYWm5w==}
     engines: {node: '>=22.19.0'}
@@ -851,6 +874,11 @@ packages:
 
   '@earendil-works/pi-ai@0.80.6':
     resolution: {integrity: sha512-7xfLk8sANBp+bpPEbjoOZTbPxsa+++b1JXAoSJsNa3vbs9AHHEclmvg54XLQcxH+fuwaeti/g2jeIfJ+mVYLpA==}
+    engines: {node: '>=22.19.0'}
+    hasBin: true
+
+  '@earendil-works/pi-ai@0.82.1':
+    resolution: {integrity: sha512-3WFYRhEp3lQB3444EhPMBcM7zSaEUE3eJgHOR7s4081NLqbw/FsWilIKWXSua0Gv3sRr7m9xMidR3pPDE7jI/A==}
     engines: {node: '>=22.19.0'}
     hasBin: true
 
@@ -886,6 +914,11 @@ packages:
 
   '@earendil-works/pi-coding-agent@0.80.6':
     resolution: {integrity: sha512-vcfD6tOk402isLl3Cm/qbn2O10TvgroMp1+/fEGM24ZdvETFCdOYv5VZ7m59EI5fPsjfSJh+CpQ5bhBrhfOg7g==}
+    engines: {node: '>=22.19.0'}
+    hasBin: true
+
+  '@earendil-works/pi-coding-agent@0.82.1':
+    resolution: {integrity: sha512-zbkAhoIuDPMF3pKuja0ajZabrMWU29FUMV9A/XMXT/XC1yXs5xt6t6t13GogQFsDrDqbFP4DkZQO1w8rWRAzYA==}
     engines: {node: '>=22.19.0'}
     hasBin: true
 
@@ -1836,6 +1869,10 @@ packages:
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
+
+  croner@9.1.0:
+    resolution: {integrity: sha512-p9nwwR4qyT5W996vBZhdvBCnMhicY5ytZkR4D1Xj0wuTDEiMnjwR57Q3RXYY/s0EpX6Ay3vgIcfaR+ewGHsi+g==}
+    engines: {node: '>=18.0'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -3190,6 +3227,21 @@ snapshots:
       - ws
       - zod
 
+  '@earendil-works/pi-agent-core@0.82.1(ws@8.20.0)(zod@4.4.3)':
+    dependencies:
+      '@earendil-works/pi-ai': 0.82.1(ws@8.20.0)(zod@4.4.3)
+      diff: 8.0.4
+      ignore: 7.0.5
+      typebox: 1.1.38
+      yaml: 2.9.0
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
   '@earendil-works/pi-ai@0.75.5(ws@8.20.0)(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
@@ -3313,6 +3365,27 @@ snapshots:
       - ws
       - zod
 
+  '@earendil-works/pi-ai@0.82.1(ws@8.20.0)(zod@4.4.3)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
+      '@aws-sdk/client-bedrock-runtime': 3.1048.0
+      '@google/genai': 1.52.0
+      '@mistralai/mistralai': 2.2.6(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.0
+      '@smithy/node-http-handler': 4.7.3
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      openai: 6.26.0(ws@8.20.0)(zod@4.4.3)
+      partial-json: 0.1.7
+      typebox: 1.1.38
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
   '@earendil-works/pi-coding-agent@0.75.5(ws@8.20.0)(zod@4.4.3)':
     dependencies:
       '@earendil-works/pi-agent-core': 0.75.5(ws@8.20.0)(zod@4.4.3)
@@ -3342,7 +3415,7 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-coding-agent@0.79.1(ws@8.20.0)(zod@4.4.3)':
+  '@earendil-works/pi-coding-agent@0.79.1':
     dependencies:
       '@earendil-works/pi-agent-core': 0.79.6(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-ai': 0.79.6(ws@8.20.0)(zod@4.4.3)
@@ -3495,6 +3568,36 @@ snapshots:
     dependencies:
       '@earendil-works/pi-agent-core': 0.80.6(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-ai': 0.80.6(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-tui': 0.79.5
+      '@silvia-odwyer/photon-node': 0.3.4
+      chalk: 5.6.2
+      cross-spawn: 7.0.6
+      diff: 8.0.4
+      glob: 13.0.6
+      highlight.js: 10.7.3
+      hosted-git-info: 9.0.3
+      ignore: 7.0.5
+      jiti: 2.7.0
+      minimatch: 10.2.5
+      proper-lockfile: 4.1.2
+      semver: 7.8.0
+      typebox: 1.1.38
+      undici: 8.5.0
+      yaml: 2.9.0
+    optionalDependencies:
+      '@mariozechner/clipboard': 0.3.9
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-coding-agent@0.82.1(ws@8.20.0)(zod@4.4.3)':
+    dependencies:
+      '@earendil-works/pi-agent-core': 0.82.1(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.82.1(ws@8.20.0)(zod@4.4.3)
       '@earendil-works/pi-tui': 0.79.5
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
@@ -4331,6 +4434,8 @@ snapshots:
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
+
+  croner@9.1.0: {}
 
   cross-spawn@7.0.6:
     dependencies:


### PR DESCRIPTION
## What

### New package: `@arvoretech/pi-scheduler` (`packages/scheduler`)

Cron-like task scheduler for pi. Schedule prompts to run later or repeatedly; tasks fire as autonomous headless pi sessions or get appended to the session they were scheduled from.

- **Schedule types:** `cron` (5/6-field, via croner), `once` (ISO or `+10m`), `interval` (`30s`/`5m`/`1h`)
- **Delivery modes:**
  - `new-session` — spawns `pi --print "<prompt>"` headless; non-zero exit or timeout (default 30min) marks the run failed
  - `origin-session` — spawns with `--session <origin-id>` to append to the scheduling session; falls back to in-process `sendUserMessage(followUp)` when the origin session is the live one (avoids two writers on the same session file)
- **Persistence:** tasks in `~/.pi/agent/scheduler/tasks.json` (atomic writes), PID-based file lock so only one pi process fires when several are open, crash recovery (interrupted runs marked as errors), run history capped at 25
- **Surface:** 6 LLM tools (`scheduler_create/list/get/update/delete/run_now` with promptSnippet + promptGuidelines), `/cron` command, status-line entry
- **Safety:** headless children get `PI_SCHEDULED_RUN=1`; the scheduler doesn't start inside them (no nesting)
- Modeled on the reference `pi-task-scheduler` package; timers are process-local (no missed-run catch-up — documented decision)

### Fix: `@arvoretech/pi-memory` stale ctx crash (0.6.2 → 0.6.3)

The debounced flush timer (`turn_end`) and `session_shutdown` handler captured `ctx` and used it after session replacement/reload, throwing `stale after session replacement` and crashing the host process with exit code 1. Discovered when a headless scheduled run completed its work but exited 1 because pi-memory crashed it.

Fix follows the documented pattern: match `/stale after session replacement/`, swallow only that, rethrow everything else (`staleSafeSetStatus` + guards around `getEntries()`/`disposeMemoryWidget`).

## How it was tested

- Scheduler engine smoke-tested: `+2s` once-task fired, `runCount: 1`, auto-disabled; invalid cron/past timestamps rejected; second process blocked by the file lock
- End-to-end in a live pi session: scheduled `+2m` task fired headless and created the expected file (exposed the pi-memory crash — run marked error despite work completing)
- After the pi-memory fix: same test run → exit 0, `lastStatus: success`, `runCount: 1`, auto-disabled
- `tsc` build + `tsc --noEmit` lint clean in both packages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scheduled task automation supporting cron, one-time, and interval schedules.
  * Added commands and tools to create, view, update, run, enable, disable, and delete scheduled tasks.
  * Added persistent task storage, execution history, status tracking, and safe single-instance scheduling.
  * Added options to deliver scheduled work in a new session or the originating session.

* **Bug Fixes**
  * Improved resilience when session context changes during memory status updates.

* **Documentation**
  * Added scheduler usage, configuration, safety, and development documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->