### PR TITLE
feat(prs-tracker)!: PR tracking opt-in com modos off/widget/context

### DIFF
--- a/packages/prs-tracker/README.md
+++ b/packages/prs-tracker/README.md
@@ -35,8 +35,8 @@ Set the default per project in `.pi/prs-tracker.json` at the hub root:
 Or via the `PI_PRS_TRACKER_MODE` env var, which wins over the file. `/prs on|off|widget|context`
 changes the mode for the current session only.
 
-`/prs track <url|owner/repo#N|N>` opts a single PR in without enabling auto-detection —
-it switches to `widget` if the extension was `off`.
+`/prs track <url|owner/repo#N|N>` adds that PR explicitly. If the extension was `off`,
+it switches to `widget`, which enables polling and auto-detection for the rest of the session.
 
 ## How it works
 
@@ -63,6 +63,7 @@ The production deploy run is matched by the `push` event on the merge commit, pi
 - `/prs` — show the current mode and usage
 - `/prs on` — enable full tracking (`context` mode) for this session
 - `/prs widget` — enable tracking without context injection
+- `/prs context` — enable full tracking with context injection
 - `/prs off` — stop polling, hide the widget and inject nothing
 - `/prs track <pr>` — track one PR explicitly (url, `owner/repo#N` or `N`)
 - `/prs hide` — hide the widget (keeps tracking)

--- a/packages/prs-tracker/README.md
+++ b/packages/prs-tracker/README.md
@@ -1,6 +1,8 @@
 # @arvoretech/pi-prs-tracker
 
-Keeps your open and recently-merged PRs pinned in the chat as a persistent widget — now with CI and production deploy status. PRs are auto-detected from `gh pr create` calls (and any GitHub PR URL) the agent runs during the session, and their status is refreshed in the background. The current status of every tracked PR is also injected into the AI's context on each LLM call, so the agent always knows whether a PR is merged and how its CI/deploy is doing.
+Keeps your open and recently-merged PRs pinned in the chat as a persistent widget — with CI and production deploy status. PRs are auto-detected from `gh pr create` calls (and any GitHub PR URL) the agent runs during the session, and their status is refreshed in the background.
+
+**Tracking is opt-in.** Since 2.0.0 the extension starts in `off` and does nothing at all — no auto-detection, no `gh` polling, no context injection — until you turn it on.
 
 ## Install
 
@@ -16,6 +18,26 @@ Or in `.pi/settings.json`:
 }
 ```
 
+## Modes
+
+| mode | auto-detect | widget | `gh` polling | context injection |
+| --- | --- | --- | --- | --- |
+| `off` (default) | no | no | no | no |
+| `widget` | yes | yes | yes | no |
+| `context` | yes | yes | yes | yes |
+
+Set the default per project in `.pi/prs-tracker.json` at the hub root:
+
+```json
+{ "mode": "widget" }
+```
+
+Or via the `PI_PRS_TRACKER_MODE` env var, which wins over the file. `/prs on|off|widget|context`
+changes the mode for the current session only.
+
+`/prs track <url|owner/repo#N|N>` opts a single PR in without enabling auto-detection —
+it switches to `widget` if the extension was `off`.
+
 ## How it works
 
 - Listens to `bash` tool executions. When a command contains `gh pr create` or its output prints a `github.com/<owner>/<repo>/pull/<n>` URL, the PR is captured automatically.
@@ -30,7 +52,7 @@ Or in `.pi/settings.json`:
 
 ## AI context injection
 
-On every LLM call the extension injects a non-displayed `custom` message (`customType: "prs-tracker-context"`) with a fresh snapshot of all tracked PRs — state (`OPEN`/`MERGED`/`CLOSED`), CI summary and deploy status. The block is rebuilt each call from the latest background poll and the previous one is filtered out, so the history is never polluted and the agent always sees the current state instead of stale info. This lets the agent answer "is this PR merged / did CI pass / did it deploy?" without re-running `gh`.
+Only in `context` mode. On every LLM call the extension injects a non-displayed `custom` message (`customType: "prs-tracker-context"`) with a fresh snapshot of all tracked PRs — state (`OPEN`/`MERGED`/`CLOSED`), CI summary and deploy status. The block is rebuilt each call from the latest background poll and the previous one is filtered out, so the history is never polluted and the agent always sees the current state instead of stale info. This lets the agent answer "is this PR merged / did CI pass / did it deploy?" without re-running `gh`.
 
 ## Deploy detection
 
@@ -38,8 +60,12 @@ The production deploy run is matched by the `push` event on the merge commit, pi
 
 ## Commands
 
-- `/prs` — show usage
-- `/prs hide` — hide the widget
+- `/prs` — show the current mode and usage
+- `/prs on` — enable full tracking (`context` mode) for this session
+- `/prs widget` — enable tracking without context injection
+- `/prs off` — stop polling, hide the widget and inject nothing
+- `/prs track <pr>` — track one PR explicitly (url, `owner/repo#N` or `N`)
+- `/prs hide` — hide the widget (keeps tracking)
 - `/prs show` — re-show the widget
 - `/prs refresh` — force an immediate status refresh
 

--- a/packages/prs-tracker/package.json
+++ b/packages/prs-tracker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@arvoretech/pi-prs-tracker",
-  "version": "1.7.1",
-  "description": "PI extension that keeps open/recently-merged PRs pinned in the chat as a persistent widget",
+  "version": "2.0.0",
+  "description": "PI extension that keeps open/recently-merged PRs pinned in the chat as a persistent widget (opt-in)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "type": "module",

--- a/packages/prs-tracker/src/index.ts
+++ b/packages/prs-tracker/src/index.ts
@@ -1,5 +1,5 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { join, dirname, basename } from "node:path";
 import { tmpdir } from "node:os";
@@ -42,7 +42,8 @@ const MERGED_RETENTION_MS = 24 * 60 * 60 * 1000;
 const GIT_REVIEW_DISCOVERY_FILE = join(tmpdir(), `pi-git-review-${process.pid}.json`);
 const GIT_REVIEW_REQUEST_FILE = join(tmpdir(), `pi-git-review-request-${process.pid}.json`);
 const PR_URL_RE = /https?:\/\/github\.com\/([^/\s]+\/[^/\s]+)\/pull\/(\d+)/g;
-const PR_REF_RE = /^(?:https?:\/\/github\.com\/)?([^/\s]+\/[^/\s]+?)(?:\/pull\/|#)(\d+)$/;
+const GITHUB_REPO_RE = /^[\w.-]+\/[\w.-]+$/;
+const PR_REF_RE = /^(?:https?:\/\/github\.com\/)?([\w.-]+\/[\w.-]+?)(?:\/pull\/|#)(\d+)$/;
 const STATE_DIR = ".pi/prs-tracker-sessions";
 const CONFIG_FILE = ".pi/prs-tracker.json";
 const DEFAULT_MODE: Mode = "off";
@@ -196,9 +197,9 @@ function keyOf(repo: string, number: number): string {
   return `${repo}#${number}`;
 }
 
-function runGh(args: string): string | null {
+function runGh(args: string[]): string | null {
   try {
-    return execSync(`gh ${args}`, { encoding: "utf-8", timeout: 30_000 }).trim();
+    return execFileSync("gh", args, { encoding: "utf-8", timeout: 30_000 }).trim();
   } catch {
     return null;
   }
@@ -256,7 +257,7 @@ function findDeployJob(
   repo: string,
   databaseId: number,
 ): { name: string; status: string; conclusion: string } | null {
-  const out = runGh(`run view ${databaseId} --repo ${repo} --json jobs`);
+  const out = runGh(["run", "view", String(databaseId), "--repo", repo, "--json", "jobs"]);
   if (!out) return null;
   try {
     const data = JSON.parse(out) as {
@@ -273,9 +274,18 @@ function findDeployJob(
 }
 
 function fetchDeploy(repo: string, sha: string): DeployInfo | null {
-  const out = runGh(
-    `run list --repo ${repo} --commit ${sha} --json databaseId,name,status,conclusion,url,event --limit 20`,
-  );
+  const out = runGh([
+    "run",
+    "list",
+    "--repo",
+    repo,
+    "--commit",
+    sha,
+    "--json",
+    "databaseId,name,status,conclusion,url,event",
+    "--limit",
+    "20",
+  ]);
   if (!out) return null;
   try {
     const runs = JSON.parse(out) as Array<{
@@ -318,9 +328,15 @@ function fetchDeploy(repo: string, sha: string): DeployInfo | null {
 }
 
 function fetchPrDetails(number: number, repo: string): TrackedPr | null {
-  const out = runGh(
-    `pr view ${number} --repo ${repo} --json number,title,state,url,isDraft,mergedAt,mergeCommit,statusCheckRollup`,
-  );
+  const out = runGh([
+    "pr",
+    "view",
+    String(number),
+    "--repo",
+    repo,
+    "--json",
+    "number,title,state,url,isDraft,mergedAt,mergeCommit,statusCheckRollup",
+  ]);
   if (!out) return null;
   try {
     const data = JSON.parse(out) as {
@@ -368,8 +384,8 @@ function parsePrRef(input: string): { repo: string; number: number } | null {
   if (full) return { repo: full[1], number: Number(full[2]) };
   const bare = /^#?(\d+)$/.exec(trimmed);
   if (!bare) return null;
-  const repo = runGh("repo view --json nameWithOwner -q .nameWithOwner");
-  if (!repo) return null;
+  const repo = runGh(["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"]);
+  if (!repo || !GITHUB_REPO_RE.test(repo)) return null;
   return { repo, number: Number(bare[1]) };
 }
 
@@ -775,7 +791,7 @@ export default function prsTrackerExtension(pi: ExtensionAPI): void {
 
   pi.registerCommand("prs", {
     description:
-      "PR tracking (opt-in). Usage: /prs [on|off|widget|track <pr>|show|hide|merged|refresh]",
+      "PR tracking (opt-in). Usage: /prs [on|off|widget|context|track <pr>|show|hide|merged|refresh]",
     handler: async (args, ctx) => {
       const raw = (args ?? "").trim();
       const [rawSub, ...rest] = raw.split(/\s+/);
@@ -788,13 +804,16 @@ export default function prsTrackerExtension(pi: ExtensionAPI): void {
           ctx.ui.notify("Usage: /prs track <url|owner/repo#N|N>", "warning");
           return;
         }
-        if (mode === "off") mode = "widget";
+        const cwd = ctx?.cwd ?? process.cwd();
+        const wasOff = mode === "off";
+        if (wasOff) loadState(cwd);
         if (!trackPr(ref.number, ref.repo)) {
           ctx.ui.notify(`Não consegui ler ${ref.repo}#${ref.number} via gh.`, "error");
           return;
         }
+        if (wasOff) mode = "widget";
         hidden = false;
-        saveState(ctx?.cwd ?? process.cwd());
+        saveState(cwd);
         startPolling(ctx);
         updateWidget(ctx);
         requestGitReviewServer();
@@ -848,7 +867,7 @@ export default function prsTrackerExtension(pi: ExtensionAPI): void {
             ctx.ui.notify(`PRs atualizados (${tracked.size} rastreado(s)).`, "info");
           } else {
             ctx.ui.notify(
-              `Modo atual: ${mode}. Usage: /prs [on|off|widget|track <pr>|show|hide|merged|refresh]`,
+              `Modo atual: ${mode}. Usage: /prs [on|off|widget|context|track <pr>|show|hide|merged|refresh]`,
               "info",
             );
           }
@@ -867,7 +886,7 @@ export default function prsTrackerExtension(pi: ExtensionAPI): void {
 
         default:
           ctx.ui.notify(
-            "Usage: /prs [on|off|widget|track <pr>|show|hide|merged|refresh]",
+            "Usage: /prs [on|off|widget|context|track <pr>|show|hide|merged|refresh]",
             "warning",
           );
       }

--- a/packages/prs-tracker/src/index.ts
+++ b/packages/prs-tracker/src/index.ts
@@ -4,6 +4,7 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { join, dirname, basename } from "node:path";
 import { tmpdir } from "node:os";
 
+type Mode = "off" | "widget" | "context";
 type CiState = "PENDING" | "PASS" | "FAIL" | "NONE";
 type DeployState = "QUEUED" | "IN_PROGRESS" | "SUCCESS" | "FAILURE" | "SKIPPED" | "NONE";
 
@@ -41,7 +42,10 @@ const MERGED_RETENTION_MS = 24 * 60 * 60 * 1000;
 const GIT_REVIEW_DISCOVERY_FILE = join(tmpdir(), `pi-git-review-${process.pid}.json`);
 const GIT_REVIEW_REQUEST_FILE = join(tmpdir(), `pi-git-review-request-${process.pid}.json`);
 const PR_URL_RE = /https?:\/\/github\.com\/([^/\s]+\/[^/\s]+)\/pull\/(\d+)/g;
+const PR_REF_RE = /^(?:https?:\/\/github\.com\/)?([^/\s]+\/[^/\s]+?)(?:\/pull\/|#)(\d+)$/;
 const STATE_DIR = ".pi/prs-tracker-sessions";
+const CONFIG_FILE = ".pi/prs-tracker.json";
+const DEFAULT_MODE: Mode = "off";
 const DEPLOY_WORKFLOW_RE = /deploy|publish|release/i;
 const DEPLOY_STAGING_RE = /staging/i;
 
@@ -49,6 +53,7 @@ const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", 
 const SPINNER_INTERVAL_MS = 120;
 
 const tracked = new Map<string, TrackedPr>();
+let mode: Mode = DEFAULT_MODE;
 let hidden = false;
 let hideMerged = false;
 let widgetVisible = false;
@@ -90,6 +95,25 @@ function findHubRoot(cwd: string): string | null {
 function getStatePath(cwd: string): string | null {
   const root = findHubRoot(cwd);
   return root ? join(root, STATE_DIR, `${sessionId}.json`) : null;
+}
+
+function parseMode(value: unknown): Mode | null {
+  return value === "off" || value === "widget" || value === "context" ? value : null;
+}
+
+function loadMode(cwd: string): Mode {
+  const fromEnv = parseMode(process.env.PI_PRS_TRACKER_MODE);
+  if (fromEnv) return fromEnv;
+  const root = findHubRoot(cwd);
+  if (!root) return DEFAULT_MODE;
+  const path = join(root, CONFIG_FILE);
+  if (!existsSync(path)) return DEFAULT_MODE;
+  try {
+    const raw = JSON.parse(readFileSync(path, "utf-8")) as { mode?: unknown };
+    return parseMode(raw.mode) ?? DEFAULT_MODE;
+  } catch {
+    return DEFAULT_MODE;
+  }
 }
 
 interface GitReviewInfo {
@@ -336,6 +360,17 @@ function trackPr(number: number, repo: string): boolean {
   }
   tracked.set(keyOf(repo, number), details);
   return true;
+}
+
+function parsePrRef(input: string): { repo: string; number: number } | null {
+  const trimmed = input.trim();
+  const full = PR_REF_RE.exec(trimmed);
+  if (full) return { repo: full[1], number: Number(full[2]) };
+  const bare = /^#?(\d+)$/.exec(trimmed);
+  if (!bare) return null;
+  const repo = runGh("repo view --json nameWithOwner -q .nameWithOwner");
+  if (!repo) return null;
+  return { repo, number: Number(bare[1]) };
 }
 
 function pruneStale(): void {
@@ -666,14 +701,35 @@ function stopPolling(): void {
   }
 }
 
+function activate(ctx: any): void {
+  const cwd = ctx?.cwd ?? process.cwd();
+  if (tracked.size === 0) loadState(cwd);
+  if (tracked.size > 0) refreshAll();
+  startPolling(ctx);
+  updateWidget(ctx);
+  requestGitReviewServer();
+}
+
+function deactivate(ctx: any): void {
+  stopPolling();
+  stopSpinner();
+  if (widgetVisible) ctx?.ui?.setWidget?.("pi-prs-tracker", undefined);
+  widgetVisible = false;
+}
+
+function setMode(next: Mode, ctx: any): void {
+  mode = next;
+  if (mode === "off") deactivate(ctx);
+  else activate(ctx);
+}
+
 export default function prsTrackerExtension(pi: ExtensionAPI): void {
   pi.on("session_start", async (_event, ctx) => {
     sessionId = getSessionId(ctx);
-    loadState(ctx?.cwd ?? process.cwd());
-    if (tracked.size > 0) refreshAll();
-    startPolling(ctx);
-    updateWidget(ctx);
-    requestGitReviewServer();
+    uiCtx = ctx;
+    mode = loadMode(ctx?.cwd ?? process.cwd());
+    if (mode === "off") return;
+    activate(ctx);
   });
 
   pi.on("session_shutdown", async () => {
@@ -685,6 +741,7 @@ export default function prsTrackerExtension(pi: ExtensionAPI): void {
     const messages = event.messages.filter(
       (m: any) => m?.customType !== CONTEXT_CUSTOM_TYPE,
     );
+    if (mode !== "context") return { messages };
     const summary = buildContextSummary();
     if (!summary) return { messages };
     messages.push({
@@ -699,7 +756,7 @@ export default function prsTrackerExtension(pi: ExtensionAPI): void {
 
   pi.on("tool_execution_end", async (event: any, ctx: any) => {
     const name = event?.toolName;
-    if (name !== "bash" || event?.isError) return;
+    if (mode === "off" || name !== "bash" || event?.isError) return;
 
     const before = tracked.size;
     const beforeSnapshot = JSON.stringify([...tracked.values()]);
@@ -716,9 +773,50 @@ export default function prsTrackerExtension(pi: ExtensionAPI): void {
   });
 
   pi.registerCommand("prs", {
-    description: "Manage the pinned PRs widget. Usage: /prs [show|hide|merged|refresh]",
+    description:
+      "PR tracking (opt-in). Usage: /prs [on|off|widget|track <pr>|show|hide|merged|refresh]",
     handler: async (args, ctx) => {
-      const sub = (args ?? "").trim().toLowerCase();
+      const raw = (args ?? "").trim();
+      const [rawSub, ...rest] = raw.split(/\s+/);
+      const sub = (rawSub ?? "").toLowerCase();
+      const rawArg = rest.join(" ");
+
+      if (sub === "track") {
+        const ref = parsePrRef(rawArg);
+        if (!ref) {
+          ctx.ui.notify("Usage: /prs track <url|owner/repo#N|N>", "warning");
+          return;
+        }
+        if (mode === "off") mode = "widget";
+        if (!trackPr(ref.number, ref.repo)) {
+          ctx.ui.notify(`Não consegui ler ${ref.repo}#${ref.number} via gh.`, "error");
+          return;
+        }
+        hidden = false;
+        saveState(ctx?.cwd ?? process.cwd());
+        startPolling(ctx);
+        updateWidget(ctx);
+        requestGitReviewServer();
+        ctx.ui.notify(`Rastreando ${ref.repo}#${ref.number} (modo ${mode}).`, "info");
+        return;
+      }
+
+      if (sub === "on" || sub === "off" || sub === "widget" || sub === "context") {
+        const next: Mode = sub === "on" ? "context" : (sub as Mode);
+        setMode(next, ctx);
+        const message: Record<Mode, string> = {
+          off: "PR tracking desligado: sem auto-detect, sem poll, sem contexto injetado.",
+          widget: "PR tracking em modo widget: auto-detect e poll ativos, nada injetado no prompt.",
+          context: "PR tracking completo: status dos PRs injetado no contexto a cada chamada.",
+        };
+        ctx.ui.notify(message[next], "info");
+        return;
+      }
+
+      if (mode === "off" && sub !== "") {
+        ctx.ui.notify("PR tracking está off. Use /prs on, /prs widget ou /prs track <pr>.", "warning");
+        return;
+      }
 
       switch (sub) {
         case "hide":
@@ -748,7 +846,10 @@ export default function prsTrackerExtension(pi: ExtensionAPI): void {
             updateWidget(ctx);
             ctx.ui.notify(`PRs atualizados (${tracked.size} rastreado(s)).`, "info");
           } else {
-            ctx.ui.notify("Usage: /prs [show|hide|refresh]", "info");
+            ctx.ui.notify(
+              `Modo atual: ${mode}. Usage: /prs [on|off|widget|track <pr>|show|hide|merged|refresh]`,
+              "info",
+            );
           }
           break;
         }
@@ -764,7 +865,10 @@ export default function prsTrackerExtension(pi: ExtensionAPI): void {
           break;
 
         default:
-          ctx.ui.notify("Usage: /prs [show|hide|merged|refresh]", "warning");
+          ctx.ui.notify(
+            "Usage: /prs [on|off|widget|track <pr>|show|hide|merged|refresh]",
+            "warning",
+          );
       }
     },
   });

--- a/packages/prs-tracker/src/index.ts
+++ b/packages/prs-tracker/src/index.ts
@@ -442,7 +442,8 @@ function resultToText(result: any): string {
 const CONTEXT_CUSTOM_TYPE = "prs-tracker-context";
 
 function ciLabel(ci: CiSummary | null): string {
-  if (!ci || ci.state === "NONE") return "sem CI";
+  if (!ci) return "CI ainda não reportado";
+  if (ci.state === "NONE") return "sem CI";
   const link = ci.url ? ` (logs: ${ci.url})` : "";
   if (ci.state === "PENDING") return `CI rodando (${ci.passed}/${ci.total} ok, ${ci.pending} pendente, ${ci.failed} falha)${link}`;
   if (ci.state === "FAIL") return `CI FALHOU (${ci.failed}/${ci.total} falharam)${link}`;


### PR DESCRIPTION
## What

`@arvoretech/pi-prs-tracker` 1.7.1 → 2.0.0. **Breaking:** a extensão passa a começar inerte.

Hoje ela não tem como ser desligada. `hidden` (o que `/prs hide` mexe) controla apenas o widget — os três comportamentos caros ignoram qualquer flag:

- `session_start` → `loadState()` + `refreshAll()` + `startPolling()` incondicionais (poll `gh` a cada 60s)
- `tool_execution_end` → varre o output de **todo** comando bash atrás de URL de PR e auto-rastreia
- `context` → injeta um bloco invisível `[PRS RASTREADOS]` em **toda** chamada de LLM, com a instrução "use como fonte de verdade"

O resultado é contexto poluído e o agente raciocinando sobre PR que não é o da tarefa atual.

### Modos

| modo | auto-detect | widget | poll `gh` | injeção no contexto |
| --- | --- | --- | --- | --- |
| `off` (novo default) | não | não | não | não |
| `widget` | sim | sim | sim | não |
| `context` (comportamento 1.x) | sim | sim | sim | sim |

O modo vem de `.pi/prs-tracker.json` no root do hub (`{ "mode": "widget" }`), ou de `PI_PRS_TRACKER_MODE`, que ganha do arquivo.

`widget` existe porque as duas coisas têm custos diferentes: o widget é barato e visual, a injeção é que compete com o contexto da tarefa. Dá pra ter um sem o outro.

### Comandos

- `/prs on|widget|context|off` — troca o modo só na sessão atual
- `/prs track <url|owner/repo#N|N>` — rastreia **um** PR sem ligar auto-detect (sobe pra `widget` se estava `off`); `N` sozinho resolve o repo via `gh repo view`

`off` para os timers e remove o widget mas **mantém** `tracked` em memória, então religar na mesma sessão não perde nada. E o handler `context` continua filtrando o bloco antigo em qualquer modo, então desligar no meio da sessão limpa o resíduo que já estava no histórico em vez de deixá-lo congelado lá.

### Migração

Quem quer o comportamento atual põe no `.pi/prs-tracker.json` do hub:

```json
{ "mode": "context" }
```

### Bonus: `sem CI` mentiroso

`summarizeChecks` retorna `null` quando o `statusCheckRollup` vem vazio — o que acontece nos primeiros segundos de vida de um PR, antes do GitHub registrar os checks. O `ciLabel` verbalizava esse `null` exatamente como o estado `NONE` (repo sem CI nenhum): **"sem CI"**.

Resultado: o bloco injetado afirmava "sem CI" para um PR cujo CI estava rodando, logo abaixo da instrução "use como fonte de verdade". Reproduzido neste próprio PR.

Agora `null` vira `"CI ainda não reportado"` e `NONE` continua `"sem CI"` — ignorância deixa de ser reportada como fato negativo.

## How it was tested

- `tsc --noEmit` (lint) e `tsc` (build) limpos no pacote
- **Não testado em runtime.** Requer `pi install file:` do pacote local e restart da sessão; a validação de comportamento (modo off realmente inerte, `/prs track`, troca de modo em runtime) ainda não foi feita ponta a ponta.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable PR tracking modes: off, widget, and context.
  * Added project and environment configuration, session controls, and direct tracking for specific pull requests.
  * Added support for PR URLs, repository references, and numeric PR identifiers.
  * Expanded `/prs` commands with mode controls and tracking actions.
* **Bug Fixes**
  * Tracking is now disabled by default, including detection, polling, widgets, and context injection.
  * AI context injection is limited to context mode.
* **Chores**
  * Updated the PR tracker to version 2.0.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
