### PR TITLE
ci: move jobs to self-hosted arc-runner-set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: arc-runner-set
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -36,7 +36,7 @@ jobs:
 
   publish:
     needs: test
-    runs-on: ubuntu-latest
+    runs-on: arc-runner-set
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Moves both CI jobs (`test`, `publish`) in `.github/workflows/ci.yml` from `ubuntu-latest` to the self-hosted `arc-runner-set` (EKS-based ARC scale set, min 0 / max 20).
- GitHub-hosted minutes are billed on private repos; self-hosted runner minutes are not. This repo burns roughly 115 billed minutes/month on `ubuntu-latest`.
- Pure label swap: `runs-on: ubuntu-latest` -> `runs-on: arc-runner-set`. No other line changed — checkout, pnpm/action-setup, setup-node, caching, and permissions blocks are untouched.

## Test plan
- [ ] CI run triggered by this PR lands on the self-hosted runner
- [ ] `test` job (build, lint, test) completes successfully
- [ ] `publish` job stays skipped on PR (only runs on push to main), no regression to its `if` condition

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated testing and publishing workflows to run on the new build infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->